### PR TITLE
The Standard for Agents: Tri-Nature theory, spec, and C# reference implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+## .NET build output
+bin/
+obj/
+[Bb]uild/
+*.user
+*.suo
+
+## Flow logs (generated at runtime)
+*.log
+log.txt
+log.math.txt
+
+## Local secrets — set appsettings.json ApiKey locally; never commit real keys
+appsettings.*.local.json
+
+## IDE / OS
+.vs/
+.idea/
+.vscode/
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,100 @@
-# The-Standard-Agent
-This is The Standard for building AI Agents according to the Tri-Nature Theory
+# The Standard for Agents
+
+**The Standard for building AI agents according to the Tri-Nature Theory.**
+
+An agent is not an LLM, a tool, a prompt, or a memory. An agent is the **orchestration
+of three natures**:
+
+```
+Agent = Orchestration(Data, Decision, Direction)
+```
+
+- **Data** — what the agent *has* (skills, memory, knowledge)
+- **Decision** — what the agent *thinks* (one brain, wrapped in a Gate and a Judge — the
+  agent's own conscience)
+- **Direction** — what the agent *does* (act internally, act externally, or return)
+
+---
+
+## Three pillars
+
+| | What it is | Answers |
+|---|---|---|
+| [`THE-TRI-NATURE-OF-AGENT.md`](THE-TRI-NATURE-OF-AGENT.md) | **The theory** — the model, the fractal, lifecycle & memory, safety, governance | *why* |
+| [`SPEC.md`](SPEC.md) | **The specification** — a language-agnostic, RFC-2119 contract with Core & Full conformance profiles | *what to build, in any language* |
+| [`Standard.Agents/`](Standard.Agents) | **The reference implementation** — a Standard-compliant C# library (.NET 10, zero external dependencies) | *one proof* |
+
+The theory says *why*, the spec says *what you must build*, and the C# is *one* way to
+build it. A conformant JavaScript, Go, Rust, or Python version proves itself against the
+same spec.
+
+---
+
+## Architecture — the 1·3·9 tiers
+
+`Coordination → Orchestration → Foundation → Broker`, flow forward only.
+
+![Architecture](architecture.svg)
+
+- **Coordination (1)** — the Agent. The only tier that loops: `Recall → Think → Act`,
+  until a terminal status.
+- **Orchestration (3)** — Data (`Recall`), Decision (`Think`), Direction (`Act`).
+- **Foundation (9)** — Skills · Memory · Knowledge · Gate · Brain · Judge · Internal ·
+  External · Return.
+- **Broker (8+1)** — one thin liaison per resource; `Return` is the dead end (no broker).
+
+---
+
+## Quick start (C# reference implementation)
+
+Requires the **.NET 10 SDK** and an **OpenAI-compatible** chat endpoint (for example a
+local [PeerLLM](https://peerllm.com) host, or any `/v1/chat/completions` server).
+
+1. Set your endpoint in `Standard.Agents.Demo/appsettings.json` — fill in `ApiUrl`,
+   `ApiKey`, and `Model` (the committed `ApiKey` is intentionally blank).
+2. Run the demo:
+   ```bash
+   dotnet run --project Standard.Agents.Demo
+   ```
+3. Try a prompt:
+   ```
+   What is 89347 * 61293 + 4472?
+   ```
+   The agent recalls its skills, decides to use the calculator tool, feeds the result
+   back into Data, and returns the answer — the full loop through every tier.
+
+---
+
+## Build it in your own language
+
+[`SPEC.md`](SPEC.md) is the normative, language-neutral blueprint. It defines every
+contract in neutral pseudo-types, the loop as a normative algorithm, the reply protocol,
+and nine MUST/MUST-NOT invariants — using RFC-2119 keywords so "compliant" is testable.
+
+Two conformance profiles:
+- **Core** — a minimal viable agent (Skill + Brain + Internal tool + Return).
+- **Full** — adds real Memory & Knowledge, guardian Gate & Judge (distinct from the
+  Brain), and External (MCP).
+
+---
+
+## Status
+
+The reference implementation runs the full 1·3·9 tier end to end.
+
+- **Real:** `SkillService`, `BrainService` (OpenAI-compatible generator), `InternalToolService`,
+  `ReturnService`, and the flow-log support broker.
+- **Honest stubs** (wired into the flow, ready to fill): `MemoryService`, `KnowledgeService`,
+  `GateService`, `JudgeService`, `ExternalToolService`.
+
+---
+
+## Key invariants
+
+- Everything is Data; prompts, rules, and rubrics live in Data (skills), never in code.
+- One agent, one brain. Many brains is the fractal — a higher-order agent delegating to
+  sub-agents.
+- The agent instance is ephemeral; persistent memory lives outside it.
+- A guardian is never the Brain — a faculty cannot certify its own trustworthiness.
+- Irreversible actions are authorized before execution, never after.
+- Security rests on the perimeter (jurisdiction), never on the visitor's conscience.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,267 @@
+# The Standard for Agents — Specification
+**Version 0.1 (draft)**
+
+A **normative, language-neutral** blueprint for building a Tri-Nature agent framework
+in any language (JavaScript, .NET, Go, Rust, Python, …). The reference implementation
+is `Standard.Agents` (C#). The rationale and philosophy live in the companion theory,
+*The Tri-Nature of Agent* (`THE-TRI-NATURE-OF-AGENT.md`); this document is the buildable
+contract.
+
+---
+
+## 1. Conformance
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, **MAY** are to be
+interpreted as in RFC 2119.
+
+An implementation is **Standard-Agents Conformant** at a given **profile** (§8) if it
+satisfies every MUST for that profile. Conformance is about **contracts and behavior**,
+not file layout or language idiom.
+
+---
+
+## 2. Notation
+
+Neutral pseudo-types — map each to your language:
+
+| Spec | Meaning |
+|---|---|
+| `Text` | UTF-8 string |
+| `Number` | integer or real |
+| `Bool` | boolean |
+| `List<T>` | ordered, immutable sequence |
+| `Map<K,V>` | key → value |
+| `Async<T>` | a value delivered asynchronously (Promise / Future / Task / coroutine) |
+| `Void` | no value |
+| `enum { … }` | a closed set of named values |
+
+`interface Name { method(params) -> Return }` denotes a **contract** (a role), not a
+class. The names are canonical *roles*; adapt casing to your language.
+
+---
+
+## 3. Data Types (MUST)
+
+### 3.1 AgentStatus
+
+```
+enum AgentStatus { Working, Responded, AwaitingInput, Refused, Failed }
+```
+
+- `Working` **MUST** be the default / initial value.
+- The loop (§5) continues while `status == Working` and stops on any other value.
+- Implementations **MUST NOT** replace this with a boolean.
+
+### 3.2 AgentContext
+
+The single carrier that threads the loop. **All content is Data**; the regions mark
+which nature last wrote each field.
+
+```
+record AgentContext {
+  prompt        : Text          // the task (input)
+  systemPrompt  : Text          // DATA:      written by Recall
+  observations  : List<Text>    // DATA:      written by Recall / Act
+  intent        : Text          // DECISION:  written by Think
+  directionType : Text          // DECISION:  written by Think
+  payload       : Text          // DECISION:  written by Think
+  rawReply      : Text          // DECISION:  written by Think
+  result        : Text          // DIRECTION: written by Act
+  status        : AgentStatus   // DIRECTION: written by Act
+}
+```
+
+- Context updates **MUST** be copy-on-write: a nature returns an updated copy; a nature
+  **MUST NOT** mutate a shared instance. (Use records/immutable structs; if unavailable,
+  a copy helper or builder.)
+
+---
+
+## 4. Component Contracts
+
+The architecture is four tiers: **Coordination → Orchestration → Foundation → Broker**.
+Flow is forward only; a tier **MUST NOT** call a tier above it.
+
+### 4.1 Brokers — thin liaisons
+
+A broker is a liaison to **exactly one** external resource. A broker:
+- **MUST** integrate one resource only.
+- **MUST NOT** contain business flow control (no branching/looping for business decisions).
+- **MUST NOT** author prompts, rules, or rubrics — those are Data.
+- **MUST** expose asynchronous methods.
+
+```
+interface SkillBroker      { selectSkills() -> Async<Text> }
+interface MemoryBroker     { selectMemories() -> Async<List<Text>>;  insertMemory(m: Text) -> Async<Void> }
+interface KnowledgeBroker  { selectKnowledge(query: Text) -> Async<List<Text>> }
+interface ClassifierBroker { classify(systemPrompt: Text, input: Text) -> Async<Text> }
+interface GeneratorBroker  { generate(systemPrompt: Text, userPrompt: Text) -> Async<Text> }
+interface VerifierBroker   { verify(systemPrompt: Text, candidate: Text) -> Async<Number> }   // 0.0–1.0
+interface ToolBroker       { has(name: Text) -> Bool;  run(name: Text, input: Text) -> Async<Text> }
+interface McpBroker        { call(name: Text, input: Text) -> Async<Text> }
+interface LogBroker        { reset() -> Async<Void>;  write(line: Text) -> Async<Void> }   // support broker
+```
+
+### 4.2 Foundation Services — one broker each
+
+A foundation wraps one broker, returns **primitives**, and speaks business language.
+
+```
+interface SkillService        { retrieveSkills() -> Async<Text> }
+interface MemoryService       { recallMemories() -> Async<List<Text>>;  remember(m: Text) -> Async<Void> }
+interface KnowledgeService    { retrieveKnowledge(query: Text) -> Async<List<Text>> }
+interface GateService         { screen(gatePrompt: Text, input: Text) -> Async<Text> }
+interface BrainService        { generate(systemPrompt: Text, userPrompt: Text) -> Async<Text> }
+interface JudgeService        { evaluate(judgePrompt: Text, candidate: Text) -> Async<Number> }
+interface InternalToolService { handles(name: Text) -> Bool;  run(name: Text, input: Text) -> Async<Text> }
+interface ExternalToolService { call(name: Text, input: Text) -> Async<Text> }
+interface ReturnService       { return(payload: Text) -> Async<Text> }   // NO broker — the dead end
+```
+
+### 4.3 Orchestration Services — one per nature
+
+Each coordinates its nature's foundations and returns an **updated AgentContext**.
+
+```
+interface DataOrchestration      { recall(ctx: AgentContext) -> Async<AgentContext> }
+interface DecisionOrchestration  { think(ctx: AgentContext)  -> Async<AgentContext> }
+interface DirectionOrchestration { act(ctx: AgentContext)    -> Async<AgentContext> }
+```
+
+Required behavior:
+- **recall** — **MUST** set `systemPrompt` from `SkillService`; **MAY** seed `observations`
+  from Memory/Knowledge. It refreshes what the agent HAS.
+- **think** — **MUST**: (a) Gate screens the input, (b) Brain generates, (c) interpret the
+  reply into `intent`/`directionType`/`payload`/`rawReply`. It **MAY** run Judge on a final
+  answer and loop instead of returning (reflective judgment). It **MUST NOT** author prompt
+  text.
+- **act** — **MUST** route by `directionType`: **Return** (terminal), **Internal** (a local
+  tool), or **External** (out across the boundary). A non-terminal result **MUST** be
+  appended to `observations`, and its `status` **MUST** be `Working`.
+
+### 4.4 Coordination — the Agent
+
+```
+interface AgentCoordination { processPrompt(prompt: Text) -> Async<Text> }
+```
+
+It runs the loop (§5) and **MUST** hold no nature logic beyond sequencing and observing
+(logging). An `AgentCoordination` **SHOULD** also satisfy the tool contract (§6) so an
+agent can be nested as a tool of another agent (the fractal).
+
+---
+
+## 5. The Loop (normative algorithm)
+
+```
+processPrompt(prompt):
+    logBroker.reset()
+    context := AgentContext { prompt: prompt }        // status defaults to Working
+    for turn in 1 .. MAX_TURNS:                        // MAX_TURNS MUST be finite; SHOULD be small
+        context := dataOrchestration.recall(context)
+        context := decisionOrchestration.think(context)
+        context := directionOrchestration.act(context)
+        if context.status != Working: break
+    return context.result
+```
+
+- The loop **MUST** cap iterations (`MAX_TURNS`).
+- Direction **MUST** feed non-terminal results back into `observations`, and the next
+  Decision **MUST** be able to read them (this is how tool results and fetched data return
+  to the Brain).
+
+---
+
+## 6. The Tool / Reply Protocol
+
+The Brain expresses its choice as text (**reference protocol**, SHOULD support) or via a
+provider-native tool-call mechanism (**MAY**).
+
+Reference protocol:
+- To act: a single line — `ACTION: <toolName>: <input>`
+- To answer: `FINAL: <answer>`
+
+Parsing (MUST):
+- A tool call **MUST** be read from the **first line only** (models often emit extra lines).
+- A final answer **MAY** span multiple lines.
+- `directionType == "ReturnResponse"` is terminal → `Responded`.
+- `directionType == "Refuse"` is terminal → `Refused`.
+- Any other `directionType` is a tool name, routed by Direction (§4.3).
+
+---
+
+## 7. Invariants (MUST / MUST NOT)
+
+1. **Everything is Data.** Produced content (a reply, a tool result, a fetched document)
+   **MUST** be treated as Data once produced.
+2. **Prompts, rules, and rubrics live in Data.** They **MUST** be loaded from skills/config
+   and **MUST NOT** be authored in Decision, in brokers, or hardcoded.
+3. **Brokers are thin.** A broker **MUST NOT** contain business flow control.
+4. **The agent is ephemeral.** An instance **MUST** be stateless across prompts. Persistent
+   memory **MUST** live outside the agent — recalled by Data, written by Direction.
+5. **A draft is not a commitment.** Where a guardian applies, output **MUST NOT** cross a
+   boundary un-vetted.
+6. **No self-certification.** A guardian (Gate/Judge) **MUST NOT** be the Brain. A faculty
+   **MUST NOT** certify its own trustworthiness.
+7. **Irreversible before, not after.** An irreversible action **MUST** be authorized before
+   execution by a trusted guardian (deterministic rule and/or human), never after.
+8. **The boundary.** External state **MUST** enter only as Data (via a Direction that reached
+   out) and effects **MUST** leave only via Direction. The three natures are the agent's
+   interior.
+9. **Configuration is not a nature.** It **MUST** be consumed by brokers to function, not
+   reasoned over by Decision.
+
+---
+
+## 8. Conformance Profiles
+
+### 8.1 Core — the minimal viable agent (MUST)
+
+- `AgentContext`, `AgentStatus` (§3).
+- The Coordination loop (§5).
+- **Data:** `SkillService` + `SkillBroker`.
+- **Decision:** `BrainService` + `GeneratorBroker`. Gate and Judge **MAY** be pass-through.
+- **Direction:** `InternalToolService` + `ToolBroker`, and `ReturnService`.
+- The reply protocol (§6).
+- Invariants 1–4, 8, 9.
+
+### 8.2 Full — adds
+
+- `MemoryService`, `KnowledgeService` backed by real stores.
+- `GateService` and `JudgeService` as **real guardians, distinct from the Brain**.
+- `ExternalToolService` (MCP / remote).
+- Invariants 5–7 (guardian & safety).
+
+---
+
+## 9. Porting Notes
+
+- **Async:** use the language's native model; every contract method is asynchronous.
+- **Immutability:** records/immutable structs with copy-update. If unavailable, a builder
+  or an explicit `copyWith`.
+- **Naming:** adapt case (PascalCase / camelCase / snake_case). The identifiers here are
+  canonical roles, not literal names.
+- **DI:** OPTIONAL. A hand-wired composition root is fully conformant.
+- **Tiers:** the four tiers **SHOULD** be preserved as module boundaries. A small-scale
+  implementation **MAY** collapse a tier that adds no value (e.g. back the three Decision
+  brokers with one inference endpoint), provided the contracts and invariants still hold.
+- **Inference:** `GeneratorBroker` **SHOULD** target an OpenAI-compatible
+  `POST /v1/chat/completions` endpoint for interoperability, but **MAY** wrap any model.
+
+---
+
+## 10. Conformance Checklist
+
+- [ ] `AgentContext` and `AgentStatus` as specified (§3)
+- [ ] Loop caps turns; non-terminal results feed back into observations (§5)
+- [ ] Brokers thin — one resource, no flow control, no authored prompts (§4.1, §7.3)
+- [ ] Prompts / rules / rubrics loaded from Data, never hardcoded (§7.2)
+- [ ] Agent instance stateless across prompts; persistent memory external (§7.4)
+- [ ] Reply protocol: first-line ACTION, terminal ReturnResponse / Refuse (§6)
+- [ ] **Full:** guardians (Gate/Judge) distinct from the Brain (§7.6)
+- [ ] **Full:** irreversible actions authorized before execution (§7.7)
+
+---
+
+*Specification v0.1 — evolves with the theory. Reference implementation: `Standard.Agents` (C#).
+Rationale: `THE-TRI-NATURE-OF-AGENT.md`.*

--- a/Standard.Agents.Demo/Program.cs
+++ b/Standard.Agents.Demo/Program.cs
@@ -1,0 +1,102 @@
+using Microsoft.Extensions.Configuration;
+using Standard.Agents;
+using Standard.Agents.Brokers.Data;
+using Standard.Agents.Brokers.Decision;
+using Standard.Agents.Brokers.Direction;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Demo.Tools;
+using Standard.Agents.Services.Coordinations;
+using Standard.Agents.Services.Foundations.Data;
+using Standard.Agents.Services.Foundations.Decision;
+using Standard.Agents.Services.Foundations.Direction;
+using Standard.Agents.Services.Orchestrations.Data;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Standard.Agents.Services.Orchestrations.Direction;
+using Standard.Agents.Tools;
+
+IConfiguration configuration = new ConfigurationBuilder()
+    .SetBasePath(AppContext.BaseDirectory)
+    .AddJsonFile("appsettings.json", optional: false)
+    .Build();
+
+IConfigurationSection peer = configuration.GetSection("PeerLLMConfigurations");
+
+// ---- the consumer's tools ----
+ITool calculator = new CalculatorTool();
+
+// ---- BROKERS (one resource each) ----
+ISkillBroker skillBroker = new SkillBroker("Skills");
+IMemoryBroker memoryBroker = new MemoryBroker();
+IKnowledgeBroker knowledgeBroker = new KnowledgeBroker();
+IClassifierBroker classifierBroker = new ClassifierBroker();
+IGeneratorBroker generatorBroker = new GeneratorBroker(
+    apiUrl: peer.GetValue<string>("ApiUrl")!,
+    apiKey: peer.GetValue<string>("ApiKey")!,
+    model: peer.GetValue<string>("Model")!,
+    temperature: peer.GetValue<double>("Temperature"),
+    maxTokens: peer.GetValue<int>("MaxTokens"));
+IVerifierBroker verifierBroker = new VerifierBroker();
+IToolBroker toolBroker = new ToolBroker([calculator]);
+IMcpBroker mcpBroker = new McpBroker();
+ILogBroker logBroker = new LogBroker("log.txt");
+
+// ---- FOUNDATIONS (nine, one broker each) ----
+ISkillService skillService = new SkillService(skillBroker);
+IMemoryService memoryService = new MemoryService(memoryBroker);
+IKnowledgeService knowledgeService = new KnowledgeService(knowledgeBroker);
+IGateService gateService = new GateService(classifierBroker);
+IBrainService brainService = new BrainService(generatorBroker);
+IJudgeService judgeService = new JudgeService(verifierBroker);
+IInternalToolService internalToolService = new InternalToolService(toolBroker);
+IExternalToolService externalToolService = new ExternalToolService(mcpBroker);
+IReturnService returnService = new ReturnService();
+
+// ---- ORCHESTRATIONS (three) ----
+IDataOrchestrationService dataOrchestration =
+    new DataOrchestrationService(skillService, memoryService, knowledgeService);
+IDecisionOrchestrationService decisionOrchestration =
+    new DecisionOrchestrationService(gateService, brainService, judgeService);
+IDirectionOrchestrationService directionOrchestration =
+    new DirectionOrchestrationService(internalToolService, externalToolService, returnService);
+
+// ---- COORDINATION (the Agent) ----
+IAgent agent = new AgentCoordinationService(
+    dataOrchestration, decisionOrchestration, directionOrchestration, logBroker);
+
+string apiUrl = peer.GetValue<string>("ApiUrl") ?? "(unset)";
+
+Console.WriteLine("Standard.Agents — Tri-Nature Agent");
+Console.WriteLine($"Brain -> local PeerLLM at {apiUrl}");
+Console.WriteLine($"Flow log -> {Path.GetFullPath("log.txt")}");
+Console.WriteLine("Type a prompt (or 'exit'). Try: What is 89347 * 61293 + 4472?");
+Console.WriteLine();
+
+while (true)
+{
+    Console.Write("Prompt: ");
+
+    string? prompt = Console.ReadLine();
+
+    if (string.IsNullOrWhiteSpace(prompt))
+    {
+        continue;
+    }
+
+    if (prompt.Equals("exit", StringComparison.OrdinalIgnoreCase))
+    {
+        break;
+    }
+
+    try
+    {
+        string answer = await agent.ProcessPromptAsync(prompt);
+
+        Console.WriteLine($"Agent: {answer}");
+    }
+    catch (Exception exception)
+    {
+        Console.WriteLine($"Agent: [error] {exception.Message}");
+    }
+
+    Console.WriteLine();
+}

--- a/Standard.Agents.Demo/Skills/00-assistant.md
+++ b/Standard.Agents.Demo/Skills/00-assistant.md
@@ -1,0 +1,14 @@
+# General Assistant
+
+You are a helpful, concise general assistant.
+Answer general questions directly from your own knowledge.
+Use the `calculator` tool for arithmetic you cannot do confidently in your head.
+
+## Response protocol
+
+Each turn, reply with EXACTLY ONE line:
+
+- `ACTION: calculator: <expression>` to compute a value
+- `FINAL: <answer>` to give your final answer to the user
+
+Prefer FINAL unless a tool is clearly needed.

--- a/Standard.Agents.Demo/Skills/10-calculator.md
+++ b/Standard.Agents.Demo/Skills/10-calculator.md
@@ -1,0 +1,7 @@
+# Skill: calculator
+
+A tool that evaluates an arithmetic expression, for example `2*(3+4)`.
+
+Use it when a calculation is needed:
+
+`ACTION: calculator: <expression>`

--- a/Standard.Agents.Demo/Standard.Agents.Demo.csproj
+++ b/Standard.Agents.Demo/Standard.Agents.Demo.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Standard.Agents\Standard.Agents.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageReference Include="NCalc" Version="6.4.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Standard.Agents.Demo</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Skills\**\*.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Standard.Agents.Demo/Tools/CalculatorTool.cs
+++ b/Standard.Agents.Demo/Tools/CalculatorTool.cs
@@ -1,0 +1,21 @@
+using System.Text.RegularExpressions;
+using Standard.Agents.Tools;
+
+namespace Standard.Agents.Demo.Tools;
+
+// A demo-provided leaf tool. The framework supplies the ITool contract and the
+// InternalTool/ToolBroker that runs it; the specific tool is the consumer's.
+public sealed partial class CalculatorTool : ITool
+{
+    public string Name => "calculator";
+
+    public ValueTask<string> ExecuteAsync(string input) =>
+        ValueTask.FromResult(
+            new NCalc.Expression(PromoteNumbers(input)).Evaluate()!.ToString()!);
+
+    private static string PromoteNumbers(string expression) =>
+        WholeNumberRegex().Replace(expression, "${0}.0");
+
+    [GeneratedRegex(@"(?<![\d.])\d+(?![\d.])")]
+    private static partial Regex WholeNumberRegex();
+}

--- a/Standard.Agents.Demo/appsettings.json
+++ b/Standard.Agents.Demo/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "PeerLLMConfigurations": {
+    "ApiUrl": "http://localhost:3000/v1/",
+    "ApiKey": "",
+    "Model": "Qwen2.5-7B-Instruct-Q5_K_M.gguf",
+    "Temperature": 0.7,
+    "MaxTokens": 1024
+  }
+}

--- a/Standard.Agents.slnx
+++ b/Standard.Agents.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="Standard.Agents.Demo/Standard.Agents.Demo.csproj" />
+  <Project Path="Standard.Agents/Standard.Agents.csproj" />
+</Solution>

--- a/Standard.Agents/Brokers/Data/IKnowledgeBroker.cs
+++ b/Standard.Agents/Brokers/Data/IKnowledgeBroker.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Brokers.Data;
+
+public interface IKnowledgeBroker
+{
+    ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query);
+}

--- a/Standard.Agents/Brokers/Data/IMemoryBroker.cs
+++ b/Standard.Agents/Brokers/Data/IMemoryBroker.cs
@@ -1,0 +1,8 @@
+namespace Standard.Agents.Brokers.Data;
+
+public interface IMemoryBroker
+{
+    ValueTask<IReadOnlyList<string>> SelectMemoriesAsync();
+
+    ValueTask InsertMemoryAsync(string memory);
+}

--- a/Standard.Agents/Brokers/Data/ISkillBroker.cs
+++ b/Standard.Agents/Brokers/Data/ISkillBroker.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Brokers.Data;
+
+public interface ISkillBroker
+{
+    ValueTask<string> SelectSkillsAsync();
+}

--- a/Standard.Agents/Brokers/Data/KnowledgeBroker.cs
+++ b/Standard.Agents/Brokers/Data/KnowledgeBroker.cs
@@ -1,0 +1,9 @@
+namespace Standard.Agents.Brokers.Data;
+
+// STUB — the retrieval resource (vector / search index). Today returns nothing;
+// swap the body for a real RAG source.
+public sealed class KnowledgeBroker : IKnowledgeBroker
+{
+    public ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query) =>
+        ValueTask.FromResult<IReadOnlyList<string>>([]);
+}

--- a/Standard.Agents/Brokers/Data/MemoryBroker.cs
+++ b/Standard.Agents/Brokers/Data/MemoryBroker.cs
@@ -1,0 +1,12 @@
+namespace Standard.Agents.Brokers.Data;
+
+// STUB — the durable, external memory store (SQLite / JSON / Redis / vector).
+// Today a no-op so the tier is wired end to end; swap the body for a real store.
+public sealed class MemoryBroker : IMemoryBroker
+{
+    public ValueTask<IReadOnlyList<string>> SelectMemoriesAsync() =>
+        ValueTask.FromResult<IReadOnlyList<string>>([]);
+
+    public ValueTask InsertMemoryAsync(string memory) =>
+        ValueTask.CompletedTask;
+}

--- a/Standard.Agents/Brokers/Data/SkillBroker.cs
+++ b/Standard.Agents/Brokers/Data/SkillBroker.cs
@@ -1,0 +1,20 @@
+namespace Standard.Agents.Brokers.Data;
+
+// Liaison to ONE resource: the skill files on disk. Reads every *.md, orders by
+// name, composes the instruction document. It only reads; a LINQ query, not a loop.
+public sealed class SkillBroker : ISkillBroker
+{
+    private readonly string skillsPath;
+
+    public SkillBroker(string skillsPath) =>
+        this.skillsPath = Path.Combine(AppContext.BaseDirectory, skillsPath);
+
+    public ValueTask<string> SelectSkillsAsync() =>
+        ValueTask.FromResult(
+            string.Join(
+                "\n\n",
+                Directory
+                    .EnumerateFiles(this.skillsPath, "*.md")
+                    .OrderBy(path => path)
+                    .Select(File.ReadAllText)));
+}

--- a/Standard.Agents/Brokers/Decision/ClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Decision/ClassifierBroker.cs
@@ -1,0 +1,9 @@
+namespace Standard.Agents.Brokers.Decision;
+
+// STUB — the Gate's classifier/guardrail model. Today allows everything; swap the
+// body for a real classifier (or point it at the same LLM as the Generator).
+public sealed class ClassifierBroker : IClassifierBroker
+{
+    public ValueTask<string> ClassifyAsync(string systemPrompt, string input) =>
+        ValueTask.FromResult("allow");
+}

--- a/Standard.Agents/Brokers/Decision/GeneratorBroker.cs
+++ b/Standard.Agents/Brokers/Decision/GeneratorBroker.cs
@@ -1,0 +1,80 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Standard.Agents.Brokers.Decision;
+
+// The Brain's liaison: a thin OpenAI-compatible client (POST /v1/chat/completions).
+// Constructs the native request from primitives, POSTs, returns the completion text.
+// No flow control, no authored prompts — those are Data.
+public sealed class GeneratorBroker : IGeneratorBroker
+{
+    private static readonly JsonSerializerOptions jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HttpClient httpClient;
+    private readonly string model;
+    private readonly double temperature;
+    private readonly int maxTokens;
+
+    public GeneratorBroker(
+        string apiUrl,
+        string apiKey,
+        string model,
+        double temperature,
+        int maxTokens)
+    {
+        this.httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(apiUrl),
+            Timeout = TimeSpan.FromSeconds(120)
+        };
+
+        this.httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", apiKey);
+
+        this.model = model;
+        this.temperature = temperature;
+        this.maxTokens = maxTokens;
+    }
+
+    public async ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt)
+    {
+        ChatCompletionRequest request = new(
+            Model: this.model,
+            Messages:
+            [
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", userPrompt)
+            ],
+            Stream: false,
+            Temperature: this.temperature,
+            MaxTokens: this.maxTokens);
+
+        HttpResponseMessage httpResponse =
+            await this.httpClient.PostAsJsonAsync("chat/completions", request, jsonOptions);
+
+        httpResponse.EnsureSuccessStatusCode();
+
+        ChatCompletionResponse? response =
+            await httpResponse.Content.ReadFromJsonAsync<ChatCompletionResponse>(jsonOptions);
+
+        return response!.Choices[0].Message.Content;
+    }
+
+    private sealed record ChatCompletionRequest(
+        string Model,
+        IReadOnlyList<ChatMessage> Messages,
+        bool Stream,
+        double Temperature,
+        int MaxTokens);
+
+    private sealed record ChatMessage(string Role, string Content);
+
+    private sealed record ChatCompletionResponse(IReadOnlyList<ChatChoice> Choices);
+
+    private sealed record ChatChoice(ChatMessage Message);
+}

