### PR TITLE
FOUNDATIONS: Run Internal Tool

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Exceptions.Run.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Exceptions.Run.cs
@@ -1,0 +1,119 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class InternalToolServiceTests
+{
+    // A THROWING tool is a dependency failure — distinct from a tool that returns
+    // an error string, which ShouldReturnToolOutputOnRunEvenIfToolReportsAnError
+    // pins as a normal result.
+    [Fact]
+    public async Task ShouldThrowDependencyExceptionOnRunIfToolErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomInput = CreateRandomString();
+        string inputName = randomName;
+        string inputInput = randomInput;
+        var toolException = new InvalidOperationException();
+
+        var failedInternalToolDependencyException =
+            new FailedInternalToolDependencyException(
+                message: "Failed internal tool dependency error occurred, contact support.",
+                innerException: toolException);
+
+        var expectedInternalToolDependencyException =
+            new InternalToolDependencyException(
+                message: "Internal tool dependency error occurred, contact support.",
+                innerException: failedInternalToolDependencyException);
+
+        this.toolBrokerMock.Setup(broker =>
+            broker.RunAsync(inputName, inputInput))
+                .ThrowsAsync(toolException);
+
+        // when
+        ValueTask<string> runTask =
+            this.internalToolService.RunAsync(inputName, inputInput);
+
+        InternalToolDependencyException actualInternalToolDependencyException =
+            await Assert.ThrowsAsync<InternalToolDependencyException>(
+                runTask.AsTask);
+
+        // then
+        actualInternalToolDependencyException.Should()
+            .BeEquivalentTo(expectedInternalToolDependencyException);
+
+        this.toolBrokerMock.Verify(broker =>
+            broker.RunAsync(inputName, inputInput),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedInternalToolDependencyException))),
+                    Times.Once);
+
+        this.toolBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // A tool asked for by a name the registry does not hold. The broker indexes
+    // directly (#17), so this surfaces as KeyNotFoundException. Direction is
+    // expected to ask HandlesAsync first, but the foundation must still categorise
+    // it rather than let a raw native escape.
+    [Fact]
+    public async Task ShouldThrowDependencyExceptionOnRunIfToolIsNotFoundAndLogItAsync()
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomInput = CreateRandomString();
+        string inputName = randomName;
+        string inputInput = randomInput;
+        var keyNotFoundException = new KeyNotFoundException();
+
+        var failedInternalToolDependencyException =
+            new FailedInternalToolDependencyException(
+                message: "Failed internal tool dependency error occurred, contact support.",
+                innerException: keyNotFoundException);
+
+        var expectedInternalToolDependencyException =
+            new InternalToolDependencyException(
+                message: "Internal tool dependency error occurred, contact support.",
+                innerException: failedInternalToolDependencyException);
+
+        this.toolBrokerMock.Setup(broker =>
+            broker.RunAsync(inputName, inputInput))
+                .ThrowsAsync(keyNotFoundException);
+
+        // when
+        ValueTask<string> runTask =
+            this.internalToolService.RunAsync(inputName, inputInput);
+
+        InternalToolDependencyException actualInternalToolDependencyException =
+            await Assert.ThrowsAsync<InternalToolDependencyException>(
+                runTask.AsTask);
+
+        // then
+        actualInternalToolDependencyException.Should()
+            .BeEquivalentTo(expectedInternalToolDependencyException);
+
+        this.toolBrokerMock.Verify(broker =>
+            broker.RunAsync(inputName, inputInput),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedInternalToolDependencyException))),
+                    Times.Once);
+
+        this.toolBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Logic.Run.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Logic.Run.cs
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class InternalToolServiceTests
+{
+    [Fact]
+    public async Task ShouldRunAsync()
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomInput = CreateRandomString();
+        string randomOutput = CreateRandomString();
+        string inputName = randomName;
+        string inputInput = randomInput;
+        string expectedOutput = randomOutput;
+
+        this.toolBrokerMock.Setup(broker =>
+            broker.RunAsync(inputName, inputInput))
+                .ReturnsAsync(randomOutput);
+
+        // when
+        string actualOutput =
+            await this.internalToolService.RunAsync(inputName, inputInput);
+
+        // then
+        actualOutput.Should().BeEquivalentTo(expectedOutput);
+
+        this.toolBrokerMock.Verify(broker =>
+            broker.RunAsync(inputName, inputInput),
+                Times.Once);
+
+        this.toolBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // A tool that RETURNS an error string is a normal result, not a failure. It
+    // becomes an observation and the loop carries on — vector 05 depends on this.
+    // Only a tool that THROWS is a dependency failure.
+    [Fact]
+    public async Task ShouldReturnToolOutputOnRunEvenIfToolReportsAnErrorAsync()
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomInput = CreateRandomString();
+        string toolReportedError = "error: could not parse expression";
+        string inputName = randomName;
+        string inputInput = randomInput;
+        string expectedOutput = toolReportedError;
+
+        this.toolBrokerMock.Setup(broker =>
+            broker.RunAsync(inputName, inputInput))
+                .ReturnsAsync(toolReportedError);
+
+        // when
+        string actualOutput =
+            await this.internalToolService.RunAsync(inputName, inputInput);
+
+        // then
+        actualOutput.Should().BeEquivalentTo(expectedOutput);
+
+        this.toolBrokerMock.Verify(broker =>
+            broker.RunAsync(inputName, inputInput),
+                Times.Once);
+
+        this.toolBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Validations.Run.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Validations.Run.cs
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class InternalToolServiceTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnRunIfNameIsInvalidAndLogItAsync(
+        string invalidName)
+    {
+        // given
+        string randomInput = CreateRandomString();
+
+        var invalidInternalToolException =
+            new InvalidInternalToolException(
+                message: "Invalid internal tool. Please correct the error and try again.");
+
+        var expectedInternalToolValidationException =
+            new InternalToolValidationException(
+                message: "Internal tool validation error occurred, fix the error and try again.",
+                innerException: invalidInternalToolException);
+
+        // when
+        ValueTask<string> runTask =
+            this.internalToolService.RunAsync(invalidName, randomInput);
+
+        InternalToolValidationException actualInternalToolValidationException =
+            await Assert.ThrowsAsync<InternalToolValidationException>(
+                runTask.AsTask);
+
+        // then
+        actualInternalToolValidationException.Should()
+            .BeEquivalentTo(expectedInternalToolValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedInternalToolValidationException))),
+                    Times.Once);
+
+        this.toolBrokerMock.Verify(broker =>
+            broker.RunAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.toolBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // Only the NAME is validated. An empty input is a legitimate call — a tool may
+    // take no arguments — so validating it would reject valid work.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldRunOnRunEvenIfInputIsEmptyAsync(string emptyInput)
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomOutput = CreateRandomString();
+        string inputName = randomName;
+        string expectedOutput = randomOutput;
+
+        this.toolBrokerMock.Setup(broker =>
+            broker.RunAsync(inputName, emptyInput))
+                .ReturnsAsync(randomOutput);
+
+        // when
+        string actualOutput =
+            await this.internalToolService.RunAsync(inputName, emptyInput);
+
+        // then
+        actualOutput.Should().BeEquivalentTo(expectedOutput);
+
+        this.toolBrokerMock.Verify(broker =>
+            broker.RunAsync(inputName, emptyInput),
+                Times.Once);
+
+        this.toolBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents/Models/Foundations/InternalTools/Exceptions/FailedInternalToolDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/InternalTools/Exceptions/FailedInternalToolDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+
+public class FailedInternalToolDependencyException : Xeption
+{
+    public FailedInternalToolDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+
+public class InternalToolDependencyException : Xeption
+{
+    public InternalToolDependencyException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Services/Foundations/Direction/IInternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/IInternalToolService.cs
@@ -8,4 +8,6 @@ namespace Standard.Agents.Services.Foundations.Direction;
 public interface IInternalToolService
 {
     ValueTask<bool> HandlesAsync(string name);
+
+    ValueTask<string> RunAsync(string name, string input);
 }

--- a/Standard.Agents/Services/Foundations/Direction/InternalToolService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Direction/InternalToolService.Exceptions.cs
@@ -11,7 +11,10 @@ namespace Standard.Agents.Services.Foundations.Direction;
 public partial class InternalToolService
 {
     private delegate ValueTask<bool> ReturningBooleanFunction();
+    private delegate ValueTask<string> ReturningStringFunction();
 
+    // HandlesAsync only reads the registry, so it has no dependency category —
+    // a lookup either answers or the service itself is broken.
     private async ValueTask<bool> TryCatch(ReturningBooleanFunction returningBooleanFunction)
     {
         try
@@ -33,6 +36,39 @@ public partial class InternalToolService
         }
     }
 
+    // RunAsync executes someone else's code, so it does have a dependency category.
+    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    {
+        try
+        {
+            return await returningStringFunction();
+        }
+        catch (InvalidInternalToolException invalidInternalToolException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidInternalToolException);
+        }
+        catch (KeyNotFoundException keyNotFoundException)
+        {
+            var failedInternalToolDependencyException =
+                new FailedInternalToolDependencyException(
+                    message: "Failed internal tool dependency error occurred, contact support.",
+                    innerException: keyNotFoundException);
+
+            throw await CreateAndLogDependencyExceptionAsync(
+                failedInternalToolDependencyException);
+        }
+        catch (Exception exception)
+        {
+            var failedInternalToolDependencyException =
+                new FailedInternalToolDependencyException(
+                    message: "Failed internal tool dependency error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogDependencyExceptionAsync(
+                failedInternalToolDependencyException);
+        }
+    }
+
     private async ValueTask<InternalToolValidationException> CreateAndLogValidationExceptionAsync(
         Xeption exception)
     {
@@ -44,6 +80,19 @@ public partial class InternalToolService
         await this.loggingBroker.LogErrorAsync(internalToolValidationException);
 
         return internalToolValidationException;
+    }
+
+    private async ValueTask<InternalToolDependencyException> CreateAndLogDependencyExceptionAsync(
+        Xeption exception)
+    {
+        var internalToolDependencyException =
+            new InternalToolDependencyException(
+                message: "Internal tool dependency error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(internalToolDependencyException);
+
+        return internalToolDependencyException;
     }
 
     private async ValueTask<InternalToolServiceException> CreateAndLogServiceExceptionAsync(

--- a/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
@@ -29,6 +29,9 @@ public partial class InternalToolService : IInternalToolService
         return await this.toolBroker.HasAsync(name);
     });
 
-    public ValueTask<string> RunAsync(string name, string input) =>
-        throw new NotImplementedException();
+    // The tool's output is returned verbatim, whatever it says. A tool reporting
+    // an error is a result, not a failure — it becomes an observation and the
+    // loop carries on. Only a throwing tool is a dependency failure.
+    public async ValueTask<string> RunAsync(string name, string input) =>
+        await this.toolBroker.RunAsync(name, input);
 }

--- a/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
@@ -32,6 +32,11 @@ public partial class InternalToolService : IInternalToolService
     // The tool's output is returned verbatim, whatever it says. A tool reporting
     // an error is a result, not a failure — it becomes an observation and the
     // loop carries on. Only a throwing tool is a dependency failure.
-    public async ValueTask<string> RunAsync(string name, string input) =>
-        await this.toolBroker.RunAsync(name, input);
+    public ValueTask<string> RunAsync(string name, string input) =>
+    TryCatch(async () =>
+    {
+        ValidateName(name);
+
+        return await this.toolBroker.RunAsync(name, input);
+    });
 }

