### PR TITLE
BROKERS: Verify

### DIFF
--- a/Standard.Agents/Brokers/Decision/IVerifierBroker.cs
+++ b/Standard.Agents/Brokers/Decision/IVerifierBroker.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Decision;
+
+public interface IVerifierBroker
+{
+    ValueTask<double> VerifyAsync(string systemPrompt, string candidate);
+}

--- a/Standard.Agents/Brokers/Decision/VerifierBroker.cs
+++ b/Standard.Agents/Brokers/Decision/VerifierBroker.cs
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using RESTFulSense.Clients;
+
+namespace Standard.Agents.Brokers.Decision;
+
+// The Judge's substrate. Separately configured from the Brain so a deployment can
+// honour invariant 7.6 — no self-certification — without touching the library.
+public sealed class VerifierBroker : IVerifierBroker
+{
+    private const string ChatCompletionsRelativeUrl = "chat/completions";
+    private const string JsonMediaType = "application/json";
+
+    private static readonly JsonSerializerOptions jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly IRESTFulApiFactoryClient apiClient;
+    private readonly string model;
+    private readonly double temperature;
+    private readonly int maxTokens;
+
+    public VerifierBroker(
+        string apiUrl,
+        string apiKey,
+        string model,
+        double temperature,
+        int maxTokens,
+        int timeoutSeconds)
+    {
+        var httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(apiUrl),
+            Timeout = TimeSpan.FromSeconds(timeoutSeconds)
+        };
+
+        httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", apiKey);
+
+        this.apiClient = new RESTFulApiFactoryClient(httpClient);
+        this.model = model;
+        this.temperature = temperature;
+        this.maxTokens = maxTokens;
+    }
+
+    public async ValueTask<double> VerifyAsync(string systemPrompt, string candidate)
+    {
+        ChatCompletionRequest chatCompletionRequest = new(
+            Model: this.model,
+            Messages:
+            [
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", candidate)
+            ],
+            Stream: false,
+            Temperature: this.temperature,
+            MaxTokens: this.maxTokens);
+
+        ChatCompletionResponse chatCompletionResponse =
+            await PostAsync<ChatCompletionRequest, ChatCompletionResponse>(
+                ChatCompletionsRelativeUrl,
+                chatCompletionRequest);
+
+        return ToScore(chatCompletionResponse.Choices[0].Message.Content);
+    }
+
+    // Constructing the declared native from the wire's primitive — a broker's job.
+    // Unparseable text throws FormatException; JudgeService localizes it. Coercing a
+    // bad score to 0.0 or 1.0 here would be the broker inventing a verdict, and a
+    // fabricated 1.0 would silently approve output no judge ever passed.
+    // Range is NOT enforced here: that is a rule, and rules live in JudgeService.
+    private static double ToScore(string content) =>
+        double.Parse(
+            content.Trim(),
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture);
+
+    private async ValueTask<TResult> PostAsync<TContent, TResult>(
+        string relativeUrl,
+        TContent content) =>
+        await this.apiClient.PostContentAsync<TContent, TResult>(
+            relativeUrl,
+            content,
+            mediaType: JsonMediaType,
+            serializationFunction: value =>
+                ValueTask.FromResult(JsonSerializer.Serialize(value, jsonOptions)),
+            deserializationFunction: json =>
+                ValueTask.FromResult(JsonSerializer.Deserialize<TResult>(json, jsonOptions)!));
+
+    private sealed record ChatCompletionRequest(
+        string Model,
+        IReadOnlyList<ChatMessage> Messages,
+        bool Stream,
+        double Temperature,
+        int MaxTokens);
+
+    private sealed record ChatMessage(
+        string Role,
+        string Content);
+
+    private sealed record ChatCompletionResponse(
+        IReadOnlyList<ChatChoice> Choices);
+
+    private sealed record ChatChoice(
+        ChatMessage Message);
+}


### PR DESCRIPTION
The Judge's substrate — **a real liaison to a real verifier**. SPEC.md §4.1.

```csharp
ValueTask<double> VerifyAsync(string systemPrompt, string candidate);
```

Returns a **score**, normatively 0.0–1.0.

## Per the #50 decision: a configurable default, not a stub

The prior version returned a hardcoded `1.0` — **every draft passed**. Invariant §7.5 says output must not cross a boundary un-vetted; a judge that always returns 1.0 vets nothing while looking like it does.

Separately configured from the Brain, which is what lets a deployment honour **invariant §7.6** — no self-certification, the guardian must not be the Brain.

## `ToScore` — three decisions worth stating

Parsing the model's text into the declared `double` is a broker **constructing natives from primitives**, not flow control.

**1. Unparseable text throws.** `FormatException` propagates and `JudgeService` localizes it. Coercing a bad score to `0.0` or `1.0` here would be the broker *inventing a verdict* — and a fabricated `1.0` would **silently approve output no judge ever passed**. Failing loudly is the only safe reading.

**2. `InvariantCulture`, explicitly.** Under a comma-decimal locale, `"0.85"` would otherwise parse to **85** — a rejected draft sailing through as wildly passing. A guardian whose verdict depends on the host's regional settings is not a guardian. This is the kind of bug that only shows up in production, in one region.

**3. Range is not enforced here.** 0.0–1.0 is a *rule*, and rules live in `JudgeService` (#27), which validates outgoing data it uses. A broker with no flow control cannot enforce a range.

## Duplication with Generator/Classifier is deliberate

Same reasoning as #13 — extracting shared HTTP plumbing would be the entanglement The Standard rejects. Duplication preserves autonomy.

## Verification

`dotnet build` → Build succeeded, 0 Error(s). No unit tests: thin broker, no logic.

**This completes the three Decision brokers** — three interfaces, collapsible substrate (Theory Ch.5).

Closes #15