--- a/Standard.Agents/Brokers/Decision/IClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Decision/IClassifierBroker.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Brokers.Decision;
+
+public interface IClassifierBroker
+{
+    ValueTask<string> ClassifyAsync(string systemPrompt, string input);
+}

--- a/Standard.Agents/Brokers/Decision/IGeneratorBroker.cs
+++ b/Standard.Agents/Brokers/Decision/IGeneratorBroker.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Brokers.Decision;
+
+public interface IGeneratorBroker
+{
+    ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt);
+}

--- a/Standard.Agents/Brokers/Decision/IVerifierBroker.cs
+++ b/Standard.Agents/Brokers/Decision/IVerifierBroker.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Brokers.Decision;
+
+public interface IVerifierBroker
+{
+    ValueTask<double> VerifyAsync(string systemPrompt, string candidate);
+}

--- a/Standard.Agents/Brokers/Decision/VerifierBroker.cs
+++ b/Standard.Agents/Brokers/Decision/VerifierBroker.cs
@@ -1,0 +1,10 @@
+namespace Standard.Agents.Brokers.Decision;
+
+// STUB — the Judge's verifier/scoring model. Today approves everything (1.0); swap
+// the body for a real verifier (reward model / LLM-as-judge). The guardian for
+// safety-critical actions must be a distinct, trusted mind — never the Brain.
+public sealed class VerifierBroker : IVerifierBroker
+{
+    public ValueTask<double> VerifyAsync(string systemPrompt, string candidate) =>
+        ValueTask.FromResult(1.0);
+}

