### PR TITLE
BROKERS: Run Tool

### DIFF
--- a/Standard.Agents/Brokers/Direction/IToolBroker.cs
+++ b/Standard.Agents/Brokers/Direction/IToolBroker.cs
@@ -8,4 +8,6 @@ namespace Standard.Agents.Brokers.Direction;
 public interface IToolBroker
 {
     ValueTask<bool> HasAsync(string name);
+
+    ValueTask<string> RunAsync(string name, string input);
 }

--- a/Standard.Agents/Brokers/Direction/ToolBroker.cs
+++ b/Standard.Agents/Brokers/Direction/ToolBroker.cs
@@ -19,4 +19,7 @@ public sealed class ToolBroker : IToolBroker
 
     public ValueTask<bool> HasAsync(string name) =>
         ValueTask.FromResult(this.tools.ContainsKey(name));
+
+    public async ValueTask<string> RunAsync(string name, string input) =>
+        await this.tools[name].ExecuteAsync(input);
 }


### PR DESCRIPTION
Execute a registered local tool — Direction's **Internal** locus. SPEC.md §4.1.

```csharp
ValueTask<string> RunAsync(string name, string input);
```

Theory Ch.5: Internal means *"act within the agent's own environment."*

## Why it indexes directly instead of `TryGetValue`

A missing key throwing `KeyNotFoundException` is **correct here**. The broker handles no exceptions and makes no decisions, and callers are expected to have asked `HasAsync` first (#16).

Swallowing the miss into a `null` or an error string would be the broker deciding *what an unknown tool means* — and that judgement belongs to `DirectionOrchestrationService`, which routes unknowns to External per vector `05-unknown-tool-recovers` (#34).

## Routing is deliberately absent

Choosing Internal vs External is a **business decision**. It is not here, and that is the point (§4.1: no business flow control).

## Verification

`dotnet build` → Build succeeded, 0 Error(s).

No unit tests: thin broker, no logic.

**This completes the Core-profile brokers**: Skill (#9), Generator (#14), Tool (#16, #17), Log (#19, #20), plus the diagnostic logger (#44). Memory/Knowledge/Classifier/Verifier/Mcp are parked on the design decision in #50.

Closes #17