--- a/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/InternalToolService.cs
@@ -28,4 +28,7 @@ public partial class InternalToolService : IInternalToolService
 
         return await this.toolBroker.HasAsync(name);
     });
+
+    public ValueTask<string> RunAsync(string name, string input) =>
+        throw new NotImplementedException();
 }


### PR DESCRIPTION
Execute a registered local tool — Direction's **Internal** locus. SPEC.md §4.2.

```csharp
ValueTask<string> RunAsync(string name, string input);
```

## TDD

```
ShouldRunAsync                                                  -> FAIL / PASS
ShouldReturnToolOutputOnRunEvenIfToolReportsAnErrorAsync        -> FAIL / PASS
ShouldThrowValidationExceptionOnRunIfNameIsInvalid...           -> FAIL / PASS  (3 cases)
ShouldThrowDependencyExceptionOnRunIfToolErrorOccurs...         -> FAIL / PASS
ShouldThrowDependencyExceptionOnRunIfToolIsNotFound...          -> FAIL / PASS
ShouldRunOnRunEvenIfInputIsEmptyAsync                           -> passes as-is (3 cases)
```

## The distinction this method turns on

| Tool behaviour | Meaning | Result |
|---|---|---|
| **returns** an error string | a normal result | becomes an observation, loop carries on |
| **throws** | a dependency failure | categorised, logged, propagated |

