### PR TITLE
BROKERS: Select Memories

### DIFF
--- a/Standard.Agents/Brokers/Data/IMemoryBroker.cs
+++ b/Standard.Agents/Brokers/Data/IMemoryBroker.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Data;
+
+public interface IMemoryBroker
+{
+    ValueTask<IReadOnlyList<string>> SelectMemoriesAsync();
+}

--- a/Standard.Agents/Brokers/Data/MemoryBroker.cs
+++ b/Standard.Agents/Brokers/Data/MemoryBroker.cs
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Data;
+
+// A durable store that outlives the agent instance. Theory Ch.7: the agent is
+// ephemeral compute; memory is a durable, external resource. Swap this for a
+// database or a vector store via IMemoryBroker — the file is the default, not the
+// design.
+//
+// One memory per line, so a read is a read and an append is an append. A JSON
+// document would need a full parse-and-rewrite to add one entry, turning every
+// write into a chance to lose the file.
+public sealed class MemoryBroker : IMemoryBroker
+{
+    private readonly string memoryPath;
+
+    public MemoryBroker(string memoryPath)
+    {
+        this.memoryPath = Path.GetFullPath(memoryPath);
+
+        // The broker owns its resource, which includes bringing it into existence —
+        // the same reason StorageBroker calls Database.Migrate() in its constructor.
+        // Doing it here keeps the read path free of an existence check, which would
+        // be flow control a broker is not allowed to have.
+        EnsureStoreExists(this.memoryPath);
+    }
+
+    public async ValueTask<IReadOnlyList<string>> SelectMemoriesAsync() =>
+        await File.ReadAllLinesAsync(this.memoryPath);
+
+    private static void EnsureStoreExists(string memoryPath)
+    {
+        string directoryPath = Path.GetDirectoryName(memoryPath)!;
+
+        Directory.CreateDirectory(directoryPath);
+
+        // Create-if-absent without truncating an existing store. `new FileStream`
+        // with OpenOrCreate would leave the file open; File.AppendAllText of nothing
+        // is the shortest honest way to say "make sure this exists, change nothing".
+        File.AppendAllText(memoryPath, string.Empty);
+    }
+}


### PR DESCRIPTION
The liaison to the durable memory store, read side. SPEC.md §4.1.

```csharp
ValueTask<IReadOnlyList<string>> SelectMemoriesAsync();
```

## Per the #50 decision: a configurable default, not a stub

The prior version returned a hardcoded `[]` and liaised with nothing.

Theory Ch.7 sets the shape: *"The agent instance is ephemeral compute. Memory is a durable, external resource."* A file is the **default, not the design** — swap for a database or vector store via `IMemoryBroker`.

## One memory per line

A JSON document would need a full parse-and-rewrite to add a single entry, turning **every write into a chance to lose the file**. Line-based means a read is a read and an append is an append.

## Why the constructor ensures the store exists

The obvious version is:

```csharp
if (File.Exists(this.memoryPath) is false) return [];    // flow control
```

But **a broker may not contain flow control** (§4.1, The Standard §1). So instead the constructor brings the resource into existence and the read path becomes a bare `ReadAllLinesAsync`.

There's direct precedent: The Standard's own `StorageBroker` calls `Database.Migrate()` **in its constructor**. Ensuring the resource exists is part of owning the resource.

## `EnsureStoreExists` is verified non-destructive

Getting this wrong loses user data silently, so I checked it rather than assumed:

```
absent             -> created, 0 lines
existing 2 lines   -> re-run constructor -> still 2 lines, content intact
```

`File.AppendAllText(path, "")` creates-if-absent **without truncating**. The tempting alternatives are both wrong: `new FileStream(OpenOrCreate)` leaves a handle open, and `File.Create` / `WriteAllText` would **erase every memory the agent had, on every startup**.

## Verification

`dotnet build` → Build succeeded, 0 Error(s). Constructor behaviour verified out-of-band (above). No unit tests: thin broker, no logic.

Closes #10
