### PR TITLE
Rename AgentBuilder to StandardAgent; apply authoritative TSSL

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,102 @@
-The Standard Software License (TSSL)
+# The Standard Software License (TSSL)
+Version 1.1
+© [2025] [HASSAN HABIB]
 
-Copyright (c) Hassan Habib. All rights reserved.
+---
 
-This software is made available under The Standard Software License (TSSL).
-The full terms of the TSSL govern the use, reproduction, and distribution of this
-software. The authoritative text of the TSSL is maintained by the copyright holder;
-this notice should be replaced with that full text.
+## 0. Ethical Use Condition
+
+Software under this license may be used for **personal** or **commercial** purposes.
+We **encourage** its use for **humanitarian** efforts and projects that serve the survival, evolution, and fulfillment of mankind.
+
+**However, this software may not be used, directly or indirectly, in any project that contributes to or facilitates:**
+
+- The threatening of human survival,
+- The hindrance of human evolution,
+- The diminishment of human fulfillment.
+
+This ethical condition is **non-negotiable** and applies to all users, distributors, and modifiers.
+
+---
+
+## 1. Freedom and Sharing
+
+Software under this license is free as in **free tea** *and* **free speech**.
+
+It is encouraged to be:
+
+- **Used** freely, as long as the Ethical Use Condition is upheld.
+- **Modified** to improve and adapt it to new use cases.
+- **Distributed** in original or modified form.
+- **Studied and learned from** as a tool for innovation and education.
+
+---
+
+## 2. License and Attribution
+
+- This license **must remain attached** to all original and modified versions of the software.
+- If you modify this software, you must **clearly state your changes**.
+- You may not **misrepresent** the origin of the software or claim original authorship of unmodified parts.
+
+---
+
+## 3. AI and Automation
+
+If this software is used in **artificial intelligence systems**, **automated decision-making**, or **data-driven platforms**, the implementers must:
+
+- **Evaluate** the application’s compliance with the Ethical Use Condition (section 0),
+- **Mitigate** any foreseeable risks that may violate that condition,
+- **Document** how the use aligns with the license’s ethical principles.
+
+---
+
+## 4. Irrevocability and Permanence of Freedom
+
+- This license is **perpetual and irrevocable**.
+- Once software is released under this license, the author **cannot revoke**, **re-license**, or **retroactively restrict** its freedoms.
+- Future versions of *The Standard Software License* may be released to clarify or extend its terms, but **existing licensed software remains bound to its original version**.
+
+---
+
+## 5. Commercial Use and Non-Monetization of the Licensed Software
+
+- You may use this software in **commercial projects**, businesses, and for-profit environments.
+- You may **charge for services** (e.g. support, consulting, hosting, integrations) built **around** this software.
+- However, you **may not sell, license, or charge for** access, usage, distribution, or copies of the software itself.
+
+> You can profit **with it**, but not **from it directly**.
+
+This ensures that once made free, the software remains free forever—regardless of popularity or success.
+
+---
+
+## 5.1 Third Party License Compliance
+
+- Any use of this Software, including Commercial Use, that incorporates or depends on third-party software must fully comply with the license terms of those third-party components.
+- This license does not grant permission to use any third-party software in a way that violates its own license terms.
+- The inclusion of third-party software in any distribution of this Software does not constitute an authorization or waiver of those third-party license restrictions.
+
+---
+
+## 6. Derivative and Combined Works
+
+- If this software is combined with other software, the portions under this license must **continue to follow these terms**, including the Ethical Use Condition and Non-Monetization rule.
+- Derivative works must clearly separate code under this license if the resulting project uses different licensing for other components.
+
+---
+
+## 7. No Warranty
+
+This software is provided **"as-is"**, without warranty of any kind.
+The authors are **not liable** for any damages or misuse, except where such liability arises from **intentional violation** of the Ethical Use Condition.
+
+---
+
+## TL;DR
+
+✅ Use it personally or commercially
+✅ Learn, teach, modify, share
+✅ Use it to help humanity
+❌ Don’t charge for the software itself
+❌ Don’t use it for harm
+🚫 You can’t take the freedom back later

--- a/README.md
+++ b/README.md
@@ -34,18 +34,16 @@ The library wires every broker and service under the hood. A consumer provides o
 what is theirs:
 
 ```csharp
-IAgent agent = new AgentBuilder()
+var agent = new StandardAgent()
     .Skills("Skills")              // where the skill files live
     .Brain(apiUrl, apiKey, model)  // the LLM
-    .Tool(new CalculatorTool())    // the tools it offers
-    .LogTo("log.txt")
-    .Build();
+    .Tool(new CalculatorTool());   // the tools it offers
 
 string answer = await agent.ProcessPromptAsync("What is 89347 * 61293 + 4472?");
 ```
 
-`AgentBuilder` also exposes `UseMemory`, `UseKnowledge`, `UseGate`, `UseJudge`, `UseMcp`,
-`UseGenerator`, and `UseLog` to swap the default brokers for real implementations.
+`StandardAgent` also exposes `UseMemory`, `UseKnowledge`, `UseGate`, `UseJudge`, `UseMcp`,
+`UseGenerator`, `UseLog`, and `LogTo` to swap the default brokers for real implementations.
 
 ## Architecture — the 1·3·9 tiers
 

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -62,12 +62,11 @@ async Task<string> RunAsync(Vector vector)
     IEnumerable<ITool> tools =
         (vector.Tools ?? []).Select(pair => (ITool)new StubTool(pair.Key, pair.Value));
 
