### PR TITLE
FOUNDATIONS: Generate

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.Exceptions.Generate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.Exceptions.Generate.cs
@@ -1,0 +1,211 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using RESTFulSense.Exceptions;
+using Standard.Agents.Models.Foundations.Brains.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Decision;
+
+public partial class BrainServiceTests
+{
+    // The endpoint is unreachable or inaccessible — configuration or infrastructure.
+    // Nothing retries these into working, so they log Critical.
+    public static TheoryData<Exception> CriticalDependencyExceptions() =>
+        new()
+        {
+            new HttpResponseUnauthorizedException(),
+            new HttpResponseForbiddenException(),
+            new HttpResponseNotFoundException(),
+            new HttpResponseUrlNotFoundException(),
+            new HttpRequestException()
+        };
+
+    // The endpoint answered, but badly. These may well succeed on retry, so they
+    // log Error — an operator paging on a 503 that cleared itself is noise.
+    public static TheoryData<Exception> DependencyExceptions() =>
+        new()
+        {
+            new HttpResponseInternalServerErrorException(),
+            new HttpResponseServiceUnavailableException()
+        };
+
+    [Theory]
+    [MemberData(nameof(CriticalDependencyExceptions))]
+    public async Task ShouldThrowCriticalDependencyExceptionOnGenerateIfCriticalErrorOccursAndLogItAsync(
+        Exception criticalDependencyException)
+    {
+        // given
+        string randomSystemPrompt = CreateRandomString();
+        string randomUserPrompt = CreateRandomString();
+
+        var failedBrainDependencyException =
+            new FailedBrainDependencyException(
+                message: "Failed brain dependency error occurred, contact support.",
+                innerException: criticalDependencyException);
+
+        var expectedBrainDependencyException =
+            new BrainDependencyException(
+                message: "Brain dependency error occurred, contact support.",
+                innerException: failedBrainDependencyException);
+
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateAsync(randomSystemPrompt, randomUserPrompt))
+                .ThrowsAsync(criticalDependencyException);
+
+        // when
+        ValueTask<string> generateTask =
+            this.brainService.GenerateAsync(randomSystemPrompt, randomUserPrompt);
+
+        BrainDependencyException actualBrainDependencyException =
+            await Assert.ThrowsAsync<BrainDependencyException>(
+                generateTask.AsTask);
+
+        // then
+        actualBrainDependencyException.Should()
+            .BeEquivalentTo(expectedBrainDependencyException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogCriticalAsync(It.Is(SameExceptionAs(
+                expectedBrainDependencyException))),
+                    Times.Once);
+
+        this.generatorBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [MemberData(nameof(DependencyExceptions))]
+    public async Task ShouldThrowDependencyExceptionOnGenerateIfDependencyErrorOccursAndLogItAsync(
+        Exception dependencyException)
+    {
+        // given
+        string randomSystemPrompt = CreateRandomString();
+        string randomUserPrompt = CreateRandomString();
+
+        var failedBrainDependencyException =
+            new FailedBrainDependencyException(
+                message: "Failed brain dependency error occurred, contact support.",
+                innerException: dependencyException);
+
+        var expectedBrainDependencyException =
+            new BrainDependencyException(
+                message: "Brain dependency error occurred, contact support.",
+                innerException: failedBrainDependencyException);
+
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateAsync(randomSystemPrompt, randomUserPrompt))
+                .ThrowsAsync(dependencyException);
+
+        // when
+        ValueTask<string> generateTask =
+            this.brainService.GenerateAsync(randomSystemPrompt, randomUserPrompt);
+
+        BrainDependencyException actualBrainDependencyException =
+            await Assert.ThrowsAsync<BrainDependencyException>(
+                generateTask.AsTask);
+
+        // then
+        actualBrainDependencyException.Should()
+            .BeEquivalentTo(expectedBrainDependencyException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedBrainDependencyException))),
+                    Times.Once);
+
+        this.generatorBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // A 400 means we sent a bad request — our fault, not the endpoint's. It is a
+    // DependencyValidation, which is why Brains carries a category Skills does not.
+    [Fact]
+    public async Task ShouldThrowDependencyValidationExceptionOnGenerateIfBadRequestErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomSystemPrompt = CreateRandomString();
+        string randomUserPrompt = CreateRandomString();
+        var badRequestException = new HttpResponseBadRequestException();
+
+        var invalidBrainException =
+            new InvalidBrainException(
+                message: "Invalid brain request. Please correct the error and try again.");
+
+        var expectedBrainDependencyValidationException =
+            new BrainDependencyValidationException(
+                message: "Brain dependency validation error occurred, fix the error and try again.",
+                innerException: invalidBrainException);
+
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateAsync(randomSystemPrompt, randomUserPrompt))
+                .ThrowsAsync(badRequestException);
+
+        // when
+        ValueTask<string> generateTask =
+            this.brainService.GenerateAsync(randomSystemPrompt, randomUserPrompt);
+
+        BrainDependencyValidationException actualBrainDependencyValidationException =
+            await Assert.ThrowsAsync<BrainDependencyValidationException>(
+                generateTask.AsTask);
+
+        // then
+        actualBrainDependencyValidationException.Should()
+            .BeEquivalentTo(expectedBrainDependencyValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedBrainDependencyValidationException))),
+                    Times.Once);
+
+        this.generatorBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnGenerateIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomSystemPrompt = CreateRandomString();
+        string randomUserPrompt = CreateRandomString();
+        var serviceException = new Exception();
+
+        var failedBrainServiceException =
+            new FailedBrainServiceException(
+                message: "Failed brain service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedBrainServiceException =
+            new BrainServiceException(
+                message: "Brain service error occurred, contact support.",
+                innerException: failedBrainServiceException);
+
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateAsync(randomSystemPrompt, randomUserPrompt))
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<string> generateTask =
+            this.brainService.GenerateAsync(randomSystemPrompt, randomUserPrompt);
+
+        BrainServiceException actualBrainServiceException =
+            await Assert.ThrowsAsync<BrainServiceException>(
+                generateTask.AsTask);
+
+        // then
+        actualBrainServiceException.Should()
+            .BeEquivalentTo(expectedBrainServiceException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedBrainServiceException))),
+                    Times.Once);
+
+        this.generatorBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.Exceptions.Generate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.Exceptions.Generate.cs
@@ -69,6 +69,10 @@ public partial class BrainServiceTests
         actualBrainDependencyException.Should()
             .BeEquivalentTo(expectedBrainDependencyException);
 
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateAsync(randomSystemPrompt, randomUserPrompt),
+                Times.Once);
+
         this.loggingBrokerMock.Verify(broker =>
             broker.LogCriticalAsync(It.Is(SameExceptionAs(
                 expectedBrainDependencyException))),
@@ -112,6 +116,10 @@ public partial class BrainServiceTests
         // then
         actualBrainDependencyException.Should()
             .BeEquivalentTo(expectedBrainDependencyException);
+
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateAsync(randomSystemPrompt, randomUserPrompt),
+                Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>
             broker.LogErrorAsync(It.Is(SameExceptionAs(
@@ -157,6 +165,10 @@ public partial class BrainServiceTests
         actualBrainDependencyValidationException.Should()
             .BeEquivalentTo(expectedBrainDependencyValidationException);
 
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateAsync(randomSystemPrompt, randomUserPrompt),
+                Times.Once);
+
         this.loggingBrokerMock.Verify(broker =>
             broker.LogErrorAsync(It.Is(SameExceptionAs(
                 expectedBrainDependencyValidationException))),
@@ -199,6 +211,10 @@ public partial class BrainServiceTests
         // then
         actualBrainServiceException.Should()
             .BeEquivalentTo(expectedBrainServiceException);
+
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateAsync(randomSystemPrompt, randomUserPrompt),
+                Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>
             broker.LogErrorAsync(It.Is(SameExceptionAs(

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.Logic.Generate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.Logic.Generate.cs
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Decision;
+
+public partial class BrainServiceTests
+{
+    [Fact]
+    public async Task ShouldGenerateAsync()
+    {
+        // given
+        string randomSystemPrompt = CreateRandomString();
+        string randomUserPrompt = CreateRandomString();
+        string randomReply = CreateRandomString();
+        string inputSystemPrompt = randomSystemPrompt;
+        string inputUserPrompt = randomUserPrompt;
+        string expectedReply = randomReply;
+
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateAsync(inputSystemPrompt, inputUserPrompt))
+                .ReturnsAsync(randomReply);
+
+        // when
+        string actualReply =
+            await this.brainService.GenerateAsync(inputSystemPrompt, inputUserPrompt);
+
+        // then
+        actualReply.Should().BeEquivalentTo(expectedReply);
+
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateAsync(inputSystemPrompt, inputUserPrompt),
+                Times.Once);
+
+        this.generatorBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // Invariant 7.2 — the Brain does not author prompts. Both prompts pass through
+    // untouched, exactly as Data supplied them. If this service ever prepends,
+    // trims, or templates anything, prompts stop being Data and this test fails.
+    [Fact]
+    public async Task ShouldPassPromptsThroughUnalteredOnGenerateAsync()
+    {
+        // given
+        string systemPromptWithFormatting = "  You are an agent.\n\nRules:\n- be terse  ";
+        string userPromptWithFormatting = "  what is 1+1?  ";
+        string randomReply = CreateRandomString();
+        string expectedReply = randomReply;
+
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateAsync(systemPromptWithFormatting, userPromptWithFormatting))
+                .ReturnsAsync(randomReply);
+
+        // when
+        string actualReply = await this.brainService.GenerateAsync(
+            systemPromptWithFormatting,
+            userPromptWithFormatting);
+
+        // then
+        actualReply.Should().BeEquivalentTo(expectedReply);
+
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateAsync(systemPromptWithFormatting, userPromptWithFormatting),
+                Times.Once);
+
+        this.generatorBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.Validations.Generate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.Validations.Generate.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Brains.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Decision;
+
+public partial class BrainServiceTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnGenerateIfUserPromptIsInvalidAndLogItAsync(
+        string invalidUserPrompt)
+    {
+        // given
+        string randomSystemPrompt = CreateRandomString();
+
+        var invalidBrainException =
+            new InvalidBrainException(
+                message: "Invalid brain input. Please correct the error and try again.");
+
+        var expectedBrainValidationException =
+            new BrainValidationException(
+                message: "Brain validation error occurred, fix the error and try again.",
+                innerException: invalidBrainException);
+
+        // when
+        ValueTask<string> generateTask =
+            this.brainService.GenerateAsync(randomSystemPrompt, invalidUserPrompt);
+
+        BrainValidationException actualBrainValidationException =
+            await Assert.ThrowsAsync<BrainValidationException>(
+                generateTask.AsTask);
+
+        // then
+        actualBrainValidationException.Should()
+            .BeEquivalentTo(expectedBrainValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedBrainValidationException))),
+                    Times.Once);
+
+        // Never spend an inference call on a prompt we already know is empty.
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.generatorBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // The system prompt is NOT validated. An agent with no skills configured has an
+    // empty system prompt and is still a legal agent — SPEC.md 8.1 lets Core run
+    // with Gate and Judge pass-through, and says nothing about requiring skills.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldGenerateOnGenerateEvenIfSystemPromptIsEmptyAsync(
+        string emptySystemPrompt)
+    {
+        // given
+        string randomUserPrompt = CreateRandomString();
+        string randomReply = CreateRandomString();
+        string expectedReply = randomReply;
+
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateAsync(emptySystemPrompt, randomUserPrompt))
+                .ReturnsAsync(randomReply);
+
+        // when
+        string actualReply =
+            await this.brainService.GenerateAsync(emptySystemPrompt, randomUserPrompt);
+
+        // then
+        actualReply.Should().BeEquivalentTo(expectedReply);
+
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateAsync(emptySystemPrompt, randomUserPrompt),
+                Times.Once);
+
+        this.generatorBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Decision;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Foundations.Decision;
+using Tynamix.ObjectFiller;
+using Xeptions;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Decision;
+
+public partial class BrainServiceTests
+{
+    private readonly Mock<IGeneratorBroker> generatorBrokerMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly IBrainService brainService;
+
+    public BrainServiceTests()
+    {
+        this.generatorBrokerMock = new Mock<IGeneratorBroker>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.brainService = new BrainService(
+            generatorBroker: this.generatorBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Brains.Exceptions;
+
+public class BrainDependencyException : Xeption
+{
+    public BrainDependencyException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainDependencyValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainDependencyValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Brains.Exceptions;
+
+public class BrainDependencyValidationException : Xeption
+{
+    public BrainDependencyValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Brains.Exceptions;
+
+public class BrainServiceException : Xeption
+{
+    public BrainServiceException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Brains.Exceptions;
+
+public class BrainValidationException : Xeption
+{
+    public BrainValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Brains/Exceptions/FailedBrainDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Brains/Exceptions/FailedBrainDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Brains.Exceptions;
+
+public class FailedBrainDependencyException : Xeption
+{
+    public FailedBrainDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Brains/Exceptions/FailedBrainServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Brains/Exceptions/FailedBrainServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Brains.Exceptions;
+
+public class FailedBrainServiceException : Xeption
+{
+    public FailedBrainServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Brains/Exceptions/InvalidBrainException.cs
+++ b/Standard.Agents/Models/Foundations/Brains/Exceptions/InvalidBrainException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Brains.Exceptions;
+
+public class InvalidBrainException : Xeption
+{
+    public InvalidBrainException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Services/Foundations/Decision/BrainService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Decision/BrainService.Exceptions.cs
@@ -1,0 +1,156 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using RESTFulSense.Exceptions;
+using Standard.Agents.Models.Foundations.Brains.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public partial class BrainService
+{
+    private delegate ValueTask<string> ReturningStringFunction();
+
+    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    {
+        try
+        {
+            return await returningStringFunction();
+        }
+        catch (InvalidBrainException invalidBrainException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidBrainException);
+        }
+        catch (HttpResponseBadRequestException httpResponseBadRequestException)
+        {
+            // A 400 means we sent something wrong — our fault, not the endpoint's.
+            var invalidBrainException =
+                new InvalidBrainException(
+                    message: "Invalid brain request. Please correct the error and try again.");
+
+            invalidBrainException.AddData(httpResponseBadRequestException.Data);
+
+            throw await CreateAndLogDependencyValidationExceptionAsync(invalidBrainException);
+        }
+        catch (HttpResponseUnauthorizedException httpResponseUnauthorizedException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseUnauthorizedException);
+        }
+        catch (HttpResponseForbiddenException httpResponseForbiddenException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseForbiddenException);
+        }
+        catch (HttpResponseNotFoundException httpResponseNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseNotFoundException);
+        }
+        catch (HttpResponseUrlNotFoundException httpResponseUrlNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseUrlNotFoundException);
+        }
+        catch (HttpResponseInternalServerErrorException httpResponseInternalServerErrorException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                httpResponseInternalServerErrorException);
+        }
+        catch (HttpResponseServiceUnavailableException httpResponseServiceUnavailableException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                httpResponseServiceUnavailableException);
+        }
+        catch (HttpRequestException httpRequestException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(httpRequestException);
+        }
+        catch (Exception exception)
+        {
+            var failedBrainServiceException =
+                new FailedBrainServiceException(
+                    message: "Failed brain service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedBrainServiceException);
+        }
+    }
+
+    private async ValueTask<BrainValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var brainValidationException =
+            new BrainValidationException(
+                message: "Brain validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(brainValidationException);
+
+        return brainValidationException;
+    }
+
+    private async ValueTask<BrainDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+        Xeption exception)
+    {
+        var brainDependencyValidationException =
+            new BrainDependencyValidationException(
+                message: "Brain dependency validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(brainDependencyValidationException);
+
+        return brainDependencyValidationException;
+    }
+
+    private async ValueTask<BrainDependencyException> CreateAndLogCriticalDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedBrainDependencyException =
+            new FailedBrainDependencyException(
+                message: "Failed brain dependency error occurred, contact support.",
+                innerException: exception);
+
+        var brainDependencyException =
+            new BrainDependencyException(
+                message: "Brain dependency error occurred, contact support.",
+                innerException: failedBrainDependencyException);
+
+        await this.loggingBroker.LogCriticalAsync(brainDependencyException);
+
+        return brainDependencyException;
+    }
+
+    private async ValueTask<BrainDependencyException> CreateAndLogDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedBrainDependencyException =
+            new FailedBrainDependencyException(
+                message: "Failed brain dependency error occurred, contact support.",
+                innerException: exception);
+
+        var brainDependencyException =
+            new BrainDependencyException(
+                message: "Brain dependency error occurred, contact support.",
+                innerException: failedBrainDependencyException);
+
+        await this.loggingBroker.LogErrorAsync(brainDependencyException);
+
+        return brainDependencyException;
+    }
+
+    private async ValueTask<BrainServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var brainServiceException =
+            new BrainServiceException(
+                message: "Brain service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(brainServiceException);
+
+        return brainServiceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Decision/BrainService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Decision/BrainService.Validations.cs
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Brains.Exceptions;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public partial class BrainService
+{
+    // Only the user prompt. An agent with no skills configured has an empty system
+    // prompt and is still a legal agent, so validating that would reject valid work.
+    private static void ValidateUserPrompt(string userPrompt)
+    {
+        if (string.IsNullOrWhiteSpace(userPrompt))
+        {
+            throw new InvalidBrainException(
+                message: "Invalid brain input. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Decision/BrainService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/BrainService.cs
@@ -23,6 +23,6 @@ public partial class BrainService : IBrainService
         this.loggingBroker = loggingBroker;
     }
 
-    public ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt) =>
-        throw new NotImplementedException();
+    public async ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt) =>
+        await this.generatorBroker.GenerateAsync(systemPrompt, userPrompt);
 }

--- a/Standard.Agents/Services/Foundations/Decision/BrainService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/BrainService.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Decision;
+using Standard.Agents.Brokers.Loggings;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+// The one reasoning engine — the singular waist of the hourglass. An agent has one
+// brain; multiplicity of brains is the fractal, not an intra-agent feature.
+public partial class BrainService : IBrainService
+{
+    private readonly IGeneratorBroker generatorBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public BrainService(
+        IGeneratorBroker generatorBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.generatorBroker = generatorBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt) =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents/Services/Foundations/Decision/BrainService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/BrainService.cs
@@ -23,6 +23,11 @@ public partial class BrainService : IBrainService
         this.loggingBroker = loggingBroker;
     }
 
-    public async ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt) =>
-        await this.generatorBroker.GenerateAsync(systemPrompt, userPrompt);
+    public ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt) =>
+    TryCatch(async () =>
+    {
+        ValidateUserPrompt(userPrompt);
+
+        return await this.generatorBroker.GenerateAsync(systemPrompt, userPrompt);
+    });
 }

--- a/Standard.Agents/Services/Foundations/Decision/IBrainService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/IBrainService.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public interface IBrainService
+{
+    ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt);
+}


### PR DESCRIPTION
The Brain — the one reasoning engine, and the **richest test surface in the codebase**. SPEC.md §4.2.

```csharp
ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt);
```

Theory Ch.5: *"An agent has **one brain**. Multiplicity of brains is not an intra-agent feature — it is the fractal."* The singular waist of the hourglass.

## Invariant §7.2 is under test, not just documented

`ShouldPassPromptsThroughUnalteredOnGenerateAsync` hands over prompts carrying deliberate leading whitespace, blank lines and trailing spaces, and asserts the broker receives them **byte-for-byte**.

That invariant — *prompts, rules and rubrics live in Data, never authored in Decision* — is easy to erode by accident and invisible once eroded. A `.Trim()` added for tidiness would look harmless and would quietly move prompt authorship out of Data and into Decision. **The test is the thing that says no.** It passes precisely because nothing was added; the absence of code is the feature.

## The full ladder — this is what RESTFulSense bought

The prior implementation called `EnsureSuccessStatusCode()`, so every one of these arrived as the same untyped `HttpRequestException` — **an expired API key and a momentary 503 were indistinguishable.**

| Native | Category | Log | Who's at fault / does waiting help? |
|---|---|---|---|
| `Unauthorized` `Forbidden` `NotFound` `UrlNotFound` `HttpRequest` | Dependency | **Critical** | endpoint unreachable/inaccessible — config or infra, nothing retries it into working |
| `InternalServerError` `ServiceUnavailable` | Dependency | Error | endpoint answered badly — may succeed on retry; paging on a self-clearing 503 is noise |
| `BadRequest` | **DependencyValidation** | Error | *we* sent something wrong — our fault, not theirs |

That last row is why **Brains ships seven exception models to Skills' four**: no file read has a "your request was malformed" equivalent.

`AddData` carries the 400's data dictionary onto the local exception, so detail from the endpoint survives categorisation instead of being dropped at the boundary.

## Only the user prompt is validated

An agent with **no skills configured has an empty system prompt and is still a legal agent** — SPEC.md §8.1 lets Core run with Gate and Judge pass-through and never requires skills. `ShouldGenerateOnGenerateEvenIfSystemPromptIsEmptyAsync` pins that. The user prompt *is* validated: there's no point spending an inference call on a prompt we already know is empty.

## A test bug worth naming

Four exception tests in the FAIL commit asserted `VerifyNoOtherCalls()` on the generator mock **without first verifying the `GenerateAsync` call they had provoked**. Moq counted the real invocation as unverified, so the tests failed on their own assertion rather than on the behaviour — the categorisation was correct from the first run.

The failure looked exactly like an implementation bug and wasn't. `VerifyNoOtherCalls` means *"nothing beyond what I verified"* — omitting the `Verify` doesn't relax the assertion, it inverts it. Fixed in the PASS commit.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 43, Total: 43**

**This completes the Core-profile foundations**: Skill (#21), Brain (#26), InternalTool (#28, #29), Return (#31) — exactly the set SPEC.md §8.1 requires.

Closes #26
