### PR TITLE
BROKERS: Generate

### DIFF
--- a/Standard.Agents/Brokers/Decision/GeneratorBroker.cs
+++ b/Standard.Agents/Brokers/Decision/GeneratorBroker.cs
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net.Http.Headers;
+using System.Text.Json;
+using RESTFulSense.Clients;
+
+namespace Standard.Agents.Brokers.Decision;
+
+public sealed class GeneratorBroker : IGeneratorBroker
+{
+    private const string ChatCompletionsRelativeUrl = "chat/completions";
+
+    // RESTFulSense defaults mediaType to "text/json"; OpenAI-compatible endpoints reject it.
+    private const string JsonMediaType = "application/json";
+
+    private static readonly JsonSerializerOptions jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly IRESTFulApiFactoryClient apiClient;
+    private readonly string model;
+    private readonly double temperature;
+    private readonly int maxTokens;
+
+    public GeneratorBroker(
+        string apiUrl,
+        string apiKey,
+        string model,
+        double temperature,
+        int maxTokens,
+        int timeoutSeconds)
+    {
+        var httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(apiUrl),
+            Timeout = TimeSpan.FromSeconds(timeoutSeconds)
+        };
+
+        httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", apiKey);
+
+        this.apiClient = new RESTFulApiFactoryClient(httpClient);
+        this.model = model;
+        this.temperature = temperature;
+        this.maxTokens = maxTokens;
+    }
+
+    public async ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt)
+    {
+        ChatCompletionRequest chatCompletionRequest = new(
+            Model: this.model,
+            Messages:
+            [
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", userPrompt)
+            ],
+            Stream: false,
+            Temperature: this.temperature,
+            MaxTokens: this.maxTokens);
+
+        ChatCompletionResponse chatCompletionResponse =
+            await PostAsync<ChatCompletionRequest, ChatCompletionResponse>(
+                ChatCompletionsRelativeUrl,
+                chatCompletionRequest);
+
+        return chatCompletionResponse.Choices[0].Message.Content;
+    }
+
+    private async ValueTask<TResult> PostAsync<TContent, TResult>(
+        string relativeUrl,
+        TContent content) =>
+        await this.apiClient.PostContentAsync<TContent, TResult>(
+            relativeUrl,
+            content,
+            mediaType: JsonMediaType,
+            serializationFunction: value =>
+                ValueTask.FromResult(JsonSerializer.Serialize(value, jsonOptions)),
+            deserializationFunction: json =>
+                ValueTask.FromResult(JsonSerializer.Deserialize<TResult>(json, jsonOptions)!));
+
+    // The wire protocol stays private so it cannot leak into the layers above.
+    private sealed record ChatCompletionRequest(
+        string Model,
+        IReadOnlyList<ChatMessage> Messages,
+        bool Stream,
+        double Temperature,
+        int MaxTokens);
+
+    private sealed record ChatMessage(
+        string Role,
+        string Content);
+
+    private sealed record ChatCompletionResponse(
+        IReadOnlyList<ChatChoice> Choices);
+
+    private sealed record ChatChoice(
+        ChatMessage Message);
+}

--- a/Standard.Agents/Brokers/Decision/IGeneratorBroker.cs
+++ b/Standard.Agents/Brokers/Decision/IGeneratorBroker.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Decision;
+
+public interface IGeneratorBroker
+{
+    ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt);
+}


### PR DESCRIPTION
The liaison to the LLM — the Brain's substrate, and the waist of the hourglass. SPEC.md §4.1.

```csharp
ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt);
```

Targets an OpenAI-compatible `POST /v1/chat/completions`, which SPEC.md §9 marks **SHOULD** for interoperability.

## Why RESTFulSense instead of raw HttpClient

The prior implementation did:

```csharp
httpResponse.EnsureSuccessStatusCode();
return response!.Choices[0].Message.Content;   // null-forgiving
```

That collapses every failure into one untyped `HttpRequestException`, and NREs on an empty body. RESTFulSense surfaces the **typed ladder** — `HttpResponseBadRequestException`, `Unauthorized`, `Forbidden`, `NotFound`, `InternalServerError`, `ServiceUnavailable` — which is exactly what `BrainService` maps in #26 to distinguish *"the endpoint is misconfigured"* (critical) from *"the server hiccuped"* (transient).

The broker still handles **nothing** (§4.1, invariant §7.3). The types just arrive intact for the foundation to localize.

## Two details worth knowing

- **`mediaType` is passed explicitly.** RESTFulSense defaults it to `text/json`; OpenAI-compatible endpoints reject that.
- **The serialization hooks are async delegates** — `Func<T, ValueTask<string>>`, not plain `Func<T, string>`. They're threaded through so snake_case (`max_tokens`) applies in both directions.

## Other decisions

- **Timeout is a constructor parameter**, not a hardcoded 120s. A broker owns its configuration, and the right value depends on the model behind the endpoint.
- **Wire DTOs are `private sealed record`s nested in the broker**, so the protocol cannot leak upward.
- **`PostAsync<TContent,TResult>`** is the private generic helper The Standard asks for.

## No unit tests

Thin broker, no logic.

## Verification

`dotnet build` → Build succeeded, 0 Error(s). Live-endpoint verification lands with the Demo exposer (#38).

Closes #14
