### PR TITLE
FOUNDATIONS: Handles

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Exceptions.Handles.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Exceptions.Handles.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class InternalToolServiceTests
+{
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnHandlesIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomName = CreateRandomString();
+        string inputName = randomName;
+        var serviceException = new Exception();
+
+        var failedInternalToolServiceException =
+            new FailedInternalToolServiceException(
+                message: "Failed internal tool service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedInternalToolServiceException =
+            new InternalToolServiceException(
+                message: "Internal tool service error occurred, contact support.",
+                innerException: failedInternalToolServiceException);
+
+        this.toolBrokerMock.Setup(broker =>
+            broker.HasAsync(inputName))
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<bool> handlesTask =
+            this.internalToolService.HandlesAsync(inputName);
+
+        InternalToolServiceException actualInternalToolServiceException =
+            await Assert.ThrowsAsync<InternalToolServiceException>(
+                handlesTask.AsTask);
+
+        // then
+        actualInternalToolServiceException.Should()
+            .BeEquivalentTo(expectedInternalToolServiceException);
+
+        this.toolBrokerMock.Verify(broker =>
+            broker.HasAsync(inputName),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedInternalToolServiceException))),
+                    Times.Once);
+
+        this.toolBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Logic.Handles.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Logic.Handles.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class InternalToolServiceTests
+{
+    // An unknown tool is a legitimate false, never an exception — conformance vector
+    // 05-unknown-tool-recovers needs that false to route the call to External.
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ShouldHandlesAsync(bool brokerHasTool)
+    {
+        // given
+        string randomName = CreateRandomString();
+        string inputName = randomName;
+        bool expectedOutcome = brokerHasTool;
+
+        this.toolBrokerMock.Setup(broker =>
+            broker.HasAsync(inputName))
+                .ReturnsAsync(brokerHasTool);
+
+        // when
+        bool actualOutcome =
+            await this.internalToolService.HandlesAsync(inputName);
+
+        // then
+        actualOutcome.Should().Be(expectedOutcome);
+
+        this.toolBrokerMock.Verify(broker =>
+            broker.HasAsync(inputName),
+                Times.Once);
+
+        this.toolBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Validations.Handles.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Validations.Handles.cs
@@ -1,0 +1,57 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class InternalToolServiceTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnHandlesIfNameIsInvalidAndLogItAsync(
+        string invalidName)
+    {
+        // given
+        var invalidInternalToolException =
+            new InvalidInternalToolException(
+                message: "Invalid internal tool. Please correct the error and try again.");
+
+        var expectedInternalToolValidationException =
+            new InternalToolValidationException(
+                message: "Internal tool validation error occurred, fix the error and try again.",
+                innerException: invalidInternalToolException);
+
+        // when
+        ValueTask<bool> handlesTask =
+            this.internalToolService.HandlesAsync(invalidName);
+
+        InternalToolValidationException actualInternalToolValidationException =
+            await Assert.ThrowsAsync<InternalToolValidationException>(
+                handlesTask.AsTask);
+
+        // then
+        actualInternalToolValidationException.Should()
+            .BeEquivalentTo(expectedInternalToolValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedInternalToolValidationException))),
+                    Times.Once);
+
+        // Validation runs before the dependency call — the broker is never reached.
+        this.toolBrokerMock.Verify(broker =>
+            broker.HasAsync(It.IsAny<string>()),
+                Times.Never);
+
+        this.toolBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Direction;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Foundations.Direction;
+using Tynamix.ObjectFiller;
+using Xeptions;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class InternalToolServiceTests
+{
+    private readonly Mock<IToolBroker> toolBrokerMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly IInternalToolService internalToolService;
+
+    public InternalToolServiceTests()
+    {
+        this.toolBrokerMock = new Mock<IToolBroker>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.internalToolService = new InternalToolService(
+            toolBroker: this.toolBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents/Models/Foundations/InternalTools/Exceptions/FailedInternalToolServiceException.cs
+++ b/Standard.Agents/Models/Foundations/InternalTools/Exceptions/FailedInternalToolServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+
+public class FailedInternalToolServiceException : Xeption
+{
+    public FailedInternalToolServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolServiceException.cs
+++ b/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+
+public class InternalToolServiceException : Xeption
+{
+    public InternalToolServiceException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolValidationException.cs
+++ b/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+
+public class InternalToolValidationException : Xeption
+{
+    public InternalToolValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InvalidInternalToolException.cs
+++ b/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InvalidInternalToolException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+
+public class InvalidInternalToolException : Xeption
+{
+    public InvalidInternalToolException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Services/Foundations/Direction/IInternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/IInternalToolService.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public interface IInternalToolService
+{
+    ValueTask<bool> HandlesAsync(string name);
+}

--- a/Standard.Agents/Services/Foundations/Direction/InternalToolService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Direction/InternalToolService.Exceptions.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public partial class InternalToolService
+{
+    private delegate ValueTask<bool> ReturningBooleanFunction();
+
+    private async ValueTask<bool> TryCatch(ReturningBooleanFunction returningBooleanFunction)
+    {
+        try
+        {
+            return await returningBooleanFunction();
+        }
+        catch (InvalidInternalToolException invalidInternalToolException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidInternalToolException);
+        }
+        catch (Exception exception)
+        {
+            var failedInternalToolServiceException =
+                new FailedInternalToolServiceException(
+                    message: "Failed internal tool service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedInternalToolServiceException);
+        }
+    }
+
+    private async ValueTask<InternalToolValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var internalToolValidationException =
+            new InternalToolValidationException(
+                message: "Internal tool validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(internalToolValidationException);
+
+        return internalToolValidationException;
+    }
+
+    private async ValueTask<InternalToolServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var internalToolServiceException =
+            new InternalToolServiceException(
+                message: "Internal tool service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(internalToolServiceException);
+
+        return internalToolServiceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Direction/InternalToolService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Direction/InternalToolService.Validations.cs
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public partial class InternalToolService
+{
+    private static void ValidateName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new InvalidInternalToolException(
+                message: "Invalid internal tool. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
@@ -21,6 +21,6 @@ public partial class InternalToolService : IInternalToolService
         this.loggingBroker = loggingBroker;
     }
 
-    public ValueTask<bool> HandlesAsync(string name) =>
-        throw new NotImplementedException();
+    public async ValueTask<bool> HandlesAsync(string name) =>
+        await this.toolBroker.HasAsync(name);
 }

--- a/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
@@ -21,6 +21,11 @@ public partial class InternalToolService : IInternalToolService
         this.loggingBroker = loggingBroker;
     }
 
-    public async ValueTask<bool> HandlesAsync(string name) =>
-        await this.toolBroker.HasAsync(name);
+    public ValueTask<bool> HandlesAsync(string name) =>
+    TryCatch(async () =>
+    {
+        ValidateName(name);
+
+        return await this.toolBroker.HasAsync(name);
+    });
 }

--- a/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Direction;
+using Standard.Agents.Brokers.Loggings;
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public partial class InternalToolService : IInternalToolService
+{
+    private readonly IToolBroker toolBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public InternalToolService(
+        IToolBroker toolBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.toolBroker = toolBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<bool> HandlesAsync(string name) =>
+        throw new NotImplementedException();
+}


### PR DESCRIPTION
Does a local tool exist by this name. SPEC.md §4.2. `Has` → **Handles**.

```csharp
ValueTask<bool> HandlesAsync(string name);
```

## TDD

```
ShouldHandlesAsync                                            -> FAIL / PASS   (2 cases)
ShouldThrowValidationExceptionOnHandlesIfNameIsInvalid...     -> FAIL / PASS   (3 cases)
ShouldThrowServiceExceptionOnHandlesIfServiceErrorOccurs...   -> FAIL / PASS
```

Every FAIL run and observed failing before commit; every PASS ran the full suite.

## An unknown tool is a `false`, never an exception

The `[Theory]` over `true`/`false` exists for the **false** case. Conformance vector `05-unknown-tool-recovers` needs that `false` so Direction can route the call to External and the agent carries on. If this threw on a miss, the vector would fail and an unknown tool would kill the loop instead of being handled.

**Note what's absent:** no test claims an unknown name throws. An *invalid* name (null/empty/whitespace) and an *unknown* name are different things, and only the first is an error.

## The validation test asserts `Times.Never` on the broker

That's the rule under test — *validate before the dependency call*. Asserting only the throw would still pass if the service asked the broker first and validated afterwards, which would mean a null name reaching a dictionary lookup.

## Unlike #31, the catch-all is testable here

`ReturnService` has no broker, so its `catch (Exception)` is unreachable from a unit test. This service has a broker to make throw. That's the difference having a resource makes.

## Spec discrepancy — resolved to async

§4.2 types this `handles(name) -> Bool`, unwrapped; §9 states *"every contract method is asynchronous."* Resolved to `ValueTask<bool>` per §9 + The Standard §1.5.1 — same contradiction, same resolution as the broker in #16. Worth raising upstream.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 16, Total: 16**

Closes #28
