### PR TITLE
FOUNDATIONS: Return

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ReturnServiceTests.Logic.Return.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ReturnServiceTests.Logic.Return.cs
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class ReturnServiceTests
+{
+    [Fact]
+    public async Task ShouldReturnAsync()
+    {
+        // given
+        string randomPayload = CreateRandomString();
+        string inputPayload = randomPayload;
+        string expectedPayload = inputPayload;
+
+        // when
+        string actualPayload = await this.returnService.ReturnAsync(inputPayload);
+
+        // then
+        actualPayload.Should().BeEquivalentTo(expectedPayload);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ReturnServiceTests.Validations.Return.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ReturnServiceTests.Validations.Return.cs
@@ -1,0 +1,51 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Returns.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class ReturnServiceTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnReturnIfPayloadIsInvalidAndLogItAsync(
+        string invalidPayload)
+    {
+        // given
+        var invalidReturnException =
+            new InvalidReturnException(
+                message: "Invalid return payload. Please correct the error and try again.");
+
+        var expectedReturnValidationException =
+            new ReturnValidationException(
+                message: "Return validation error occurred, fix the error and try again.",
+                innerException: invalidReturnException);
+
+        // when
+        ValueTask<string> returnTask =
+            this.returnService.ReturnAsync(invalidPayload);
+
+        ReturnValidationException actualReturnValidationException =
+            await Assert.ThrowsAsync<ReturnValidationException>(
+                returnTask.AsTask);
+
+        // then
+        actualReturnValidationException.Should()
+            .BeEquivalentTo(expectedReturnValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedReturnValidationException))),
+                    Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ReturnServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ReturnServiceTests.cs
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Foundations.Direction;
+using Tynamix.ObjectFiller;
+using Xeptions;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class ReturnServiceTests
+{
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly IReturnService returnService;
+
+    public ReturnServiceTests()
+    {
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.returnService = new ReturnService(
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents/Models/Foundations/Returns/Exceptions/FailedReturnServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Returns/Exceptions/FailedReturnServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Returns.Exceptions;
+
+public class FailedReturnServiceException : Xeption
+{
+    public FailedReturnServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Returns/Exceptions/InvalidReturnException.cs
+++ b/Standard.Agents/Models/Foundations/Returns/Exceptions/InvalidReturnException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Returns.Exceptions;
+
+public class InvalidReturnException : Xeption
+{
+    public InvalidReturnException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Returns/Exceptions/ReturnServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Returns/Exceptions/ReturnServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Returns.Exceptions;
+
+public class ReturnServiceException : Xeption
+{
+    public ReturnServiceException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Returns/Exceptions/ReturnValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Returns/Exceptions/ReturnValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Returns.Exceptions;
+
+public class ReturnValidationException : Xeption
+{
+    public ReturnValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Services/Foundations/Direction/IReturnService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/IReturnService.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public interface IReturnService
+{
+    ValueTask<string> ReturnAsync(string payload);
+}

--- a/Standard.Agents/Services/Foundations/Direction/ReturnService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ReturnService.Exceptions.cs
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Returns.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public partial class ReturnService
+{
+    private delegate ValueTask<string> ReturningStringFunction();
+
+    // No dependency catches: Return has no broker, so there is no external
+    // resource that can fail. Validation and the catch-all is the whole surface.
+    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    {
+        try
+        {
+            return await returningStringFunction();
+        }
+        catch (InvalidReturnException invalidReturnException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidReturnException);
+        }
+        catch (Exception exception)
+        {
+            var failedReturnServiceException =
+                new FailedReturnServiceException(
+                    message: "Failed return service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedReturnServiceException);
+        }
+    }
+
+    private async ValueTask<ReturnValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var returnValidationException =
+            new ReturnValidationException(
+                message: "Return validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(returnValidationException);
+
+        return returnValidationException;
+    }
+
+    private async ValueTask<ReturnServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var returnServiceException =
+            new ReturnServiceException(
+                message: "Return service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(returnServiceException);
+
+        return returnServiceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Direction/ReturnService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ReturnService.Validations.cs
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Returns.Exceptions;
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public partial class ReturnService
+{
+    private static void ValidatePayload(string payload)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            throw new InvalidReturnException(
+                message: "Invalid return payload. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Direction/ReturnService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ReturnService.cs
@@ -17,5 +17,10 @@ public partial class ReturnService : IReturnService
         this.loggingBroker = loggingBroker;
 
     public ValueTask<string> ReturnAsync(string payload) =>
-        ValueTask.FromResult(payload);
+    TryCatch(() =>
+    {
+        ValidatePayload(payload);
+
+        return ValueTask.FromResult(payload);
+    });
 }

--- a/Standard.Agents/Services/Foundations/Direction/ReturnService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ReturnService.cs
@@ -17,5 +17,5 @@ public partial class ReturnService : IReturnService
         this.loggingBroker = loggingBroker;
 
     public ValueTask<string> ReturnAsync(string payload) =>
-        throw new NotImplementedException();
+        ValueTask.FromResult(payload);
 }

--- a/Standard.Agents/Services/Foundations/Direction/ReturnService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ReturnService.cs
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Loggings;
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+// The one foundation with no broker — the dead end. Return hands the result back
+// and touches no external resource, so it has no dependency exceptions to map.
+public partial class ReturnService : IReturnService
+{
+    private readonly ILoggingBroker loggingBroker;
+
+    public ReturnService(ILoggingBroker loggingBroker) =>
+        this.loggingBroker = loggingBroker;
+
+    public ValueTask<string> ReturnAsync(string payload) =>
+        throw new NotImplementedException();
+}


### PR DESCRIPTION
The terminal Direction — **the dead end**. SPEC.md §4.2.

```csharp
ValueTask<string> ReturnAsync(string payload);
```

Theory Ch.5: Return is *"no action — hand the result back."*

## The only foundation with no broker

This is the asymmetry behind `FOUNDATION · 9` vs `BROKER · 8+1` — `architecture.svg` draws Return's broker as a **dashed dead end**. It takes `ILoggingBroker` only, which is a support broker and always allowed.

**Its shape follows from that.** With no external resource, there is nothing to fail — so there are no dependency exceptions and no ladder. Validation plus a catch-all is the entire surface. Writing a dependency ladder here to look symmetric with the other foundations would be inventing failures that cannot happen.

## TDD

```
ShouldReturnAsync                                                -> FAIL
ShouldReturnAsync                                                -> PASS
ShouldThrowValidationExceptionOnReturnIfPayloadIsInvalid...      -> FAIL   (3 cases)
ShouldThrowValidationExceptionOnReturnIfPayloadIsInvalid...      -> PASS
```

Every FAIL run and observed failing before commit; every PASS ran the full suite.

## Why an empty payload is invalid, not merely odd

Direction returning `""` would terminate the loop with an empty `Result`, and the caller would get **silence with no way to tell a considered empty answer from a broken one**. Failing loudly here is what keeps that from reaching a user.

Null / empty / whitespace are one `[Theory]` — three spellings of the same defect. Circuit-breaking and structural: it stops immediately, because there is exactly one input and nothing to accumulate alongside it.

## Known gap — the catch-all has no unit test

With no broker, there is **no seam to inject an unexpected failure through**, so the `catch (Exception)` block is unreachable from a unit test.

It stays, because The Standard requires every service to end in `catch (Exception)` so nothing escapes uncategorised. But the coverage claim would be false, so it isn't made. Faking a seam to manufacture the test would be worse than the gap.

This is a real consequence of "no broker," and worth knowing when reading the suite.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 10, Total: 10** (4 new cases across 2 methods)

Closes #31