Conformance vector `05-unknown-tool-recovers` rests on that line: the agent must recover from a tool reporting trouble, and it only can if the report travels back as **data** rather than as an exception.

`ShouldReturnToolOutputOnRunEvenIfToolReportsAnErrorAsync` exists to stop a future reader "improving" this into inspecting output and throwing on anything error-shaped. That would read as defensive and would silently break the vector.

## Only the name is validated

An empty *input* is a legitimate call — a tool may take no arguments — so validating it would reject valid work. `ShouldRunOnRunEvenIfInputIsEmptyAsync` pins that, and passes without any implementation change. It's there to keep someone from adding input validation later out of symmetry with the name.

## Two dependency tests, two routes

- a tool that **throws mid-execution**
- a tool asked for by a name the registry doesn't hold → `KeyNotFoundException`, because the broker indexes directly (#17)

Direction is *expected* to ask `HandlesAsync` first, but the foundation cannot rely on its caller doing so. It must categorise the miss rather than let a raw native escape upward.

## Two TryCatch overloads, deliberately different

| Overload | For | Dependency category? |
|---|---|---|
| `ValueTask<bool>` | `Handles` | **No** — reading a registry either answers or *we* are broken |
| `ValueTask<string>` | `Run` | **Yes** — it executes someone else's code |

Collapsing them into one generic `TryCatch` would force a single catch list onto both and blur that line.

The string overload's catch-all maps to **Dependency, not Service**: anything thrown inside `RunAsync` came out of a tool, and the tool is the dependency. Sending it to Service would blame the agent for someone else's bug.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 26, Total: 26**

Closes #29
