### PR TITLE
BROKERS: Insert Memory

### DIFF
--- a/Standard.Agents/Brokers/Data/IMemoryBroker.cs
+++ b/Standard.Agents/Brokers/Data/IMemoryBroker.cs
@@ -8,4 +8,6 @@ namespace Standard.Agents.Brokers.Data;
 public interface IMemoryBroker
 {
     ValueTask<IReadOnlyList<string>> SelectMemoriesAsync();
+
+    ValueTask InsertMemoryAsync(string memory);
 }

--- a/Standard.Agents/Brokers/Data/MemoryBroker.cs
+++ b/Standard.Agents/Brokers/Data/MemoryBroker.cs
@@ -31,6 +31,12 @@ public sealed class MemoryBroker : IMemoryBroker
     public async ValueTask<IReadOnlyList<string>> SelectMemoriesAsync() =>
         await File.ReadAllLinesAsync(this.memoryPath);
 
+    // Append, never rewrite — the store only grows. Forgetting is a business
+    // decision and would arrive as its own routine, not as a side effect of
+    // remembering.
+    public async ValueTask InsertMemoryAsync(string memory) =>
+        await File.AppendAllLinesAsync(this.memoryPath, [memory]);
+
     private static void EnsureStoreExists(string memoryPath)
     {
         string directoryPath = Path.GetDirectoryName(memoryPath)!;


### PR DESCRIPTION
The liaison to the durable memory store, write side. SPEC.md §4.1.

```csharp
ValueTask InsertMemoryAsync(string memory);
```

## Per the #50 decision: a configurable default, not a stub

The prior version was `ValueTask.CompletedTask` — it accepted a memory and **dropped it**. An agent could call Remember all day and remember nothing.

## Append, never rewrite

The store only grows. **Forgetting is a business decision** and would arrive as its own routine, not as a side effect of remembering. A broker that pruned or deduplicated while writing would be deciding what's worth keeping — not a broker's call (§4.1: no business flow control).

## `AppendAllLinesAsync`, not `AppendAllTextAsync` + `"\n"`

It handles the line terminator itself, so a memory **cannot silently merge into the previous one** if a caller passes text without a trailing newline. Line integrity is the store's whole contract — `SelectMemoriesAsync` (#10) reads it back by line, and one malformed write would corrupt two memories at once.

## Invariant §7.4 governs the call site, not this file

*"Persistent memory MUST live outside the agent — recalled by Data, written by Direction."*

`MemoryService` (#23) exposes this as the Data-side abstraction, but the **write is invoked from Direction** (#34). Worth keeping straight when wiring the orchestrations.

## Verification

`dotnet build` → Build succeeded, 0 Error(s). No unit tests: thin broker, no logic.

Closes #11
