### PR TITLE
BROKERS: Select Skills

### DIFF
--- a/Standard.Agents/Brokers/Data/ISkillBroker.cs
+++ b/Standard.Agents/Brokers/Data/ISkillBroker.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Data;
+
+public interface ISkillBroker
+{
+    ValueTask<string> SelectSkillsAsync();
+}

--- a/Standard.Agents/Brokers/Data/SkillBroker.cs
+++ b/Standard.Agents/Brokers/Data/SkillBroker.cs
@@ -1,0 +1,34 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Data;
+
+public sealed class SkillBroker : ISkillBroker
+{
+    private const string SkillFilePattern = "*.md";
+    private const string SkillSeparator = "\n\n";
+
+    private readonly string skillsPath;
+
+    public SkillBroker(string skillsPath) =>
+        this.skillsPath = Path.Combine(AppContext.BaseDirectory, skillsPath);
+
+    public async ValueTask<string> SelectSkillsAsync()
+    {
+        List<string> skills = [];
+
+        // Ordinal filename order — the "00-", "10-" prefixes are how authors sequence skills.
+        IOrderedEnumerable<string> skillFilePaths =
+            Directory.EnumerateFiles(this.skillsPath, SkillFilePattern)
+                .OrderBy(skillFilePath => skillFilePath, StringComparer.Ordinal);
+
+        foreach (string skillFilePath in skillFilePaths)
+        {
+            skills.Add(await File.ReadAllTextAsync(skillFilePath));
+        }
+
+        return string.Join(SkillSeparator, skills);
+    }
+}


### PR DESCRIPTION
The liaison to the skills files — *what the agent was taught*. SPEC.md §4.1.

```csharp
ValueTask<string> SelectSkillsAsync();
```

Reads every `*.md` under the configured skills path and concatenates them in **ordinal filename order**. The `00-`, `10-` prefixes are how authors sequence skills, so ordering is part of reading the resource, not a business decision. `StringComparer.Ordinal` is explicit rather than inherited from the current culture, so the order cannot drift by locale.

## Broker rules honored (§4.1, The Standard §1)

| Rule | How |
|---|---|
| One resource | the filesystem, nothing else |
| No business flow control | the loop reads files; it decides nothing |
| No exception handling | IO exceptions propagate untouched to `SkillService` (#21), which localizes them |
| No authored prompts | it *reads* prompts; it never writes them (invariant §7.2) |
| Owns its config | `skillsPath` |
| `ValueTask` | The Standard §1.5.1 |

## Changed from the prior implementation

The old broker wrapped synchronous `File.ReadAllText` inside `ValueTask.FromResult` — sync-over-async. This uses `File.ReadAllTextAsync` for a genuinely async path, per The Standard §1.5.1.

## No unit tests

Brokers are thin and carry no logic.

## Note — the spec is silent on skill format

SPEC.md types this as `selectSkills() -> Async<Text>` and says nothing more; the return is opaque Text. The `*.md` convention is **inherited from the prior implementation, not specified**. Since invariant §7.2 makes prompts-as-Data normative, the format deserves to be written down rather than left implicit.

## Verification

`dotnet build` → Build succeeded, 0 Error(s).

Closes #9
