### PR TITLE
INFRA: Setup Solution And Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,87 @@
+# The Standard for Agents
+
+The C# reference implementation of **[The Standard for Agents](https://github.com/hassanhabib/The-Standard-Agent-Specs)**.
+
+```
+Agent = Orchestration(Data, Decision, Direction)
+```
+
+- **Data** — what the agent *has* (skills, memory, knowledge) · verb: **Recall**
+- **Decision** — what the agent *thinks* (one brain, wrapped in a Gate and a Judge) · verb: **Think**
+- **Direction** — what the agent *does* (act internally, act externally, or return) · verb: **Act**
+
+Orchestration is not a fourth nature. It is the composition operator — the loop.
+
+## The 1·3·9
+
+| Tier | Count | Members |
+|---|---|---|
+| **Coordination** | 1 | `AgentCoordinationService` — the only loop: Recall → Think → Act |
+| **Orchestration** | 3 | Data · Decision · Direction |
+| **Foundation** | 9 | Skills, Memory, Knowledge / Gate, Brain, Judge / Internal, External, Return |
+| **Broker** | 8+1 | one liaison per resource, plus the logging support broker |
+
+Nine foundations, eight brokers: `ReturnService` has no broker. It is the dead end — the terminal
+Direction hands the result back and touches nothing.
+
+Flow is forward only. A tier never calls the tier above it.
+
+## Governance
+
+Two rulebooks, and they compose:
+
+- **[SPEC.md](https://github.com/hassanhabib/The-Standard-Agent-Specs/blob/main/SPEC.md)** owns
+  **contracts and behavior**. It is normative and language-neutral.
+- **[The Standard](https://github.com/hassanhabib/The-Standard)** owns **structure, exceptions,
+  and process** — brokers, foundations, orchestrations, the `Xeption` model, and FAIL/PASS TDD.
+
+They do not collide: SPEC.md §1 states that *"conformance is about contracts and behavior, not file
+layout or language idiom."*
+
+The theory is settled in
+**[THE-TRI-NATURE-OF-AGENT.md](https://github.com/hassanhabib/The-Standard-Agent-Specs/blob/main/THE-TRI-NATURE-OF-AGENT.md)**
+before any code is written. Build to it.
+
+## Structure
+
+```
+Standard.Agents/                  the library
+  |-- Brokers/{Data,Decision,Direction,Loggings}
+  |-- Models/Foundations/{Entity}/Exceptions
+  |-- Models/Orchestrations/Agents          AgentContext, AgentStatus
+  |-- Services/{Foundations,Orchestrations,Coordinations}
+  |-- Tools/                                ITool, AgentTool — the fractal bridge
+Standard.Agents.Tests.Unit/       unit tests, mirroring the service tree
+conformance/                      language-neutral behavioral vectors
+```
+
+## Conformance
+
+Agent behavior involves an LLM and is non-deterministic, so it cannot be asserted directly.
+[`conformance/`](conformance/CONFORMANCE.md) instead pins the **deterministic** contracts — the loop,
+reply interpretation, tool routing, and the feed-back of results into Data — by scripting the Brain.
+
+```bash
+dotnet test                                        # unit tests
+dotnet run --project Standard.Agents.Conformance   # spec certification; exit 0 = conformant
+```
+
+A **Core** implementation is a minimal viable agent. A **Full** implementation adds real memory,
+knowledge, guardian gate/judge, and external tools.
+
+## Contributing
+
+This repo follows [The Standard's practices](https://github.com/hassanhabib/The-Standard):
+
+- One issue per method. One branch per issue.
+- Branch: `users/[username]/[CATEGORY]-[entity]-[action]`, where the action speaks the language of
+  its layer — brokers `insert`/`select`, foundations `add`/`retrieve`.
+- Foundations and up are test-driven, two commits per test:
+  `[TestName] -> FAIL`, then `[TestName] -> PASS`. A FAIL commit must have been *run and observed
+  failing*.
+- Brokers carry no unit tests — they are thin and hold no logic. Commit as `BROKERS: [Description]`.
+- PR title: `[CATEGORY]: [Description Of Work Completed]`.
+
+## License
+
+[The Standard Software License (TSSL) v1.1](LICENSE).

--- a/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
+++ b/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DeepCloner" Version="0.10.4" />
+    <!-- Pinned to 7.x: the last Apache-2.0 line. FluentAssertions 8+ ships under a
+         commercial Xceed license. -->
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
+    <PackageReference Include="Xeption" Version="2.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Standard.Agents\Standard.Agents.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Standard.Agents.slnx
+++ b/Standard.Agents.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="Standard.Agents/Standard.Agents.csproj" />
+  <Project Path="Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj" />
+</Solution>

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RESTFulSense" Version="3.2.0" />
+    <PackageReference Include="Xeption" Version="2.9.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Scaffolds the solution so every later issue has a home.

## Projects

| Project | Purpose |
|---|---|
| `Standard.Agents` | the library (net10.0) |
| `Standard.Agents.Tests.Unit` | xUnit, mirroring the service tree |

`Standard.Agents.Demo` and `Standard.Agents.Conformance` are created by their own issues (#38, #39) rather than scaffolded here as empty placeholders — a console project needs a `Program.cs`, and that code belongs to the issue that owns it.

## Packages

The library previously carried **zero package references**. Two enter, deliberately:

- **`Xeption`** — required by The Standard's exception model (`UpsertDataList`, `ThrowIfContainsErrors`)
- **`RESTFulSense`** — gives `GeneratorBroker` the typed HTTP exception ladder that `BrainService` maps against, replacing `EnsureSuccessStatusCode()` + null-forgiving `response!`

All-In/All-Out: partial adoption is not standardization.

**`FluentAssertions` is pinned to 7.2.2**, the last Apache-2.0 release. Version 8+ ships under a commercial Xceed license — pinning keeps the repo free of any paid-license obligation.

## Layout

```
Standard.Agents
  |-- Brokers/{Data,Decision,Direction,Loggings}
  |-- Models/Foundations/{Skills,Memories,Knowledges,Gates,Brains,Judges,
  |                       InternalTools,ExternalTools,Returns}/Exceptions
  |-- Models/Orchestrations/Agents      AgentContext, AgentStatus
  |-- Services/{Foundations,Orchestrations,Coordinations}/{Data,Decision,Direction}
  |-- Tools
```

`AgentContext` lives under `Models/Orchestrations/Agents` — a **deliberate shared model**. The Standard forbids models shared across independent flows (horizontal entanglement), but the three natures are one loop, not independent flows, and SPEC.md §3 mandates a single context record.

## Verification

```
dotnet build   → Build succeeded. 0 Error(s)
dotnet test    → runner wired; no tests yet (first lands with #7)
```

Closes #6