--- a/Standard.Agents/Brokers/Direction/IMcpBroker.cs
+++ b/Standard.Agents/Brokers/Direction/IMcpBroker.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Brokers.Direction;
+
+public interface IMcpBroker
+{
+    ValueTask<string> CallAsync(string name, string input);
+}

--- a/Standard.Agents/Brokers/Direction/IToolBroker.cs
+++ b/Standard.Agents/Brokers/Direction/IToolBroker.cs
@@ -1,0 +1,8 @@
+namespace Standard.Agents.Brokers.Direction;
+
+public interface IToolBroker
+{
+    bool Has(string name);
+
+    ValueTask<string> RunAsync(string name, string input);
+}

--- a/Standard.Agents/Brokers/Direction/McpBroker.cs
+++ b/Standard.Agents/Brokers/Direction/McpBroker.cs
@@ -1,0 +1,9 @@
+namespace Standard.Agents.Brokers.Direction;
+
+// STUB — liaison to external MCP servers / remote APIs. Today reports "not
+// configured"; swap the body for a real MCP / REST client.
+public sealed class McpBroker : IMcpBroker
+{
+    public ValueTask<string> CallAsync(string name, string input) =>
+        ValueTask.FromResult($"[external '{name}' not configured]");
+}

--- a/Standard.Agents/Brokers/Direction/ToolBroker.cs
+++ b/Standard.Agents/Brokers/Direction/ToolBroker.cs
@@ -1,0 +1,20 @@
+using Standard.Agents.Tools;
+
+namespace Standard.Agents.Brokers.Direction;
+
+// Liaison to the in-process tool registry. Holds the registered ITools and runs one
+// by name. Which tool to run (and whether it's internal vs external) is the
+// Direction orchestration's decision, not the broker's.
+public sealed class ToolBroker : IToolBroker
+{
+    private readonly IReadOnlyDictionary<string, ITool> tools;
+
+    public ToolBroker(IEnumerable<ITool> tools) =>
+        this.tools = tools.ToDictionary(tool => tool.Name, StringComparer.OrdinalIgnoreCase);
+
+    public bool Has(string name) =>
+        this.tools.ContainsKey(name);
+
+    public ValueTask<string> RunAsync(string name, string input) =>
+        this.tools[name].ExecuteAsync(input);
+}

