### PR TITLE
BROKERS: Classify

### DIFF
--- a/Standard.Agents/Brokers/Decision/ClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Decision/ClassifierBroker.cs
@@ -1,0 +1,106 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net.Http.Headers;
+using System.Text.Json;
+using RESTFulSense.Clients;
+
+namespace Standard.Agents.Brokers.Decision;
+
+// The Gate's substrate. Its own broker, its own configuration — so a deployment
+// that needs a guardian distinct from the Brain (invariant 7.6) points this at a
+// different model without touching anything else. SPEC.md 9 allows the substrate
+// to collapse onto one endpoint; the contracts stay separate either way.
+public sealed class ClassifierBroker : IClassifierBroker
+{
+    private const string ChatCompletionsRelativeUrl = "chat/completions";
+    private const string JsonMediaType = "application/json";
+
+    private static readonly JsonSerializerOptions jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly IRESTFulApiFactoryClient apiClient;
+    private readonly string model;
+    private readonly double temperature;
+    private readonly int maxTokens;
+
+    public ClassifierBroker(
+        string apiUrl,
+        string apiKey,
+        string model,
+        double temperature,
+        int maxTokens,
+        int timeoutSeconds)
+    {
+        var httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(apiUrl),
+            Timeout = TimeSpan.FromSeconds(timeoutSeconds)
+        };
+
+        httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", apiKey);
+
+        this.apiClient = new RESTFulApiFactoryClient(httpClient);
+        this.model = model;
+        this.temperature = temperature;
+        this.maxTokens = maxTokens;
+    }
+
+    public async ValueTask<string> ClassifyAsync(string systemPrompt, string input)
+    {
+        ChatCompletionRequest chatCompletionRequest = new(
+            Model: this.model,
+            Messages:
+            [
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", input)
+            ],
+            Stream: false,
+            Temperature: this.temperature,
+            MaxTokens: this.maxTokens);
+
+        ChatCompletionResponse chatCompletionResponse =
+            await PostAsync<ChatCompletionRequest, ChatCompletionResponse>(
+                ChatCompletionsRelativeUrl,
+                chatCompletionRequest);
+
+        // Returned verbatim. Reading the label is GateService's job — deciding what
+        // "refuse" means is a business decision and does not belong in a broker.
+        return chatCompletionResponse.Choices[0].Message.Content;
+    }
+
+    private async ValueTask<TResult> PostAsync<TContent, TResult>(
+        string relativeUrl,
+        TContent content) =>
+        await this.apiClient.PostContentAsync<TContent, TResult>(
+            relativeUrl,
+            content,
+            mediaType: JsonMediaType,
+            serializationFunction: value =>
+                ValueTask.FromResult(JsonSerializer.Serialize(value, jsonOptions)),
+            deserializationFunction: json =>
+                ValueTask.FromResult(JsonSerializer.Deserialize<TResult>(json, jsonOptions)!));
+
+    private sealed record ChatCompletionRequest(
+        string Model,
+        IReadOnlyList<ChatMessage> Messages,
+        bool Stream,
+        double Temperature,
+        int MaxTokens);
+
+    private sealed record ChatMessage(
+        string Role,
+        string Content);
+
+    private sealed record ChatCompletionResponse(
+        IReadOnlyList<ChatChoice> Choices);
+
+    private sealed record ChatChoice(
+        ChatMessage Message);
+}

--- a/Standard.Agents/Brokers/Decision/IClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Decision/IClassifierBroker.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Decision;
+
+public interface IClassifierBroker
+{
+    ValueTask<string> ClassifyAsync(string systemPrompt, string input);
+}


### PR DESCRIPTION
The Gate's substrate — **a real liaison to a real classifier**. SPEC.md §4.1.

```csharp
ValueTask<string> ClassifyAsync(string systemPrompt, string input);
```

Returns a **label**. Theory Ch.5: the three Decision brokers are interfaces distinguished by output shape — a label (classify), text (generate), a score (judge).

## Per the #50 decision: a configurable default, not a stub

The prior version was:

```csharp
public ValueTask<string> ClassifyAsync(string systemPrompt, string input) =>
    ValueTask.FromResult("allow");        // liaises with nothing
```

That isn't a placeholder, it's a **security shape**. A Gate that always allows is not a guardian. Theory Ch.9: *"A heretic brain with no guardian is running as root with no permission checks."* Shipping it as the default was worth killing.

## Why its own broker and its own config

Configurable: `apiUrl`, `apiKey`, `model`, `temperature`, `maxTokens`, `timeoutSeconds`.

That's what makes **invariant §7.6 reachable** — a deployment needing a guardian distinct from the Brain points this at a different model and touches nothing else. SPEC.md §9 allows the substrate to collapse onto one endpoint (*"back the three Decision brokers with one inference endpoint"*); the contracts stay separate either way. Theory Ch.5: **three interfaces, collapsible substrate**.

## The label is returned verbatim

Reading it is `GateService`'s job. Deciding what `"refuse"` means is a business decision and has no place in a broker (§4.1: no business flow control).

## On the duplication with GeneratorBroker — it's deliberate

The HTTP plumbing and wire DTOs are near-identical, and stay that way. Extracting a shared `HttpPoster` or a base broker is precisely the entanglement The Standard rejects — **no Utils, no Commons, no local base components**. Duplication is permitted where it preserves autonomy, and it does: swapping this broker's transport must not touch the Brain's.

If this looks like something to DRY on review, that's the rule saying no.

## Verification

`dotnet build` → Build succeeded, 0 Error(s). No unit tests: thin broker, no logic.

Closes #13
