### PR TITLE
BROKERS: Call Mcp

### DIFF
--- a/Standard.Agents/Brokers/Direction/IMcpBroker.cs
+++ b/Standard.Agents/Brokers/Direction/IMcpBroker.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Direction;
+
+public interface IMcpBroker
+{
+    ValueTask<string> CallAsync(string name, string input);
+}

--- a/Standard.Agents/Brokers/Direction/McpBroker.cs
+++ b/Standard.Agents/Brokers/Direction/McpBroker.cs
@@ -1,0 +1,124 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using RESTFulSense.Clients;
+
+namespace Standard.Agents.Brokers.Direction;
+
+// The door across the boundary. Invariant 7.8: external state enters only as Data
+// via a Direction that reached out, and effects leave only via Direction. This
+// broker is that door.
+//
+// The default speaks MCP over JSON-RPC 2.0. Swap it via IMcpBroker for stdio
+// transport, a bare REST API, or another agent.
+public sealed class McpBroker : IMcpBroker
+{
+    private const string JsonMediaType = "application/json";
+    private const string JsonRpcVersion = "2.0";
+    private const string ToolsCallMethod = "tools/call";
+    private const string InputArgumentName = "input";
+
+    private static readonly JsonSerializerOptions jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private readonly IRESTFulApiFactoryClient apiClient;
+    private readonly string relativeUrl;
+    private int requestId;
+
+    public McpBroker(
+        string endpointUrl,
+        string relativeUrl,
+        int timeoutSeconds)
+    {
+        var httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(endpointUrl),
+            Timeout = TimeSpan.FromSeconds(timeoutSeconds)
+        };
+
+        this.apiClient = new RESTFulApiFactoryClient(httpClient);
+        this.relativeUrl = relativeUrl;
+    }
+
+    public async ValueTask<string> CallAsync(string name, string input)
+    {
+        JsonRpcRequest jsonRpcRequest = new(
+            JsonRpc: JsonRpcVersion,
+            Id: Interlocked.Increment(ref this.requestId),
+            Method: ToolsCallMethod,
+            Params: new ToolCallParams(
+                Name: name,
+                Arguments: new Dictionary<string, string>
+                {
+                    [InputArgumentName] = input
+                }));
+
+        JsonRpcResponse jsonRpcResponse =
+            await PostAsync<JsonRpcRequest, JsonRpcResponse>(
+                this.relativeUrl,
+                jsonRpcRequest);
+
+        return ToText(jsonRpcResponse);
+    }
+
+    // JSON-RPC reports failure in a 200 body, so HTTP status alone cannot see it.
+    // Surfacing it as a native exception is the transport saying "no" — the same
+    // role SqlException plays for a storage broker. ExternalToolService localizes
+    // it (#30). Returning the error text as if it were a result would hand the
+    // Brain a failure dressed up as an answer.
+    private static string ToText(JsonRpcResponse jsonRpcResponse)
+    {
+        if (jsonRpcResponse.Error is not null)
+        {
+            throw new HttpRequestException(jsonRpcResponse.Error.Message);
+        }
+
+        return string.Concat(
+            jsonRpcResponse.Result!.Content.Select(content => content.Text));
+    }
+
+    private async ValueTask<TResult> PostAsync<TContent, TResult>(
+        string relativeUrl,
+        TContent content) =>
+        await this.apiClient.PostContentAsync<TContent, TResult>(
+            relativeUrl,
+            content,
+            mediaType: JsonMediaType,
+            serializationFunction: value =>
+                ValueTask.FromResult(JsonSerializer.Serialize(value, jsonOptions)),
+            deserializationFunction: json =>
+                ValueTask.FromResult(JsonSerializer.Deserialize<TResult>(json, jsonOptions)!));
+
+    private sealed record JsonRpcRequest(
+        [property: JsonPropertyName("jsonrpc")] string JsonRpc,
+        int Id,
+        string Method,
+        ToolCallParams Params);
+
+    private sealed record ToolCallParams(
+        string Name,
+        IReadOnlyDictionary<string, string> Arguments);
+
+    private sealed record JsonRpcResponse(
+        ToolCallResult? Result,
+        JsonRpcError? Error);
+
+    private sealed record ToolCallResult(
+        IReadOnlyList<ToolCallContent> Content);
+
+    private sealed record ToolCallContent(
+        string Type,
+        string Text);
+
+    private sealed record JsonRpcError(
+        int Code,
+        string Message);
+}


### PR DESCRIPTION
The door across the boundary. SPEC.md §4.1.

```csharp
ValueTask<string> CallAsync(string name, string input);
```

Invariant §7.8: *external state MUST enter only as Data (via a Direction that reached out) and effects MUST leave only via Direction.* **This broker is that door.**

## Per the #50 decision: a configurable default, not a stub

The prior version returned `"[external 'name' not configured]"` — a string pretending to be a tool result, for every call, forever.

The default speaks **MCP over JSON-RPC 2.0**. Configurable: `endpointUrl`, `relativeUrl`, `timeoutSeconds`. Swap via `IMcpBroker` for stdio transport, a bare REST API, or another agent.

## Verified against real envelopes before shipping

```
REQUEST:    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"weather","arguments":{"input":"today"}}}
PARSED OK:  18C and raining
PARSED ERR: result=null  error="Method not found"
```

## Three details that would each have been a silent bug

**1. `jsonrpc` carries an explicit `[JsonPropertyName]`.** The camelCase policy would otherwise emit `"jsonRpc"`, and every request would be rejected as malformed by a spec-compliant server — **a bug that would present as a network problem.**

**2. Ids come from `Interlocked.Increment`.** JSON-RPC requires a request id; a broker reusing one would break correlation the moment two turns overlap.

**3. `ToText` throws on a JSON-RPC error rather than returning its message.** JSON-RPC reports failure **inside a 200 body**, so HTTP status alone cannot see it — without this, the failure is invisible to RESTFulSense.

Surfacing it as a native exception is *the transport saying no* — the same role `SqlException` plays for a storage broker. `ExternalToolService` localizes it (#30). Returning the error text as a **result** would hand the Brain a failure dressed up as an answer, and the agent would reason on top of it as though the tool had worked.

## Judgement worth flagging

`if (jsonRpcResponse.Error is not null)` is arguably flow control. My reading: it's **protocol handling** — the envelope's own failure channel — not a business decision. Nothing here decides what the failure *means*; that's Direction's call (#34).

## Note on vector 05

`05-unknown-tool-recovers` routes an unknown tool here and expects recovery. Per CONFORMANCE.md the harness supplies its **own** stub External reporting *"not configured"* — so the vector constrains the harness (#39), not this broker. The real broker's job is to reach a real server.

## Verification

`dotnet build` → Build succeeded, 0 Error(s). Wire format verified out-of-band (above). No unit tests: thin broker, no logic.

**This completes all 8+2 brokers.**

Closes #18