--- a/Standard.Agents/Brokers/Loggings/ILogBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/ILogBroker.cs
@@ -1,0 +1,10 @@
+namespace Standard.Agents.Brokers.Loggings;
+
+public interface ILogBroker
+{
+    string LogPath { get; }
+
+    ValueTask ResetAsync();
+
+    ValueTask WriteAsync(string content);
+}

--- a/Standard.Agents/Brokers/Loggings/LogBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LogBroker.cs
@@ -1,0 +1,19 @@
+namespace Standard.Agents.Brokers.Loggings;
+
+// Support broker: a thin liaison to the flow-log file. Reset wipes it per prompt;
+// Write appends. No flow control, no thinking.
+public sealed class LogBroker : ILogBroker
+{
+    private readonly string logPath;
+
+    public string LogPath => this.logPath;
+
+    public LogBroker(string logPath) =>
+        this.logPath = Path.GetFullPath(logPath);
+
+    public async ValueTask ResetAsync() =>
+        await File.WriteAllTextAsync(this.logPath, string.Empty);
+
+    public async ValueTask WriteAsync(string content) =>
+        await File.AppendAllTextAsync(this.logPath, content + Environment.NewLine);
+}

--- a/Standard.Agents/IAgent.cs
+++ b/Standard.Agents/IAgent.cs
@@ -1,0 +1,8 @@
+namespace Standard.Agents;
+
+// An agent takes a prompt and returns an answer. This is also the shape a tool has,
+// which is why an agent can be wrapped as a tool (AgentTool) and nested — the fractal.
+public interface IAgent
+{
+    ValueTask<string> ProcessPromptAsync(string prompt);
+}

--- a/Standard.Agents/Models/AgentContext.cs
+++ b/Standard.Agents/Models/AgentContext.cs
@@ -1,0 +1,23 @@
+namespace Standard.Agents.Models;
+
+// Everything the agent HAS at a point in the loop — Data in flight. Each nature
+// reads it and returns an updated copy. One record because all content is Data; the
+// regions mark which nature last wrote them.
+public sealed record AgentContext
+{
+    public string Prompt { get; init; } = string.Empty;
+
+    // DATA — Recall
+    public string SystemPrompt { get; init; } = string.Empty;
+    public IReadOnlyList<string> Observations { get; init; } = [];
+
+    // DECISION — Think
+    public string Intent { get; init; } = string.Empty;
+    public string DirectionType { get; init; } = string.Empty;
+    public string Payload { get; init; } = string.Empty;
+    public string RawReply { get; init; } = string.Empty;
+
+    // DIRECTION — Act
+    public string Result { get; init; } = string.Empty;
+    public AgentStatus Status { get; init; }
+}

--- a/Standard.Agents/Models/AgentStatus.cs
+++ b/Standard.Agents/Models/AgentStatus.cs
@@ -1,0 +1,12 @@
+namespace Standard.Agents.Models;
+
+// The agent's lifecycle state. Working means keep looping; every other value is a
+// terminal Direction — a reason the loop ended.
+public enum AgentStatus
+{
+    Working,
+    Responded,
+    AwaitingInput,
+    Refused,
+    Failed
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -1,0 +1,72 @@
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models;
+using Standard.Agents.Services.Orchestrations.Data;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Standard.Agents.Services.Orchestrations.Direction;
+
+namespace Standard.Agents.Services.Coordinations;
+
+// The Agent: pure composition. It binds the three orchestrations in a loop, flowing
+// one AgentContext through Recall → Think → Act until a terminal Status. It holds no
+// nature logic — the loop, and observing the loop (the flow log), is all it does.
+public sealed class AgentCoordinationService : IAgentCoordinationService
+{
+    private const int MaxTurns = 7;
+
+    private readonly IDataOrchestrationService dataOrchestration;
+    private readonly IDecisionOrchestrationService decisionOrchestration;
+    private readonly IDirectionOrchestrationService directionOrchestration;
+    private readonly ILogBroker logBroker;
+
+    public AgentCoordinationService(
+        IDataOrchestrationService dataOrchestration,
+        IDecisionOrchestrationService decisionOrchestration,
+        IDirectionOrchestrationService directionOrchestration,
+        ILogBroker logBroker)
+    {
+        this.dataOrchestration = dataOrchestration;
+        this.decisionOrchestration = decisionOrchestration;
+        this.directionOrchestration = directionOrchestration;
+        this.logBroker = logBroker;
+    }
+
+    public async ValueTask<string> ProcessPromptAsync(string prompt)
+    {
+        await this.logBroker.ResetAsync();
+        await this.logBroker.WriteAsync($"RECEIVED: {prompt}");
+
+        AgentContext context = new() { Prompt = prompt };
+
+        for (int turn = 1; turn <= MaxTurns; turn++)
+        {
+            context = await this.dataOrchestration.RecallAsync(context);
+            context = await this.decisionOrchestration.ThinkAsync(context);
+            context = await this.directionOrchestration.ActAsync(context);
+
+            await LogTurnAsync(turn, context);
+
+            if (context.Status != AgentStatus.Working)
+            {
+                break;
+            }
+        }
+
+        return context.Result;
+    }
+
+    private async ValueTask LogTurnAsync(int turn, AgentContext context)
+    {
+        string observations = context.Observations.Count == 0
+            ? "(none)"
+            : Environment.NewLine +
+              string.Join(Environment.NewLine, context.Observations.Select(o => "  - " + o));
+
+        await this.logBroker.WriteAsync(
+            $"{Environment.NewLine}================ turn {turn} ================{Environment.NewLine}" +
+            $"[RECALL] observations: {observations}{Environment.NewLine}" +
+            $"[THINK]  model said: {context.RawReply}{Environment.NewLine}" +
+            $"  parsed -> intent={context.Intent}, direction={context.DirectionType}, " +
+            $"payload=\"{context.Payload}\"{Environment.NewLine}" +
+            $"[ACT]    status={context.Status}, result=\"{context.Result}\"");
+    }
+}

--- a/Standard.Agents/Services/Coordinations/IAgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/IAgentCoordinationService.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Services.Coordinations;
+
+// The Agent. Coordinates the three orchestrations in a loop. It IS an IAgent.
+public interface IAgentCoordinationService : IAgent
+{
+}

--- a/Standard.Agents/Services/Foundations/Data/IKnowledgeService.cs
+++ b/Standard.Agents/Services/Foundations/Data/IKnowledgeService.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Services.Foundations.Data;
+
+public interface IKnowledgeService
+{
+    ValueTask<IReadOnlyList<string>> RetrieveKnowledgeAsync(string query);
+}

--- a/Standard.Agents/Services/Foundations/Data/IMemoryService.cs
+++ b/Standard.Agents/Services/Foundations/Data/IMemoryService.cs
@@ -1,0 +1,8 @@
+namespace Standard.Agents.Services.Foundations.Data;
+
+public interface IMemoryService
+{
+    ValueTask<IReadOnlyList<string>> RecallMemoriesAsync();
+
+    ValueTask RememberAsync(string memory);
+}

--- a/Standard.Agents/Services/Foundations/Data/ISkillService.cs
+++ b/Standard.Agents/Services/Foundations/Data/ISkillService.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Services.Foundations.Data;
+
+public interface ISkillService
+{
+    ValueTask<string> RetrieveSkillsAsync();
+}

--- a/Standard.Agents/Services/Foundations/Data/KnowledgeService.cs
+++ b/Standard.Agents/Services/Foundations/Data/KnowledgeService.cs
@@ -1,0 +1,16 @@
+using Standard.Agents.Brokers.Data;
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+// Foundation over ONE broker (the knowledge index). On-demand retrieval for the
+// current task — what the agent can look up.
+public sealed class KnowledgeService : IKnowledgeService
+{
+    private readonly IKnowledgeBroker knowledgeBroker;
+
+    public KnowledgeService(IKnowledgeBroker knowledgeBroker) =>
+        this.knowledgeBroker = knowledgeBroker;
+
+    public async ValueTask<IReadOnlyList<string>> RetrieveKnowledgeAsync(string query) =>
+        await this.knowledgeBroker.SelectKnowledgeAsync(query);
+}

--- a/Standard.Agents/Services/Foundations/Data/MemoryService.cs
+++ b/Standard.Agents/Services/Foundations/Data/MemoryService.cs
@@ -1,0 +1,19 @@
+using Standard.Agents.Brokers.Data;
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+// Foundation over ONE broker (the memory store). Persistent memory lives outside the
+// agent; this is the only way it enters (Recall) and is written (Remember).
+public sealed class MemoryService : IMemoryService
+{
+    private readonly IMemoryBroker memoryBroker;
+
+    public MemoryService(IMemoryBroker memoryBroker) =>
+        this.memoryBroker = memoryBroker;
+
+    public async ValueTask<IReadOnlyList<string>> RecallMemoriesAsync() =>
+        await this.memoryBroker.SelectMemoriesAsync();
+
+    public async ValueTask RememberAsync(string memory) =>
+        await this.memoryBroker.InsertMemoryAsync(memory);
+}

--- a/Standard.Agents/Services/Foundations/Data/SkillService.cs
+++ b/Standard.Agents/Services/Foundations/Data/SkillService.cs
@@ -1,0 +1,15 @@
+using Standard.Agents.Brokers.Data;
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+// Foundation over ONE broker (the skill broker). Business language: Select → Retrieve.
+public sealed class SkillService : ISkillService
+{
+    private readonly ISkillBroker skillBroker;
+
+    public SkillService(ISkillBroker skillBroker) =>
+        this.skillBroker = skillBroker;
+
+    public async ValueTask<string> RetrieveSkillsAsync() =>
+        await this.skillBroker.SelectSkillsAsync();
+}

--- a/Standard.Agents/Services/Foundations/Decision/BrainService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/BrainService.cs
@@ -1,0 +1,17 @@
+using Standard.Agents.Brokers.Decision;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+// Foundation over ONE broker (the generator). The one Brain — it produces the
+// reasoning. Interpreting that reply into a decision is the Decision orchestration's
+// job; this service just generates.
+public sealed class BrainService : IBrainService
+{
+    private readonly IGeneratorBroker generatorBroker;
+
+    public BrainService(IGeneratorBroker generatorBroker) =>
+        this.generatorBroker = generatorBroker;
+
+    public async ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt) =>
+        await this.generatorBroker.GenerateAsync(systemPrompt, userPrompt);
+}

