### PR TITLE
BROKERS: Select Knowledge

### DIFF
--- a/Standard.Agents/Brokers/Data/IKnowledgeBroker.cs
+++ b/Standard.Agents/Brokers/Data/IKnowledgeBroker.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Data;
+
+public interface IKnowledgeBroker
+{
+    ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query);
+}

--- a/Standard.Agents/Brokers/Data/KnowledgeBroker.cs
+++ b/Standard.Agents/Brokers/Data/KnowledgeBroker.cs
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Data;
+
+// Knowledge is what the agent can look up now — Theory Ch.5. The resource here is
+// a documents directory, and the index is the filesystem.
+//
+// This is the default, not the design. A real deployment points IKnowledgeBroker at
+// a vector store or a search API. The point of shipping a working one is that
+// "retrieved content is Data" stays a real path rather than a claim: an agent with
+// documents on disk genuinely retrieves, and swapping in embeddings changes the
+// broker and nothing else.
+public sealed class KnowledgeBroker : IKnowledgeBroker
+{
+    private readonly string knowledgePath;
+    private readonly string searchPattern;
+    private readonly int maxResults;
+
+    public KnowledgeBroker(
+        string knowledgePath,
+        string searchPattern,
+        int maxResults)
+    {
+        this.knowledgePath = Path.GetFullPath(knowledgePath);
+        this.searchPattern = searchPattern;
+        this.maxResults = maxResults;
+
+        // The broker owns its resource, so it brings it into existence — the same
+        // reason StorageBroker calls Database.Migrate() in its constructor. It also
+        // keeps the read path free of an existence check, which would be flow control.
+        Directory.CreateDirectory(this.knowledgePath);
+    }
+
+    public async ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query)
+    {
+        List<string> matches = [];
+
+        IOrderedEnumerable<string> documentPaths =
+            Directory.EnumerateFiles(
+                this.knowledgePath,
+                this.searchPattern,
+                SearchOption.AllDirectories)
+                    .OrderBy(documentPath => documentPath, StringComparer.Ordinal);
+
+        foreach (string documentPath in documentPaths)
+        {
+            string document = await File.ReadAllTextAsync(documentPath);
+
+            // Substring matching is the honest limit of a filesystem index. It is
+            // not semantic and does not pretend to be — that is what swapping the
+            // broker for a vector store buys.
+            if (document.Contains(query, StringComparison.OrdinalIgnoreCase))
+            {
+                matches.Add(document);
+            }
+
+            if (matches.Count == this.maxResults)
+            {
+                break;
+            }
+        }
+
+        return matches;
+    }
+}


### PR DESCRIPTION
The liaison to the retrieval index. SPEC.md §4.1.

```csharp
ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query);
```

Theory Ch.5: Knowledge is *"what I can look up now."*

## Per the #50 decision: a configurable default, not a stub

The prior version returned `[]`, and the theory doc still lists Knowledge under *"theory until wired."* **It's wired now.**

The resource is a **documents directory**; the index is the filesystem. Configurable: `knowledgePath`, `searchPattern`, `maxResults`.

## This is the default, not the design

A real deployment points `IKnowledgeBroker` at a vector store or a search API. The reason to ship a working one anyway: **"retrieved content is Data" stays a real path rather than a claim.** An agent with documents on disk genuinely retrieves, and swapping in embeddings changes this broker and nothing else.

**Substring matching is the honest limit of a filesystem index.** It is not semantic and does not pretend to be — that's stated in a comment, because a reader who assumed semantic search here would trust recall this cannot deliver.

## Grey area, stated rather than hidden

`document.Contains(query)` and the `maxResults` break are technically `if`s inside a broker, which §4.1 forbids for *business* decisions.

My reading: these are **this resource's query semantics — the `WHERE` and the `LIMIT`** — not business decisions. A SQL broker gets both from the database for free; a filesystem has no query engine, so a broker for a queryless resource has to express them in code.

What is deliberately **not** here: any judgement about relevance, ranking, or whether a hit is worth returning. That would be business logic and belongs to `KnowledgeService` (#24).

Flagging it because it's arguable, and I'd rather it be argued than assumed.

## Constructor creates the directory

Keeps an existence check out of the read path — same reasoning as `MemoryBroker` (#10) and The Standard's `StorageBroker` calling `Database.Migrate()` in its constructor. Owning the resource includes bringing it into existence.

## Verification

`dotnet build` → Build succeeded, 0 Error(s). No unit tests: thin broker, no logic.

Closes #12
