### PR TITLE
BROKERS: Reset Log

### DIFF
--- a/Standard.Agents/Brokers/Loggings/ILogBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/ILogBroker.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Loggings;
+
+public interface ILogBroker
+{
+    string LogPath { get; }
+
+    ValueTask ResetAsync();
+}

--- a/Standard.Agents/Brokers/Loggings/LogBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LogBroker.cs
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Loggings;
+
+public sealed class LogBroker : ILogBroker
+{
+    private readonly string logPath;
+
+    public string LogPath => this.logPath;
+
+    public LogBroker(string logPath) =>
+        this.logPath = Path.GetFullPath(logPath);
+
+    public async ValueTask ResetAsync() =>
+        await File.WriteAllTextAsync(this.logPath, string.Empty);
+}


### PR DESCRIPTION
The support broker that clears the agent's trace for a fresh prompt. SPEC.md §4.1.

```csharp
string LogPath { get; }
ValueTask ResetAsync();
```

Coordination calls this once at the top of `ProcessPromptAsync` (SPEC.md §5), so each prompt's narrative starts clean. This is the **+1** in `BROKER · 8+1` — a support broker, not one of the eight nature brokers.

## Decisions

- **`LogPath` is exposed** so the Demo exposer can tell the user where the trace landed, without the broker printing anything itself (that would be flow control it has no business having).
- **`Path.GetFullPath` at construction** — the path resolves once against the working directory at startup, so a later `cd` cannot silently move the log.

## Broker rules honored

One resource · no flow control · no exception handling (IO failures propagate untouched) · owns its config · `ValueTask`.

## No unit tests

Thin broker, no logic.

## This is not the diagnostic logger

This is the **agent's turn trace**. The Standard's exception model needs `LogErrorAsync(Exception)` / `LogCriticalAsync(Exception)`, which do not exist on this contract and have no spec basis here. Those live on a separate `ILoggingBroker` over `ILogger<T>` — different resource, different broker, making the real count **8+2**.

Full reasoning and the upstream question in #44. That issue blocks every FOUNDATIONS issue.

## Verification

`dotnet build` → Build succeeded, 0 Error(s).

Closes #19