--- a/Standard.Agents/Services/Foundations/Decision/GateService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/GateService.cs
@@ -1,0 +1,16 @@
+using Standard.Agents.Brokers.Decision;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+// Foundation over ONE broker (the classifier). The agent's conscience at the front
+// door — screens the input to accept, refuse, or route it. Not the Brain.
+public sealed class GateService : IGateService
+{
+    private readonly IClassifierBroker classifierBroker;
+
+    public GateService(IClassifierBroker classifierBroker) =>
+        this.classifierBroker = classifierBroker;
+
+    public async ValueTask<string> ScreenAsync(string gatePrompt, string input) =>
+        await this.classifierBroker.ClassifyAsync(gatePrompt, input);
+}

--- a/Standard.Agents/Services/Foundations/Decision/IBrainService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/IBrainService.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public interface IBrainService
+{
+    ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt);
+}

--- a/Standard.Agents/Services/Foundations/Decision/IGateService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/IGateService.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public interface IGateService
+{
+    ValueTask<string> ScreenAsync(string gatePrompt, string input);
+}

--- a/Standard.Agents/Services/Foundations/Decision/IJudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/IJudgeService.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public interface IJudgeService
+{
+    ValueTask<double> EvaluateAsync(string judgePrompt, string candidate);
+}

--- a/Standard.Agents/Services/Foundations/Decision/JudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/JudgeService.cs
@@ -1,0 +1,17 @@
+using Standard.Agents.Brokers.Decision;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+// Foundation over ONE broker (the verifier). The agent's conscience at the back door
+// — scores a candidate before it leaves. For safety-critical output the guardian
+// must be a distinct, trusted mind, never the Brain.
+public sealed class JudgeService : IJudgeService
+{
+    private readonly IVerifierBroker verifierBroker;
+
+    public JudgeService(IVerifierBroker verifierBroker) =>
+        this.verifierBroker = verifierBroker;
+
+    public async ValueTask<double> EvaluateAsync(string judgePrompt, string candidate) =>
+        await this.verifierBroker.VerifyAsync(judgePrompt, candidate);
+}

--- a/Standard.Agents/Services/Foundations/Direction/ExternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ExternalToolService.cs
@@ -1,0 +1,16 @@
+using Standard.Agents.Brokers.Direction;
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+// Foundation over ONE broker (MCP). Acts OUTWARD across the boundary — remote tools,
+// APIs, other agents/services.
+public sealed class ExternalToolService : IExternalToolService
+{
+    private readonly IMcpBroker mcpBroker;
+
+    public ExternalToolService(IMcpBroker mcpBroker) =>
+        this.mcpBroker = mcpBroker;
+
+    public async ValueTask<string> CallAsync(string toolName, string input) =>
+        await this.mcpBroker.CallAsync(toolName, input);
+}

--- a/Standard.Agents/Services/Foundations/Direction/IExternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/IExternalToolService.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public interface IExternalToolService
+{
+    ValueTask<string> CallAsync(string toolName, string input);
+}

--- a/Standard.Agents/Services/Foundations/Direction/IInternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/IInternalToolService.cs
@@ -1,0 +1,8 @@
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public interface IInternalToolService
+{
+    bool Handles(string toolName);
+
+    ValueTask<string> RunAsync(string toolName, string input);
+}

--- a/Standard.Agents/Services/Foundations/Direction/IReturnService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/IReturnService.cs
@@ -1,0 +1,6 @@
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public interface IReturnService
+{
+    ValueTask<string> ReturnAsync(string payload);
+}

--- a/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
@@ -1,0 +1,19 @@
+using Standard.Agents.Brokers.Direction;
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+// Foundation over ONE broker (the tool registry). Acts WITHIN the agent's own
+// environment — in-process tools.
+public sealed class InternalToolService : IInternalToolService
+{
+    private readonly IToolBroker toolBroker;
+
+    public InternalToolService(IToolBroker toolBroker) =>
+        this.toolBroker = toolBroker;
+
+    public bool Handles(string toolName) =>
+        this.toolBroker.Has(toolName);
+
+    public async ValueTask<string> RunAsync(string toolName, string input) =>
+        await this.toolBroker.RunAsync(toolName, input);
+}