-    IAgent agent = new AgentBuilder()
+    IAgent agent = new StandardAgent()
         .UseSkills(new StubSkillBroker())
         .UseGenerator(new ScriptedGeneratorBroker(vector.GeneratorReplies))
         .Tools(tools)
-        .UseLog(new NullLogBroker())
-        .Build();
+        .UseLog(new NullLogBroker());
 
     return await agent.ProcessPromptAsync(vector.Prompt);
 }

--- a/Standard.Agents.Demo/Program.cs
+++ b/Standard.Agents.Demo/Program.cs
@@ -18,7 +18,7 @@ IConfigurationSection peer = configuration.GetSection("PeerLLMConfigurations");
 // The library wires every broker and service under the hood. The consumer supplies
 // only what is theirs: where the skills live, the brain (LLM) config, the tools it
 // offers, and where to write the flow log.
-IAgent agent = new AgentBuilder()
+var agent = new StandardAgent()
     .Skills("Skills")
     .Brain(
         apiUrl: peer.GetValue<string>("ApiUrl")!,
@@ -27,8 +27,7 @@ IAgent agent = new AgentBuilder()
         temperature: peer.GetValue<double>("Temperature"),
         maxTokens: peer.GetValue<int>("MaxTokens"))
     .Tool(new CalculatorTool())
-    .LogTo("log.txt")
-    .Build();
+    .LogTo("log.txt");
 
 string apiUrl = peer.GetValue<string>("ApiUrl") ?? "(unset)";
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -18,7 +18,7 @@ using Standard.Agents.Tools;
 
 namespace Standard.Agents;
 
-public sealed class AgentBuilder
+public sealed class StandardAgent : IAgent
 {
     private readonly List<ITool> tools = [];
 
@@ -39,13 +39,16 @@ public sealed class AgentBuilder
     private IMcpBroker? mcpBroker;
     private ILogBroker? logBroker;
 
-    public AgentBuilder Skills(string path)
+    private IAgent? agent;
+
+    public StandardAgent Skills(string path)
     {
         this.skillsPath = path;
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder Brain(
+    public StandardAgent Brain(
         string apiUrl,
         string apiKey,
         string model,
@@ -57,76 +60,94 @@ public sealed class AgentBuilder
         this.model = model;
         this.temperature = temperature;
         this.maxTokens = maxTokens;
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder Tool(ITool tool)
+    public StandardAgent Tool(ITool tool)
     {
         this.tools.Add(tool);
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder Tools(IEnumerable<ITool> tools)
+    public StandardAgent Tools(IEnumerable<ITool> tools)
     {
         this.tools.AddRange(tools);
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder LogTo(string path)
+    public StandardAgent LogTo(string path)
     {
         this.logPath = path;
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder UseSkills(ISkillBroker broker)
+    public StandardAgent UseSkills(ISkillBroker broker)
     {
         this.skillBroker = broker;
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder UseGenerator(IGeneratorBroker broker)
+    public StandardAgent UseGenerator(IGeneratorBroker broker)
     {
         this.generatorBroker = broker;
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder UseMemory(IMemoryBroker broker)
+    public StandardAgent UseMemory(IMemoryBroker broker)
     {
         this.memoryBroker = broker;
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder UseKnowledge(IKnowledgeBroker broker)
+    public StandardAgent UseKnowledge(IKnowledgeBroker broker)
     {
         this.knowledgeBroker = broker;
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder UseGate(IClassifierBroker broker)
+    public StandardAgent UseGate(IClassifierBroker broker)
     {
         this.classifierBroker = broker;
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder UseJudge(IVerifierBroker broker)
+    public StandardAgent UseJudge(IVerifierBroker broker)
     {
         this.verifierBroker = broker;
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder UseMcp(IMcpBroker broker)
+    public StandardAgent UseMcp(IMcpBroker broker)
     {
         this.mcpBroker = broker;
+        this.agent = null;
         return this;
     }
 
-    public AgentBuilder UseLog(ILogBroker broker)
+    public StandardAgent UseLog(ILogBroker broker)
     {
         this.logBroker = broker;
+        this.agent = null;
         return this;
     }
 
-    public IAgent Build()
+    public ValueTask<string> ProcessPromptAsync(string prompt)
+    {
+        this.agent ??= Compose();
+        return this.agent.ProcessPromptAsync(prompt);
+    }
+
+    private IAgent Compose()
     {
         ISkillBroker skill = this.skillBroker ?? new SkillBroker(this.skillsPath);
         IGeneratorBroker generator = this.generatorBroker


### PR DESCRIPTION
## StandardAgent — the client entry point

The consumer now writes:

```csharp
var agent = new StandardAgent()
    .Skills("Skills")
    .Brain(apiUrl, apiKey, model)
    .Tool(new CalculatorTool());

string answer = await agent.ProcessPromptAsync("...");
```

`StandardAgent` **implements `IAgent`** and composes the tri-nature stack lazily, so there is no `.Build()` step — `new StandardAgent()` *is* the agent. Fluent `Skills / Brain / Tool / Tools / LogTo` plus the `UseX` broker overrides are unchanged. The demo and the conformance runner both use it (6/6 vectors pass).

## License fix

Replaces the placeholder `LICENSE` with the **authoritative TSSL v1.1** text. The license commit from the previous round did not reach `main` (the PR merged at an earlier commit), so `main` still had the placeholder — this corrects it.