### PR TITLE
BROKERS: Write Log

### DIFF
--- a/Standard.Agents/Brokers/Loggings/ILogBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/ILogBroker.cs
@@ -10,4 +10,6 @@ public interface ILogBroker
     string LogPath { get; }
 
     ValueTask ResetAsync();
+
+    ValueTask WriteAsync(string content);
 }

--- a/Standard.Agents/Brokers/Loggings/LogBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LogBroker.cs
@@ -16,4 +16,7 @@ public sealed class LogBroker : ILogBroker
 
     public async ValueTask ResetAsync() =>
         await File.WriteAllTextAsync(this.logPath, string.Empty);
+
+    public async ValueTask WriteAsync(string content) =>
+        await File.AppendAllTextAsync(this.logPath, content + Environment.NewLine);
 }


### PR DESCRIPTION
Appends a line to the agent's trace. SPEC.md §4.1.

```csharp
ValueTask WriteAsync(string content);
```

This is the **observing** half of SPEC.md §4.4, which allows Coordination exactly two jobs: *"sequencing and observing (logging)."* Coordination writes one line per turn, so the trace reads as the agent's narrative — recall, think, act, repeat.

## Decisions

- **Appends rather than rewrites** — the turn history is the point. `ResetAsync` (#19) is the only thing that clears it, once per prompt.
- **`Environment.NewLine`**, not a hardcoded `\n` — the trace is read by a human on whatever platform wrote it.
- **`async ValueTask` with a direct call**, never `Task.Run` wrapping a synchronous call. The Standard §1.5.1: wrapping costs a thread-pool hop and a heap-allocated `ValueTask` for nothing.

## Broker rules honored

One resource · no flow control (the broker decides nothing about *what* is worth logging — that is Coordination's call) · no exception handling · owns its config.

## No unit tests

Thin broker, no logic.

## Verification

`dotnet build` → Build succeeded, 0 Error(s).

Closes #20