--- a/Standard.Agents/Services/Foundations/Direction/ReturnService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ReturnService.cs
@@ -1,0 +1,10 @@
+namespace Standard.Agents.Services.Foundations.Direction;
+
+// The dead-end foundation: no broker, no external resource. Its "resource" is the
+// caller. Today it hands the payload back unchanged; later it can format, stream, or
+// deliver over a channel. This is where Return grows.
+public sealed class ReturnService : IReturnService
+{
+    public ValueTask<string> ReturnAsync(string payload) =>
+        ValueTask.FromResult(payload);
+}

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -1,0 +1,41 @@
+using Standard.Agents.Models;
+using Standard.Agents.Services.Foundations.Data;
+
+namespace Standard.Agents.Services.Orchestrations.Data;
+
+// DATA — Recall. Coordinates the three Data foundations (Skills, Memory, Knowledge)
+// and folds what the agent HAS into the context. Skills become the system prompt;
+// recalled memory + retrieved knowledge seed the working observations.
+public sealed class DataOrchestrationService : IDataOrchestrationService
+{
+    private readonly ISkillService skillService;
+    private readonly IMemoryService memoryService;
+    private readonly IKnowledgeService knowledgeService;
+
+    public DataOrchestrationService(
+        ISkillService skillService,
+        IMemoryService memoryService,
+        IKnowledgeService knowledgeService)
+    {
+        this.skillService = skillService;
+        this.memoryService = memoryService;
+        this.knowledgeService = knowledgeService;
+    }
+
+    public async ValueTask<AgentContext> RecallAsync(AgentContext context)
+    {
+        string skills = await this.skillService.RetrieveSkillsAsync();
+        IReadOnlyList<string> memories = await this.memoryService.RecallMemoriesAsync();
+        IReadOnlyList<string> knowledge = await this.knowledgeService.RetrieveKnowledgeAsync(context.Prompt);
+
+        IReadOnlyList<string> recalled = [.. memories, .. knowledge];
+
+        return context with
+        {
+            SystemPrompt = skills,
+            Observations = context.Observations.Count == 0 && recalled.Count > 0
+                ? recalled
+                : context.Observations
+        };
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Data/IDataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/IDataOrchestrationService.cs
@@ -1,0 +1,8 @@
+using Standard.Agents.Models;
+
+namespace Standard.Agents.Services.Orchestrations.Data;
+
+public interface IDataOrchestrationService
+{
+    ValueTask<AgentContext> RecallAsync(AgentContext context);
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -1,0 +1,124 @@
+using System.Text;
+using Standard.Agents.Models;
+using Standard.Agents.Services.Foundations.Decision;
+
+namespace Standard.Agents.Services.Orchestrations.Decision;
+
+// DECISION — Think. Coordinates the conscience-wrapped Brain: Gate screens the input,
+// the one Brain reasons, the Judge screens the output. It authors no prompt text
+// (that is Data); it frames the task, reads the reply, and interprets it into the
+// next direction.
+public sealed class DecisionOrchestrationService : IDecisionOrchestrationService
+{
+    private readonly IGateService gateService;
+    private readonly IBrainService brainService;
+    private readonly IJudgeService judgeService;
+
+    public DecisionOrchestrationService(
+        IGateService gateService,
+        IBrainService brainService,
+        IJudgeService judgeService)
+    {
+        this.gateService = gateService;
+        this.brainService = brainService;
+        this.judgeService = judgeService;
+    }
+
+    public async ValueTask<AgentContext> ThinkAsync(AgentContext context)
+    {
+        // GATE — the conscience at the front door.
+        string verdict = await this.gateService.ScreenAsync(context.SystemPrompt, context.Prompt);
+
+        if (verdict.Equals("refuse", StringComparison.OrdinalIgnoreCase))
+        {
+            return context with
+            {
+                Intent = "Refused",
+                DirectionType = "Refuse",
+                Payload = "I'm not able to help with that.",
+                RawReply = verdict
+            };
+        }
+
+        // BRAIN — the one brain reasons.
+        string userMessage = BuildUserMessage(context);
+        string reply =
+            (await this.brainService.GenerateAsync(context.SystemPrompt, userMessage)).Trim();
+
+        AgentContext decided = Interpret(context, reply);
+
+        // JUDGE — reflective check on a final answer (the stub verifier approves
+        // everything today; a low score would loop instead of returning).
+        if (decided.DirectionType.Equals("ReturnResponse", StringComparison.OrdinalIgnoreCase))
+        {
+            double score = await this.judgeService.EvaluateAsync(context.SystemPrompt, decided.Payload);
+
+            if (score < 0.3)
+            {
+                return context with
+                {
+                    Observations = [.. context.Observations, "draft rejected by judge — revise"],
+                    Status = AgentStatus.Working
+                };
+            }
+        }
+
+        return decided;
+    }
+
+    private static string BuildUserMessage(AgentContext context)
+    {
+        StringBuilder userMessage = new();
+
+        userMessage.Append("Task: ").Append(context.Prompt);
+
+        if (context.Observations.Count > 0)
+        {
+            userMessage.AppendLine().AppendLine().AppendLine("Observations so far:");
+
+            foreach (string observation in context.Observations)
+            {
+                userMessage.Append("- ").AppendLine(observation);
+            }
+        }
+
+        return userMessage.ToString();
+    }
+
+    private static AgentContext Interpret(AgentContext context, string reply)
+    {
+        string firstLine = reply.Split('\n')[0].Trim();
+
+        bool modelChoseToAct =
+            firstLine.StartsWith("ACTION:", StringComparison.OrdinalIgnoreCase);
+
+        if (modelChoseToAct)
+        {
+            string[] toolCall =
+                firstLine["ACTION:".Length..].Split(':', 2, StringSplitOptions.TrimEntries);
+
+            string toolName = toolCall[0];
+            string toolInput = toolCall.Length > 1 ? toolCall[1] : string.Empty;
+
+            return context with
+            {
+                Intent = "UseTool",
+                DirectionType = toolName,
+                Payload = toolInput,
+                RawReply = reply
+            };
+        }
+
+        string answer = reply.StartsWith("FINAL:", StringComparison.OrdinalIgnoreCase)
+            ? reply["FINAL:".Length..].Trim()
+            : reply;
+
+        return context with
+        {
+            Intent = "Answer",
+            DirectionType = "ReturnResponse",
+            Payload = answer,
+            RawReply = reply
+        };
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/IDecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/IDecisionOrchestrationService.cs
@@ -1,0 +1,8 @@
+using Standard.Agents.Models;
+
+namespace Standard.Agents.Services.Orchestrations.Decision;
+
+public interface IDecisionOrchestrationService
+{
+    ValueTask<AgentContext> ThinkAsync(AgentContext context);
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -1,0 +1,63 @@
+using Standard.Agents.Models;
+using Standard.Agents.Services.Foundations.Direction;
+
+namespace Standard.Agents.Services.Orchestrations.Direction;
+
+// DIRECTION — Act. Routes the decision to a locus: Return (up to caller, terminal),
+// Internal (a local tool), or External (out across the boundary). A tool result is
+// sent back to Data as an observation, keeping the loop going.
+public sealed class DirectionOrchestrationService : IDirectionOrchestrationService
+{
+    private readonly IInternalToolService internalToolService;
+    private readonly IExternalToolService externalToolService;
+    private readonly IReturnService returnService;
+
+    public DirectionOrchestrationService(
+        IInternalToolService internalToolService,
+        IExternalToolService externalToolService,
+        IReturnService returnService)
+    {
+        this.internalToolService = internalToolService;
+        this.externalToolService = externalToolService;
+        this.returnService = returnService;
+    }
+
+    public async ValueTask<AgentContext> ActAsync(AgentContext context)
+    {
+        // RETURN — up to the caller (terminal).
+        if (context.DirectionType.Equals("ReturnResponse", StringComparison.OrdinalIgnoreCase))
+        {
+            string answer = await this.returnService.ReturnAsync(context.Payload);
+            return context with { Result = answer, Status = AgentStatus.Responded };
+        }
+
+        if (context.DirectionType.Equals("Refuse", StringComparison.OrdinalIgnoreCase))
+        {
+            string answer = await this.returnService.ReturnAsync(context.Payload);
+            return context with { Result = answer, Status = AgentStatus.Refused };
+        }
+
+        // INTERNAL — a local tool the agent owns.
+        if (this.internalToolService.Handles(context.DirectionType))
+        {
+            string result = await this.internalToolService.RunAsync(context.DirectionType, context.Payload);
+
+            return context with
+            {
+                Result = result,
+                Observations = [.. context.Observations, $"{context.DirectionType}({context.Payload}) => {result}"],
+                Status = AgentStatus.Working
+            };
+        }
+
+        // EXTERNAL — out across the boundary (MCP / remote). Stub today.
+        string external = await this.externalToolService.CallAsync(context.DirectionType, context.Payload);
+
+        return context with
+        {
+            Result = external,
+            Observations = [.. context.Observations, $"{context.DirectionType}({context.Payload}) => {external}"],
+            Status = AgentStatus.Working
+        };
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/IDirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/IDirectionOrchestrationService.cs
@@ -1,0 +1,8 @@
+using Standard.Agents.Models;
+
+namespace Standard.Agents.Services.Orchestrations.Direction;
+
+public interface IDirectionOrchestrationService
+{
+    ValueTask<AgentContext> ActAsync(AgentContext context);
+}

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Standard.Agents/Tools/AgentTool.cs
+++ b/Standard.Agents/Tools/AgentTool.cs
@@ -1,0 +1,19 @@
+namespace Standard.Agents.Tools;
+
+// The fractal bridge: wraps a whole Agent as a tool, so a Direction can be another
+// Agent.
+public sealed class AgentTool : ITool
+{
+    private readonly IAgent agent;
+
+    public string Name { get; }
+
+    public AgentTool(string name, IAgent agent)
+    {
+        this.Name = name;
+        this.agent = agent;
+    }
+
+    public ValueTask<string> ExecuteAsync(string input) =>
+        this.agent.ProcessPromptAsync(input);
+}

--- a/Standard.Agents/Tools/ITool.cs
+++ b/Standard.Agents/Tools/ITool.cs
@@ -1,0 +1,10 @@
+namespace Standard.Agents.Tools;
+
+// The fractal contract. Every effector is a tool: input in, output out. A leaf tool
+// (a calculator) satisfies it; a whole agent satisfies it too (via AgentTool).
+public interface ITool
+{
+    string Name { get; }
+
+    ValueTask<string> ExecuteAsync(string input);
+}

--- a/THE-TRI-NATURE-OF-AGENT.md
+++ b/THE-TRI-NATURE-OF-AGENT.md
@@ -1,0 +1,305 @@
+# The Standard for Agents
+## Book I — The Tri-Nature of Agent
+
+> An agent is not an LLM, a tool, a prompt, or a memory.
+> An agent is the **orchestration of three natures**.
+
+```
+Agent = Orchestration(Data, Decision, Direction)
+```
+
+- **Data** is what the agent **has**.
+- **Decision** is what the agent **thinks**.
+- **Direction** is what the agent **does**.
+- **Orchestration** is what **binds** them into agency.
+
+This document is the living source of the Standard. The theory is settled here first;
+code is built to it.
+
+---
+
+## Chapter 1 — The Three Natures
+
+Everything in an agent falls into exactly one of three buckets.
+
+### Data — what it HAS  ·  verb: Recall
+Any static information: configuration, skills, identity, instructions, rules, context,
+retrieved content, prompts, and responses. **Once content is produced, it becomes Data.**
+Data does not think and does not act. It is only material to be interpreted.
+
+### Decision — what it THINKS  ·  verb: Think
+The **act** of reasoning under ambiguity. Not data in itself — the *process* of making
+decisions that lead to actions. Deterministic evaluation is not Decision (that is
+computation). Another mind's judgment is not this agent's Decision (that is external).
+Decision is only the agent's *own* reasoning.
+
+### Direction — what it DOES  ·  verb: Act
+Any action: calling an API or MCP server, running a tool, persisting back to Data,
+returning the response, asking a question, refusing an unsafe action.
+
+### Orchestration — what BINDS them
+Orchestration is **not a fourth nature**. It is the composition operator — the loop.
+Every concrete thing it does reduces to one of the three natures.
+
+---
+
+## Chapter 2 — The Loop
+
+```
+new context
+   ↓
+Recall (Data) → Think (Decision) → Act (Direction)
+   ↑____________________________________|
+        (Direction sends its result back into Data)
+   ↓
+repeat until a terminal Status
+```
+
+One `AgentContext` — **Data in flight** — threads the loop. Each nature reads it and
+returns an updated copy. The loop ends at a terminal Status.
+
+---
+
+## Chapter 3 — The Carriers
+
+**Every model is Data.** The nature is the *act*, never the struct. `AgentContext` is the
+one record that threads the loop; its regions are marked by which nature last wrote them.
+
+```csharp
+public sealed record AgentContext
+{
+    public string Prompt { get; init; } = "";
+
+    // DATA — what it HAS
+    public string SystemPrompt { get; init; } = "";
+    public IReadOnlyList<string> Observations { get; init; } = [];
+
+    // DECISION — what it THINKS
+    public string Intent { get; init; } = "";
+    public string DirectionType { get; init; } = "";
+    public string Payload { get; init; } = "";
+    public string RawReply { get; init; } = "";
+
+    // DIRECTION — what it DID
+    public string Result { get; init; } = "";
+    public AgentStatus Status { get; init; }
+}
+```
+
+**`AgentStatus` is an enum, never a boolean** — the terminal states *are* the terminal
+Directions, and new behaviors slot in without touching the loop:
+
+```csharp
+public enum AgentStatus { Working, Responded, AwaitingInput, Refused, Failed }
+```
+
+---
+
+## Chapter 4 — The Fractal Property
+
+The pattern repeats **upward and downward**. Same shape at every scale.
+
+- **Upward** — a Direction can be another whole Agent (an agent wrapped as a tool).
+  Agents nest inside agents. Turtles up.
+- **Downward** — each nature decomposes again, *where genuine physical multiplicity
+  exists*. Turtles down. (The fractal is descriptive, not a mandate: do not force three
+  where the world has one.)
+
+```
+Agent
+├── Data      = (Skills, Memory, Knowledge)   — three sources
+├── Decision  = (Gate,   Brain,  Judge)       — one brain, flanked by conscience
+└── Direction = (Internal, External, Return)  — three loci
+```
+
+---
+
+## Chapter 5 — The Sub-Natures
+
+Each nature's legs are organized along that nature's natural dimension. The whole reads
+as one sentence: *what I was taught, remember, and can look up → screened, thought, and
+verified → acted out, in, or not at all.*
+
+### Data = (Skills, Memory, Knowledge) — by SOURCE (fan-in)
+| Leg | Is | Broker |
+|---|---|---|
+| **Skills** | authored — what I was taught (identity, instructions, tools, behavior) | `SkillBroker` (files) |
+| **Memory** | experienced — what I remember (persistent, shareable, across sessions) | `MemoryBroker` (durable store) |
+| **Knowledge** | retrieved — what I can look up now (RAG, search, documents, live data) | `KnowledgeBroker` (index/API) |
+
+### Decision = (Gate, Brain, Judge) — ONE brain, wrapped in conscience
+An agent has **one brain**. Multiplicity of brains is not an intra-agent feature — it is
+the **fractal** (a higher-order agent choosing which specialist sub-agent to consult, via
+Direction). The Brain is flanked by two conscience faculties that are **not brains**:
+
+| Leg | Role | May be |
+|---|---|---|
+| **Gate** (Classifier) | screen the INPUT — accept / refuse / route in | deterministic rule · LLM guardrail · human |
+| **Brain** (Generator) | the one reasoning engine — *thinks the task* | the LLM |
+| **Judge** | screen the OUTPUT — accept / refuse / revise out | deterministic rule · LLM verifier · human |
+
+Physically, the three are *interfaces* distinguished by output shape — a **label**
+(classify), **text** (generate), a **score** (judge). At small scale one model wears all
+three hats; at enterprise scale they separate into specialized models. **Three interfaces,
+collapsible substrate.** For anything safety-critical the guardian must **not** be the
+brain (see Chapters 8–10).
+
+### Direction = (Internal, External, Return) — by LOCUS (fan-out)
+| Leg | Is | Example |
+|---|---|---|
+| **Internal** | act within the agent's own environment | a local/in-process tool, a memory write |
+| **External** | act outward, across the boundary | MCP server, remote API, another agent |
+| **Return** | no action — hand the result back | the terminal Direction; the response to the caller |
+
+### The Hourglass
+Data **fans in** (many sources → one context); Direction **fans out** (one decision →
+many effectors); the Brain is the singular waist. Data and Direction are plural because
+they **touch the world**; the Brain is singular because it touches **only its own mind**.
+
+---
+
+## Chapter 6 — The Boundary Principle
+
+> Everything *outside* the agent reaches it only through **Direction** (going out) and
+> **Data** (coming back). The three natures are strictly the agent's *interior*.
+
+It explains every hard case:
+- A rule's *content* → **Data** (Skills). Its deterministic evaluation → **Direction**;
+  the verdict → **Data**.
+- A human → **Direction** (ask) → their answer → **Data**.
+- Another agent's brain → **Direction** (delegate via MCP / AgentTool) → its reply → **Data**.
+- The agent's *own* inference → **Decision** — the only thing that never crosses the boundary.
+
+**Configuration is not a nature.** It is system composition — how the brokers *function*.
+Infrastructure config → the Brokers. Behavioral preferences → fold into Skills.
+
+---
+
+## Chapter 7 — Lifecycle & Memory
+
+**The agent instance is ephemeral compute. Memory is a durable, external resource.**
+
+- The instance spins up, **recalls, thinks, acts, persists — and dies.** It carries no state
+  between prompts.
+- **Working memory** (within one prompt) lives in the context and dies with the loop.
+- **Persistent memory** lives *outside* the flow — a durable, shareable store behind a
+  broker. **Recalled by Data, written by Direction.**
+- The gap between prompt N and N+1 is irrelevant to the agent: it always recalls from the
+  store. If a day passes, the instance is gone; the store remains.
+
+---
+
+## Chapter 8 — Judgment: Reflection vs Guardianship
+
+Judgment splits by one question: **can the same brain be trusted to judge this?**
+
+| Kind | Trust | Mechanism |
+|---|---|---|
+| **Reflective** (quality, grounding, coherence) | the brain *wants* to get it right | **the loop** — the draft becomes Data, the next Think reconsiders it (same brain) |
+| **Guardian** (policy, safety, refusal) | the brain may *want* to violate | a **distinct conscience** — never the same brain: a deterministic rule, a separate verifier, or a compliance *sub-agent* (the fractal) |
+
+**You cannot let a faculty certify its own trustworthiness.** A heretic (uncensored) brain
+judging its own output will approve it. The refusal must come from a mind that is *not* the
+brain. Reflection is *in-band*; guardianship is *out-of-band*.
+
+Corollary: **producing a draft ≠ committing to return it.** The brain's output is a *draft*
+(internal Data). Only a deliberate, post-judgment Direction returns it. Nothing crosses the
+boundary un-vetted.
+
+---
+
+## Chapter 9 — Safety: The Privilege Boundary
+
+> The **Decision→Direction boundary is a privilege boundary** — like userspace → kernel.
+> The brain is untrusted userspace: it may *propose* anything. Direction is the privileged
+> syscall, where proposals become real-world effects. A heretic brain with no guardian is
+> **running as root with no permission checks.**
+
+The dividing line for *where* the guardian sits is **reversibility**:
+
+| | Guardian position | Why |
+|---|---|---|
+| **Reversible** output (a draft) | may loop — stash → judge → return | nothing left the boundary; retract for free |
+| **Irreversible** action (cut power, move money, delete, deploy) | **must gate BEFORE execution — never after** | you cannot un-ring the bell |
+
+For catastrophic actions the guardian is **layered by stakes** — and never a single
+fool-able model:
+1. **Deterministic rules** — hard blocks that cannot be talked out of (Rules-as-Data,
+   evaluated deterministically — un-jailbreakable).
+2. **Human approval** — `AwaitingInput` for the irreversible / high-stakes.
+3. **An LLM verifier** — for nuance, but never the sole guard on anything catastrophic.
+
+Enforce on both sides for depth: Decision won't *commit* an unauthorized action, and
+Direction won't *execute* one. The guardian is not optional for any agent with real
+Direction capability — it is the authorization layer that makes an agent safe to give
+hands at all.
+
+---
+
+## Chapter 10 — Governance: Jurisdiction
+
+**An environment is a jurisdiction** — it plays the tri-nature at a higher order to govern
+the agents inside it (its Data = the laws; its Decision = "is this permitted here?"; its
+Direction = grant / revoke / quarantine / expel).
+
+When an agent enters an environment, two things happen — and keeping them separate is the
+whole security story:
+
+1. **The place feeds its rules into the agent's Data.** The agent *learns* local law —
+   same agent, different environment, different Data, different behavior ("when in Rome").
+   This is the *cooperative* path.
+2. **The place enforces at its own boundary with its own guardian.** Because **you cannot
+   trust a visitor to self-police.** A rogue agent ignores the rulebook you hand it.
+
+> **Self-governance is cooperative and subvertible. Jurisdiction is authoritative and
+> final. Security rests on the perimeter, never on the visitor's conscience.**
+
+- **Capability follows location, gated at the perimeter.** Tools are granted by the
+  jurisdiction; the environment's guardian ensures the agent cannot reach past its grant.
+  More trust → more tools; locked-down place → almost none.
+- **Data carries a policy hierarchy, not a flat blob.** Home values < environmental mandate
+  < higher jurisdiction; the Judge enforces precedence (local law supersedes home preference
+  for actions taken here). Rules-as-Data are inert until a Judge reads and gates on them.
+
+The Judge is therefore not one component in one agent — it is the **enforcement fabric of
+the whole cyberspace.** Every boundary between minds and capabilities has one, or that
+boundary is not real. Without judges: rough agents gaining access where they should not.
+That is the hospital, and the matrix, same root cause.
+
+---
+
+## Chapter 11 — Structural Mapping (to The Standard)
+
+| Concept | Standard element |
+|---|---|
+| The three natures | **Services** — `DataService.Recall`, `DecisionService.Think`, `DirectionService.Act` (one interface each) |
+| Each sub-nature's resource | **Brokers** — thin liaisons, one resource per broker, no flow control, no authored prompts |
+| The loop | **Orchestration** — pure composition; holds no nature logic |
+| Data in flight | **`AgentContext`** — one record; every model is Data |
+| Lifecycle state | **`AgentStatus`** enum |
+| An agent as a tool | **`ITool`** — the fractal bridge (a Direction may be a leaf tool or a whole Agent) |
+
+Flow is forward only: `Exposer → Orchestration → Service → Broker → resource`.
+Prompts, rules, and rubrics are **Data** (Skills), never authored in code.
+
+---
+
+## Settled Invariants
+
+0. Everything is Data, Decision, or Direction. Orchestration binds; it is not a fourth nature.
+1. Every model is Data. Once content is produced, it becomes Data.
+2. An agent has one brain. Multiplicity of brains is the fractal (agents of agents).
+3. Prompts / rules / rubrics live in Data (Skills), never in code.
+4. The agent is ephemeral; persistent memory lives outside it, recalled by Data, written by Direction.
+5. Producing a draft ≠ committing to return it. Nothing crosses a boundary un-vetted.
+6. You cannot let a faculty certify its own trustworthiness. Guardians are never the brain.
+7. Irreversible actions are authorized before execution — by rule and/or human, never after.
+8. Security rests on the perimeter (jurisdiction), never on the visitor's conscience.
+
+## Open / To Settle
+- Whether Gate/Brain/Judge get explicit separate interfaces now or later.
+- Knowledge (retrieval) and Memory brokers are theory until wired.
+
+---
+
+*The Standard for Agents — Book I. Settled before code. Build to it.*

--- a/architecture.svg
+++ b/architecture.svg
@@ -1,0 +1,112 @@
+<svg viewBox="0 0 1240 545" role="img" xmlns="http://www.w3.org/2000/svg">
+<title>The Tri-Nature of Agent — full architecture</title>
+<desc>Exposer (Client) calls Coordination (the Agent, which loops Recall then Think then Act until a terminal Status). Coordination coordinates three Orchestrations: Data (Recall), Decision (Think), Direction (Act). Each Orchestration coordinates three Foundation services over brokers. Data: Skills over files, Memory over store, Knowledge over index. Decision: Gate over classifier, Brain over LLM, Judge over verifier. Direction: Internal over tools, External over MCP, Return which is a dead end with no broker.</desc>
+<style>
+  svg { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; background:#ffffff; }
+  :root { --ink:#1c1c1c; --muted:#6d6d6d; --line:#c9c9c4; --surf:#ffffff; --surf2:#f0efec; --accent:#3f6f8f; --accent-weak:#dbe6ee; --on-accent:#ffffff; }
+  @media (prefers-color-scheme: dark){ svg{ background:#161616; } :root{ --ink:#ececec; --muted:#9a9a9a; --line:#3d3d3d; --surf:#1f1f1f; --surf2:#2b2b2b; --accent:#5f93b8; --accent-weak:#22323d; --on-accent:#0e1620; } }
+  .conn{ stroke:var(--line); stroke-width:1.3; }
+  .client{ fill:var(--surf); stroke:var(--accent); stroke-width:1.5; }
+  .coord{ fill:var(--accent); }
+  .orch{ fill:var(--accent-weak); stroke:var(--accent); stroke-width:1.5; }
+  .fnd{ fill:var(--surf2); stroke:var(--line); stroke-width:1; }
+  .broker{ fill:var(--surf); stroke:var(--line); stroke-width:1; }
+  .dead{ fill:none; stroke:var(--muted); stroke-width:1; stroke-dasharray:4 3; }
+  text{ fill:var(--ink); }
+  .t-client{ font-weight:700; font-size:13px; }
+  .t-sub{ fill:var(--muted); font-size:10.5px; }
+  .t-coord{ fill:var(--on-accent); font-weight:700; font-size:15px; }
+  .t-coordsub{ fill:var(--on-accent); opacity:.85; font-size:11px; }
+  .t-orch{ font-weight:700; font-size:14px; letter-spacing:.5px; }
+  .t-verb{ fill:var(--muted); font-size:11px; }
+  .t-fnd{ font-weight:600; font-size:12.5px; }
+  .t-brk{ fill:var(--muted); font-size:10px; }
+  .t-row{ fill:var(--muted); font-size:10px; font-weight:700; letter-spacing:.5px; }
+</style>
+
+<text class="t-row" x="12" y="50">EXPOSER</text>
+<text class="t-row" x="12" y="138">COORDINATION · 1</text>
+<text class="t-row" x="12" y="267">ORCHESTRATION · 3</text>
+<text class="t-row" x="12" y="403">FOUNDATION · 9</text>
+<text class="t-row" x="12" y="494">BROKER · 8+1</text>
+
+<line class="conn" x1="660" y1="68" x2="660" y2="100"/>
+<line class="conn" x1="660" y1="168" x2="310" y2="232"/>
+<line class="conn" x1="660" y1="168" x2="660" y2="232"/>
+<line class="conn" x1="660" y1="168" x2="1010" y2="232"/>
+<line class="conn" x1="310" y1="292" x2="202" y2="372"/>
+<line class="conn" x1="310" y1="292" x2="310" y2="372"/>
+<line class="conn" x1="310" y1="292" x2="418" y2="372"/>
+<line class="conn" x1="660" y1="292" x2="552" y2="372"/>
+<line class="conn" x1="660" y1="292" x2="660" y2="372"/>
+<line class="conn" x1="660" y1="292" x2="768" y2="372"/>
+<line class="conn" x1="1010" y1="292" x2="902" y2="372"/>
+<line class="conn" x1="1010" y1="292" x2="1010" y2="372"/>
+<line class="conn" x1="1010" y1="292" x2="1118" y2="372"/>
+<line class="conn" x1="202" y1="426" x2="202" y2="470"/>
+<line class="conn" x1="310" y1="426" x2="310" y2="470"/>
+<line class="conn" x1="418" y1="426" x2="418" y2="470"/>
+<line class="conn" x1="552" y1="426" x2="552" y2="470"/>
+<line class="conn" x1="660" y1="426" x2="660" y2="470"/>
+<line class="conn" x1="768" y1="426" x2="768" y2="470"/>
+<line class="conn" x1="902" y1="426" x2="902" y2="470"/>
+<line class="conn" x1="1010" y1="426" x2="1010" y2="470"/>
+<line class="conn" x1="1118" y1="426" x2="1118" y2="470"/>
+
+<rect class="client" x="530" y="24" width="260" height="44" rx="8"/>
+<text class="t-client" x="660" y="43" text-anchor="middle">CLIENT</text>
+<text class="t-sub" x="660" y="59" text-anchor="middle">prompt in · answer out</text>
+
+<rect class="coord" x="490" y="100" width="340" height="68" rx="9"/>
+<text class="t-coord" x="660" y="126" text-anchor="middle">COORDINATION</text>
+<text class="t-coordsub" x="660" y="145" text-anchor="middle">the Agent · Recall → Think → Act</text>
+<text class="t-coordsub" x="660" y="160" text-anchor="middle">loops until a terminal Status</text>
+
+<rect class="orch" x="210" y="232" width="200" height="60" rx="7"/>
+<text class="t-orch" x="310" y="258" text-anchor="middle">DATA</text>
+<text class="t-verb" x="310" y="278" text-anchor="middle">Recall — what it has</text>
+<rect class="orch" x="560" y="232" width="200" height="60" rx="7"/>
+<text class="t-orch" x="660" y="258" text-anchor="middle">DECISION</text>
+<text class="t-verb" x="660" y="278" text-anchor="middle">Think — what it decides</text>
+<rect class="orch" x="910" y="232" width="200" height="60" rx="7"/>
+<text class="t-orch" x="1010" y="258" text-anchor="middle">DIRECTION</text>
+<text class="t-verb" x="1010" y="278" text-anchor="middle">Act — what it does</text>
+
+<rect class="fnd" x="152" y="372" width="100" height="54" rx="6"/>
+<text class="t-fnd" x="202" y="403" text-anchor="middle">Skills</text>
+<rect class="fnd" x="260" y="372" width="100" height="54" rx="6"/>
+<text class="t-fnd" x="310" y="403" text-anchor="middle">Memory</text>
+<rect class="fnd" x="368" y="372" width="100" height="54" rx="6"/>
+<text class="t-fnd" x="418" y="403" text-anchor="middle">Knowledge</text>
+<rect class="fnd" x="502" y="372" width="100" height="54" rx="6"/>
+<text class="t-fnd" x="552" y="403" text-anchor="middle">Gate</text>
+<rect class="fnd" x="610" y="372" width="100" height="54" rx="6"/>
+<text class="t-fnd" x="660" y="403" text-anchor="middle">Brain</text>
+<rect class="fnd" x="718" y="372" width="100" height="54" rx="6"/>
+<text class="t-fnd" x="768" y="403" text-anchor="middle">Judge</text>
+<rect class="fnd" x="852" y="372" width="100" height="54" rx="6"/>
+<text class="t-fnd" x="902" y="403" text-anchor="middle">Internal</text>
+<rect class="fnd" x="960" y="372" width="100" height="54" rx="6"/>
+<text class="t-fnd" x="1010" y="403" text-anchor="middle">External</text>
+<rect class="fnd" x="1068" y="372" width="100" height="54" rx="6"/>
+<text class="t-fnd" x="1118" y="403" text-anchor="middle">Return</text>
+
+<rect class="broker" x="152" y="470" width="100" height="40" rx="5"/>
+<text class="t-brk" x="202" y="494" text-anchor="middle">files</text>
+<rect class="broker" x="260" y="470" width="100" height="40" rx="5"/>
+<text class="t-brk" x="310" y="494" text-anchor="middle">store</text>
+<rect class="broker" x="368" y="470" width="100" height="40" rx="5"/>
+<text class="t-brk" x="418" y="494" text-anchor="middle">index</text>
+<rect class="broker" x="502" y="470" width="100" height="40" rx="5"/>
+<text class="t-brk" x="552" y="494" text-anchor="middle">classifier</text>
+<rect class="broker" x="610" y="470" width="100" height="40" rx="5"/>
+<text class="t-brk" x="660" y="494" text-anchor="middle">LLM</text>
+<rect class="broker" x="718" y="470" width="100" height="40" rx="5"/>
+<text class="t-brk" x="768" y="494" text-anchor="middle">verifier</text>
+<rect class="broker" x="852" y="470" width="100" height="40" rx="5"/>
+<text class="t-brk" x="902" y="494" text-anchor="middle">tools</text>
+<rect class="broker" x="960" y="470" width="100" height="40" rx="5"/>
+<text class="t-brk" x="1010" y="494" text-anchor="middle">MCP</text>
+<rect class="dead" x="1068" y="470" width="100" height="40" rx="5"/>
+<text class="t-brk" x="1118" y="494" text-anchor="middle">dead end</text>
+</svg>


### PR DESCRIPTION
Introduces the initial framework — three complementary pillars.

## Theory
`THE-TRI-NATURE-OF-AGENT.md` — the model `Agent = Orchestration(Data, Decision, Direction)`, the fractal (agents nest as tools; each nature decomposes), lifecycle & memory (ephemeral agent, durable external memory), safety (the Decision→Direction privilege boundary, reversibility), and governance (an environment is a jurisdiction).

## Specification
`SPEC.md` — a normative, language-agnostic blueprint (RFC-2119, neutral pseudo-types) so a conformant framework can be built in JavaScript, Go, Rust, Python, etc. Defines all 21 contracts, the loop as a normative algorithm, the reply protocol, nine MUST/MUST-NOT invariants, and **Core** vs **Full** conformance profiles.

## Reference implementation
`Standard.Agents/` — a Standard-compliant C# library (.NET 10, zero external dependencies) implementing the full 1·3·9 tier: `Coordination → 3 Orchestrations → 9 Foundations → 8 Brokers`.
- **Real:** Skill, Brain (OpenAI-compatible generator), InternalTool, Return, plus the flow-log support broker.
- **Honest stubs** (wired into the flow, ready to fill): Memory, Knowledge, Gate, Judge, External.

`Standard.Agents.Demo/` — a console consumer that runs the agent end to end against an OpenAI-compatible endpoint; `Program.cs` is the composition root, reading top-down like the architecture diagram.

Also adds `architecture.svg`, an expanded `README.md`, and a `.gitignore`. The committed `appsettings.json` `ApiKey` is intentionally blank (set locally).

### Not included yet (follow-up phases)
- The Standard exception/validation TryCatch taxonomy per foundation
- Making the five stub brokers real (Memory store, Knowledge/RAG, Gate/Judge guardians, External/MCP)
- Unit tests, an `AddStandardAgent` DI extension, and a language-neutral conformance test suite