### PR TITLE
BROKERS: Has Tool

### DIFF
--- a/Standard.Agents/Brokers/Direction/IToolBroker.cs
+++ b/Standard.Agents/Brokers/Direction/IToolBroker.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Direction;
+
+public interface IToolBroker
+{
+    ValueTask<bool> HasAsync(string name);
+}

--- a/Standard.Agents/Brokers/Direction/ToolBroker.cs
+++ b/Standard.Agents/Brokers/Direction/ToolBroker.cs
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Tools;
+
+namespace Standard.Agents.Brokers.Direction;
+
+public sealed class ToolBroker : IToolBroker
+{
+    private readonly IReadOnlyDictionary<string, ITool> tools;
+
+    // Tool names come from a model's text output, so matching is case-insensitive.
+    public ToolBroker(IEnumerable<ITool> tools) =>
+        this.tools = tools.ToDictionary(
+            tool => tool.Name,
+            StringComparer.OrdinalIgnoreCase);
+
+    public ValueTask<bool> HasAsync(string name) =>
+        ValueTask.FromResult(this.tools.ContainsKey(name));
+}

--- a/Standard.Agents/Tools/ITool.cs
+++ b/Standard.Agents/Tools/ITool.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Tools;
+
+public interface ITool
+{
+    string Name { get; }
+
+    ValueTask<string> ExecuteAsync(string input);
+}


### PR DESCRIPTION
Local tool registry lookup. SPEC.md §4.1.

```csharp
ValueTask<bool> HasAsync(string name);
```

## Also lands `Tools/ITool.cs`

```csharp
public interface ITool
{
    string Name { get; }
    ValueTask<string> ExecuteAsync(string input);
}
```

The broker's **resource is the registry of `ITool` instances**, so the contract has to exist for the broker to liaise with anything. `AgentTool` — the fractal bridge that wraps a whole agent as a tool — stays in #37 where it belongs.

## Case-insensitive matching

A tool name arrives from a model's *text output* via the `ACTION:` line. A model will not reliably match the casing an author registered, so `StringComparer.OrdinalIgnoreCase` is the honest choice.

## Spec discrepancy — resolved to async

SPEC.md **contradicts itself**:

| Where | Says |
|---|---|
| §4.1 | `has(name: Text) -> Bool` — **not** wrapped in `Async<>` |
| §9 | *"every contract method is asynchronous"* |

Resolved in favour of **§9 + The Standard §1.5.1**: every public interface method returns `ValueTask` even when nothing is awaited, so callers never change if the registry later moves off-process. §1 permits this — *"conformance is about contracts and behavior"* and *"the names are canonical roles, not literal names."*

The same contradiction hits `handles` in §4.2 → #28. **Worth raising upstream against the spec repo.**

## An unknown name is a `false`, not an exception

Conformance vector `05-unknown-tool-recovers` depends on `false` routing the call to External rather than failing.

## Verification

`dotnet build` → Build succeeded, 0 Error(s).

No unit tests: thin broker, no logic.

Closes #16
