### PR TITLE
CONFIG: Add NuGet.config Pinning nuget.org

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!-- clear drops feeds inherited from the machine's global config, so a restore
+         depends on this repo rather than on who cloned it. -->
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Restores inherited whatever feeds sat in the machine's global NuGet config.

## Symptom

Every build emitted four of these, and restores intermittently **failed outright** — one spurious build failure already hit mid-PR:

```
warning NU1900: Unable to load the service index for source
https://pkgs.dev.azure.com/redrhinoleak/_packaging/REDRHINO/nuget/v3/index.json
```

An unreachable private Azure DevOps feed, from the machine's global config, with nothing to do with this repo.

## Why it matters beyond noise

This is a **public OSS repo**. A contributor cloning it inherits *their* global feeds — private corporate ones, stale mirrors, whatever is on their box. Restore should depend on the repo, not on who cloned it.

Rewritability: *"forkable, clonable, buildable, and testable with minimal surprise"* · *"no hidden prerequisites."*

## The fix

`<clear />` is the load-bearing line — it **drops** inherited sources rather than appending to them.

## Verification

| | Before | After |
|---|---|---|
| NU1900 warnings | 4 | **0** |
| `dotnet build` | succeeded, 4 warnings | **succeeded, 0 Warning(s), 0 Error(s)** |

Confirmed against a `dotnet restore --force`.

Closes #48
