### PR TITLE
FOUNDATIONS: Retrieve Skills

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/SkillServiceTests.Exceptions.RetrieveSkills.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/SkillServiceTests.Exceptions.RetrieveSkills.cs
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Skills.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class SkillServiceTests
+{
+    [Fact]
+    public async Task ShouldThrowDependencyExceptionOnRetrieveSkillsIfFileNotFoundErrorOccursAndLogItAsync()
+    {
+        // given
+        var fileNotFoundException = new FileNotFoundException();
+
+        var failedSkillDependencyException =
+            new FailedSkillDependencyException(
+                message: "Failed skill dependency error occurred, contact support.",
+                innerException: fileNotFoundException);
+
+        var expectedSkillDependencyException =
+            new SkillDependencyException(
+                message: "Skill dependency error occurred, contact support.",
+                innerException: failedSkillDependencyException);
+
+        this.skillBrokerMock.Setup(broker =>
+            broker.SelectSkillsAsync())
+                .ThrowsAsync(fileNotFoundException);
+
+        // when
+        ValueTask<string> retrieveSkillsTask =
+            this.skillService.RetrieveSkillsAsync();
+
+        SkillDependencyException actualSkillDependencyException =
+            await Assert.ThrowsAsync<SkillDependencyException>(
+                retrieveSkillsTask.AsTask);
+
+        // then
+        actualSkillDependencyException.Should()
+            .BeEquivalentTo(expectedSkillDependencyException);
+
+        this.skillBrokerMock.Verify(broker =>
+            broker.SelectSkillsAsync(),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogCriticalAsync(It.Is(SameExceptionAs(
+                expectedSkillDependencyException))),
+                    Times.Once);
+
+        this.skillBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/SkillServiceTests.Exceptions.RetrieveSkills.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/SkillServiceTests.Exceptions.RetrieveSkills.cs
@@ -12,16 +12,24 @@ namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
 
 public partial class SkillServiceTests
 {
-    [Fact]
-    public async Task ShouldThrowDependencyExceptionOnRetrieveSkillsIfFileNotFoundErrorOccursAndLogItAsync()
+    public static TheoryData<Exception> CriticalDependencyExceptions() =>
+        new()
+        {
+            new FileNotFoundException(),
+            new DirectoryNotFoundException(),
+            new UnauthorizedAccessException()
+        };
+
+    [Theory]
+    [MemberData(nameof(CriticalDependencyExceptions))]
+    public async Task ShouldThrowDependencyExceptionOnRetrieveSkillsIfCriticalErrorOccursAndLogItAsync(
+        Exception criticalDependencyException)
     {
         // given
-        var fileNotFoundException = new FileNotFoundException();
-
         var failedSkillDependencyException =
             new FailedSkillDependencyException(
                 message: "Failed skill dependency error occurred, contact support.",
-                innerException: fileNotFoundException);
+                innerException: criticalDependencyException);
 
         var expectedSkillDependencyException =
             new SkillDependencyException(
@@ -30,7 +38,7 @@ public partial class SkillServiceTests
 
         this.skillBrokerMock.Setup(broker =>
             broker.SelectSkillsAsync())
-                .ThrowsAsync(fileNotFoundException);
+                .ThrowsAsync(criticalDependencyException);
 
         // when
         ValueTask<string> retrieveSkillsTask =

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/SkillServiceTests.Exceptions.RetrieveSkills.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/SkillServiceTests.Exceptions.RetrieveSkills.cs
@@ -64,4 +64,95 @@ public partial class SkillServiceTests
         this.skillBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
+
+    [Fact]
+    public async Task ShouldThrowDependencyExceptionOnRetrieveSkillsIfIOErrorOccursAndLogItAsync()
+    {
+        // given
+        var ioException = new IOException();
+
+        var failedSkillDependencyException =
+            new FailedSkillDependencyException(
+                message: "Failed skill dependency error occurred, contact support.",
+                innerException: ioException);
+
+        var expectedSkillDependencyException =
+            new SkillDependencyException(
+                message: "Skill dependency error occurred, contact support.",
+                innerException: failedSkillDependencyException);
+
+        this.skillBrokerMock.Setup(broker =>
+            broker.SelectSkillsAsync())
+                .ThrowsAsync(ioException);
+
+        // when
+        ValueTask<string> retrieveSkillsTask =
+            this.skillService.RetrieveSkillsAsync();
+
+        SkillDependencyException actualSkillDependencyException =
+            await Assert.ThrowsAsync<SkillDependencyException>(
+                retrieveSkillsTask.AsTask);
+
+        // then
+        actualSkillDependencyException.Should()
+            .BeEquivalentTo(expectedSkillDependencyException);
+
+        this.skillBrokerMock.Verify(broker =>
+            broker.SelectSkillsAsync(),
+                Times.Once);
+
+        // Error, not Critical — a transient IO failure may well succeed on retry.
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedSkillDependencyException))),
+                    Times.Once);
+
+        this.skillBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnRetrieveSkillsIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        var serviceException = new Exception();
+
+        var failedSkillServiceException =
+            new FailedSkillServiceException(
+                message: "Failed skill service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedSkillServiceException =
+            new SkillServiceException(
+                message: "Skill service error occurred, contact support.",
+                innerException: failedSkillServiceException);
+
+        this.skillBrokerMock.Setup(broker =>
+            broker.SelectSkillsAsync())
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<string> retrieveSkillsTask =
+            this.skillService.RetrieveSkillsAsync();
+
+        SkillServiceException actualSkillServiceException =
+            await Assert.ThrowsAsync<SkillServiceException>(
+                retrieveSkillsTask.AsTask);
+
+        // then
+        actualSkillServiceException.Should()
+            .BeEquivalentTo(expectedSkillServiceException);
+
+        this.skillBrokerMock.Verify(broker =>
+            broker.SelectSkillsAsync(),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedSkillServiceException))),
+                    Times.Once);
+
+        this.skillBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
 }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/SkillServiceTests.Logic.RetrieveSkills.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/SkillServiceTests.Logic.RetrieveSkills.cs
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class SkillServiceTests
+{
+    [Fact]
+    public async Task ShouldRetrieveSkillsAsync()
+    {
+        // given
+        string randomSkills = CreateRandomString();
+        string retrievedSkills = randomSkills;
+        string expectedSkills = retrievedSkills;
+
+        this.skillBrokerMock.Setup(broker =>
+            broker.SelectSkillsAsync())
+                .ReturnsAsync(retrievedSkills);
+
+        // when
+        string actualSkills = await this.skillService.RetrieveSkillsAsync();
+
+        // then
+        actualSkills.Should().BeEquivalentTo(expectedSkills);
+
+        this.skillBrokerMock.Verify(broker =>
+            broker.SelectSkillsAsync(),
+                Times.Once);
+
+        this.skillBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/SkillServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/SkillServiceTests.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Data;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Foundations.Data;
+using Tynamix.ObjectFiller;
+using Xeptions;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class SkillServiceTests
+{
+    private readonly Mock<ISkillBroker> skillBrokerMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly ISkillService skillService;
+
+    public SkillServiceTests()
+    {
+        this.skillBrokerMock = new Mock<ISkillBroker>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.skillService = new SkillService(
+            skillBroker: this.skillBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents/Models/Foundations/Skills/Exceptions/FailedSkillDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Skills/Exceptions/FailedSkillDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Skills.Exceptions;
+
+public class FailedSkillDependencyException : Xeption
+{
+    public FailedSkillDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Skills/Exceptions/FailedSkillServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Skills/Exceptions/FailedSkillServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Skills.Exceptions;
+
+public class FailedSkillServiceException : Xeption
+{
+    public FailedSkillServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Skills/Exceptions/SkillDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Skills/Exceptions/SkillDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Skills.Exceptions;
+
+public class SkillDependencyException : Xeption
+{
+    public SkillDependencyException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Skills/Exceptions/SkillServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Skills/Exceptions/SkillServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Skills.Exceptions;
+
+public class SkillServiceException : Xeption
+{
+    public SkillServiceException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Services/Foundations/Data/ISkillService.cs
+++ b/Standard.Agents/Services/Foundations/Data/ISkillService.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+public interface ISkillService
+{
+    ValueTask<string> RetrieveSkillsAsync();
+}

--- a/Standard.Agents/Services/Foundations/Data/SkillService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Data/SkillService.Exceptions.cs
@@ -18,12 +18,34 @@ public partial class SkillService
         {
             return await returningStringFunction();
         }
+        // FileNotFound and DirectoryNotFound both derive from IOException, so they
+        // must be caught above any IOException block or it would swallow them.
         catch (FileNotFoundException fileNotFoundException)
         {
             var failedSkillDependencyException =
                 new FailedSkillDependencyException(
                     message: "Failed skill dependency error occurred, contact support.",
                     innerException: fileNotFoundException);
+
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                failedSkillDependencyException);
+        }
+        catch (DirectoryNotFoundException directoryNotFoundException)
+        {
+            var failedSkillDependencyException =
+                new FailedSkillDependencyException(
+                    message: "Failed skill dependency error occurred, contact support.",
+                    innerException: directoryNotFoundException);
+
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                failedSkillDependencyException);
+        }
+        catch (UnauthorizedAccessException unauthorizedAccessException)
+        {
+            var failedSkillDependencyException =
+                new FailedSkillDependencyException(
+                    message: "Failed skill dependency error occurred, contact support.",
+                    innerException: unauthorizedAccessException);
 
             throw await CreateAndLogCriticalDependencyExceptionAsync(
                 failedSkillDependencyException);

--- a/Standard.Agents/Services/Foundations/Data/SkillService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Data/SkillService.Exceptions.cs
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Skills.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+public partial class SkillService
+{
+    private delegate ValueTask<string> ReturningStringFunction();
+
+    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    {
+        try
+        {
+            return await returningStringFunction();
+        }
+        catch (FileNotFoundException fileNotFoundException)
+        {
+            var failedSkillDependencyException =
+                new FailedSkillDependencyException(
+                    message: "Failed skill dependency error occurred, contact support.",
+                    innerException: fileNotFoundException);
+
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                failedSkillDependencyException);
+        }
+    }
+
+    private async ValueTask<SkillDependencyException> CreateAndLogCriticalDependencyExceptionAsync(
+        Xeption exception)
+    {
+        var skillDependencyException =
+            new SkillDependencyException(
+                message: "Skill dependency error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogCriticalAsync(skillDependencyException);
+
+        return skillDependencyException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Data/SkillService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Data/SkillService.Exceptions.cs
@@ -50,6 +50,26 @@ public partial class SkillService
             throw await CreateAndLogCriticalDependencyExceptionAsync(
                 failedSkillDependencyException);
         }
+        catch (IOException ioException)
+        {
+            var failedSkillDependencyException =
+                new FailedSkillDependencyException(
+                    message: "Failed skill dependency error occurred, contact support.",
+                    innerException: ioException);
+
+            throw await CreateAndLogDependencyExceptionAsync(
+                failedSkillDependencyException);
+        }
+        catch (Exception exception)
+        {
+            var failedSkillServiceException =
+                new FailedSkillServiceException(
+                    message: "Failed skill service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(
+                failedSkillServiceException);
+        }
     }
 
     private async ValueTask<SkillDependencyException> CreateAndLogCriticalDependencyExceptionAsync(
@@ -63,5 +83,31 @@ public partial class SkillService
         await this.loggingBroker.LogCriticalAsync(skillDependencyException);
 
         return skillDependencyException;
+    }
+
+    private async ValueTask<SkillDependencyException> CreateAndLogDependencyExceptionAsync(
+        Xeption exception)
+    {
+        var skillDependencyException =
+            new SkillDependencyException(
+                message: "Skill dependency error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(skillDependencyException);
+
+        return skillDependencyException;
+    }
+
+    private async ValueTask<SkillServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var skillServiceException =
+            new SkillServiceException(
+                message: "Skill service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(skillServiceException);
+
+        return skillServiceException;
     }
 }

--- a/Standard.Agents/Services/Foundations/Data/SkillService.cs
+++ b/Standard.Agents/Services/Foundations/Data/SkillService.cs
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Data;
+using Standard.Agents.Brokers.Loggings;
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+public partial class SkillService : ISkillService
+{
+    private readonly ISkillBroker skillBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public SkillService(
+        ISkillBroker skillBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.skillBroker = skillBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<string> RetrieveSkillsAsync() =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents/Services/Foundations/Data/SkillService.cs
+++ b/Standard.Agents/Services/Foundations/Data/SkillService.cs
@@ -21,6 +21,7 @@ public partial class SkillService : ISkillService
         this.loggingBroker = loggingBroker;
     }
 
-    public async ValueTask<string> RetrieveSkillsAsync() =>
-        await this.skillBroker.SelectSkillsAsync();
+    public ValueTask<string> RetrieveSkillsAsync() =>
+    TryCatch(async () =>
+        await this.skillBroker.SelectSkillsAsync());
 }

--- a/Standard.Agents/Services/Foundations/Data/SkillService.cs
+++ b/Standard.Agents/Services/Foundations/Data/SkillService.cs
@@ -21,6 +21,6 @@ public partial class SkillService : ISkillService
         this.loggingBroker = loggingBroker;
     }
 
-    public ValueTask<string> RetrieveSkillsAsync() =>
-        throw new NotImplementedException();
+    public async ValueTask<string> RetrieveSkillsAsync() =>
+        await this.skillBroker.SelectSkillsAsync();
 }


### PR DESCRIPTION
The first Standard-compliant foundation, and the exemplar the other ten follow. SPEC.md §4.2.

```csharp
ValueTask<string> RetrieveSkillsAsync();
```

Technology language `SelectSkills` → business language **Retrieve**.

## TDD — the history is the evidence

```
ShouldRetrieveSkillsAsync                                             -> FAIL
ShouldRetrieveSkillsAsync                                             -> PASS
ShouldThrowDependencyExceptionOnRetrieveSkills...FileNotFound...      -> FAIL
ShouldThrowDependencyExceptionOnRetrieveSkills...FileNotFound...      -> PASS
ShouldThrowDependencyExceptionOnRetrieveSkills...CriticalError...     -> FAIL
ShouldThrowDependencyExceptionOnRetrieveSkills...CriticalError...     -> PASS
ShouldThrowDependencyExceptionOnRetrieveSkills...IOError...           -> FAIL
ShouldThrowServiceExceptionOnRetrieveSkills...ServiceError...         -> FAIL
ShouldThrowDependencyExceptionOnRetrieveSkills...IOError...           -> PASS
ShouldThrowServiceExceptionOnRetrieveSkills...ServiceError...         -> PASS
```

**Every FAIL was run and observed failing before it was committed** — each commit message records the actual runner output. Every PASS ran the *full* suite, not just the new test.

## The severity split is the point

| Native | Category | Log | Why |
|---|---|---|---|
| `FileNotFoundException` | Dependency | **Critical** | skills missing = deployment/config fault |
| `DirectoryNotFoundException` | Dependency | **Critical** | same |
| `UnauthorizedAccessException` | Dependency | **Critical** | permission fault, won't fix itself |
| `IOException` | Dependency | Error | disk hiccup / locked file — may succeed on retry |
| `Exception` | Service | Error | anything unforeseen, categorised so nothing escapes raw |

## Catch order is load-bearing

`FileNotFoundException` and `DirectoryNotFoundException` **both derive from `IOException`**. The `IOException` block must sit *below* them or it swallows them and downgrades a misconfiguration to a transient error. Commented in place so the next reader doesn't "tidy" the order.

The blocks are deliberately **not** collapsed into `catch (Exception e) when (...)`. Explicit catches say plainly which natives are expected — No Magic: what you see is what you get.

## Structure

```
Services/Foundations/Data/ISkillService.cs
Services/Foundations/Data/SkillService.cs             (logic — reads as intent)
Services/Foundations/Data/SkillService.Exceptions.cs  (TryCatch + CreateAndLog helpers)
Models/Foundations/Skills/Exceptions/                 (4 models, two-tier)
```

No `.Validations.cs` — `RetrieveSkillsAsync` takes no input. There is nothing to validate, and an empty partial would be ceremony.

## Test conventions established here

Moq for both brokers (no hand-rolled fakes) · Tynamix `MnemonicString` so no test asserts on a value it hardcoded · FluentAssertions · `SameExceptionAs` via Xeption · `VerifyNoOtherCalls` on every mock so an unwanted broker call fails the test · a `[Theory]` where three natives share one category, rather than three near-identical `[Fact]`s.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 6, Total: 6**

Closes #21
