### PR TITLE
DATA: Add AgentContext And AgentStatus

### DIFF
--- a/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Orchestrations.Agents;
+
+// A record with init-only properties: a nature returns an updated copy via a `with`
+// expression and never mutates a shared instance. SPEC.md 3 requires copy-on-write.
+public sealed record AgentContext
+{
+    public string Prompt { get; init; } = "";
+
+    // DATA — what it HAS. Written by Recall.
+    public string SystemPrompt { get; init; } = "";
+    public IReadOnlyList<string> Observations { get; init; } = [];
+
+    // DECISION — what it THINKS. Written by Think.
+    public string Intent { get; init; } = "";
+    public string DirectionType { get; init; } = "";
+    public string Payload { get; init; } = "";
+    public string RawReply { get; init; } = "";
+
+    // DIRECTION — what it DID. Written by Act.
+    public string Result { get; init; } = "";
+    public AgentStatus Status { get; init; }
+}

--- a/Standard.Agents/Models/Orchestrations/Agents/AgentStatus.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentStatus.cs
@@ -1,0 +1,16 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Orchestrations.Agents;
+
+public enum AgentStatus
+{
+    // Working is first so it is the default — the loop runs while a context is Working.
+    Working = 0,
+    Responded = 1,
+    AwaitingInput = 2,
+    Refused = 3,
+    Failed = 4
+}


### PR DESCRIPTION
The two data-carrier models the whole loop is built on. SPEC.md §3.

## `AgentStatus`

```csharp
public enum AgentStatus { Working = 0, Responded, AwaitingInput, Refused, Failed }
```

- `Working` is declared **first** so it is `default(AgentStatus)` — §3 requires it to be the initial value, and the loop continues while `status == Working`.
- Explicit ordinals so a later mid-list insert cannot shift the meaning of an existing value.
- §3 forbids replacing this with a boolean. Theory Ch.3 gives the reason: *"the terminal states are the terminal Directions, and new behaviors slot in without touching the loop."*

## `AgentContext`

A `sealed record` with `init`-only properties — copy-on-write for free, which §3 makes a **MUST**: a nature returns an updated copy via `with` and never mutates a shared instance.

Properties are grouped by **the nature that writes them**. That grouping is the contract, not decoration:

| Nature | Writes |
|---|---|
| Recall (Data) | `SystemPrompt`, `Observations` |
| Think (Decision) | `Intent`, `DirectionType`, `Payload`, `RawReply` |
| Act (Direction) | `Result`, `Status` |

`Status` needs no initializer — `Working` is `0`, so a fresh context is Working and the loop runs.

## Note — a deliberate shared model

The Standard forbids models shared across independent flows (horizontal entanglement). The three natures are **one loop, not independent flows**, and §3 mandates a single context record. Placed under `Models/Orchestrations/Agents` because the orchestrations produce and consume it; Coordination only sequences.

## Deferred by the spec, not by us

- `Intent` is listed as written by Think, but §6's parsing rules define **no producer** for it → settled in #33.
- `Failed` / `AwaitingInput` are in the enum with **no defined trigger** → settled in #34.

## Verification

`dotnet build` → Build succeeded, 0 Error(s).

No unit tests: these are anemic data-carrier models with no behavior to assert.

Closes #7, closes #8
