### PR TITLE
BROKERS: Log Error And Log Critical

### DIFF
--- a/Standard.Agents/Brokers/Loggings/ILoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/ILoggingBroker.cs
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Loggings;
+
+public interface ILoggingBroker
+{
+    ValueTask LogInformationAsync(string message);
+
+    ValueTask LogTraceAsync(string message);
+
+    ValueTask LogDebugAsync(string message);
+
+    ValueTask LogWarningAsync(string message);
+
+    ValueTask LogErrorAsync(Exception exception);
+
+    ValueTask LogCriticalAsync(Exception exception);
+}

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Standard.Agents.Brokers.Loggings;
+
+public sealed class LoggingBroker : ILoggingBroker
+{
+    private readonly ILogger<LoggingBroker> logger;
+
+    public LoggingBroker(ILogger<LoggingBroker> logger) =>
+        this.logger = logger;
+
+    // ILogger<T> is synchronous. These are async ValueTask for the uniform contract
+    // (The Standard 1.5.1) and call straight through — never Task.Run.
+    public async ValueTask LogInformationAsync(string message) =>
+        this.logger.LogInformation(message);
+
+    public async ValueTask LogTraceAsync(string message) =>
+        this.logger.LogTrace(message);
+
+    public async ValueTask LogDebugAsync(string message) =>
+        this.logger.LogDebug(message);
+
+    public async ValueTask LogWarningAsync(string message) =>
+        this.logger.LogWarning(message);
+
+    public async ValueTask LogErrorAsync(Exception exception) =>
+        this.logger.LogError(exception, exception.Message);
+
+    public async ValueTask LogCriticalAsync(Exception exception) =>
+        this.logger.LogCritical(exception, exception.Message);
+}

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="RESTFulSense" Version="3.2.0" />
     <PackageReference Include="Xeption" Version="2.9.0" />
   </ItemGroup>


### PR DESCRIPTION
The diagnostic logging broker The Standard's exception model depends on. Unblocks every FOUNDATIONS issue (#21–#31).

## Why a second log broker

The spec's `LogBroker` (#19, #20) **cannot serve this**. It is the agent's turn trace — `reset` and `write`, nothing else. Foundations need:

```csharp
await this.loggingBroker.LogErrorAsync(skillValidationException);
```

...and the critical-vs-non-critical split is load-bearing — it separates *"the endpoint is misconfigured"* (`LogCriticalAsync`) from *"the server hiccuped"* (`LogErrorAsync`).

Two different resources — a trace file and `ILogger<T>` — so under **one resource, one broker**, they are two brokers:

| Broker | Resource | Purpose |
|---|---|---|
| `ILogBroker` | the trace file | the agent's turn narrative (SPEC.md §4.1) |
| `ILoggingBroker` | `ILogger<T>` | diagnostics + exception logging (The Standard) |

**The count is 8+2, not the 8+1 in `architecture.svg`.** Conformance is unaffected: SPEC.md §1 scopes conformance to contracts and behavior, not layout; `LogBroker` keeps its exact contract, and no MUST is broken by an added support broker. Invariant §7.3 still holds — this broker is thin.

Collapsing them would either force `LogBroker` to grow six severity methods with no spec basis, or force foundations to serialize exceptions into `WriteAsync(string)` and lose severity. Both are worse.

## Implementation

Every method is `async ValueTask` calling **straight through** to `ILogger<T>`, which is synchronous. Never `Task.Run` — that buys a thread-pool hop and a heap-allocated `ValueTask` for nothing (The Standard §1.5.1).

Adds `Microsoft.Extensions.Logging.Abstractions` — *abstractions only*, so the library still picks no logging implementation on its consumers' behalf.

## No unit tests

Thin broker, no logic.

## Worth raising upstream against the spec repo

`8+1` assumes an agent needs one log. An implementation that takes The Standard's exception model seriously needs two. Either the spec acknowledges the diagnostic logger, or it states that support brokers are unbounded and `+1` is illustrative.

## Verification

`dotnet build` → Build succeeded, 0 Error(s).

Closes #44
