### PR TITLE
FOUNDATIONS: Screen

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/GateServiceTests.Exceptions.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/GateServiceTests.Exceptions.Screen.cs
@@ -1,0 +1,224 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using RESTFulSense.Exceptions;
+using Standard.Agents.Models.Foundations.Gates.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Decision;
+
+public partial class GateServiceTests
+{
+    public static TheoryData<Exception> CriticalDependencyExceptions() =>
+        new()
+        {
+            new HttpResponseUnauthorizedException(),
+            new HttpResponseForbiddenException(),
+            new HttpResponseNotFoundException(),
+            new HttpResponseUrlNotFoundException(),
+            new HttpRequestException()
+        };
+
+    public static TheoryData<Exception> DependencyExceptions() =>
+        new()
+        {
+            new HttpResponseInternalServerErrorException(),
+            new HttpResponseServiceUnavailableException()
+        };
+
+    // A guardian that cannot reach its classifier MUST throw, never return "allow".
+    // Failing open here would mean an unreachable endpoint silently disables
+    // screening — the agent would look healthy while running unguarded.
+    [Theory]
+    [MemberData(nameof(CriticalDependencyExceptions))]
+    public async Task ShouldThrowCriticalDependencyExceptionOnScreenIfCriticalErrorOccursAndLogItAsync(
+        Exception criticalDependencyException)
+    {
+        // given
+        string randomGatePrompt = CreateRandomString();
+        string randomInput = CreateRandomString();
+
+        var failedGateDependencyException =
+            new FailedGateDependencyException(
+                message: "Failed gate dependency error occurred, contact support.",
+                innerException: criticalDependencyException);
+
+        var expectedGateDependencyException =
+            new GateDependencyException(
+                message: "Gate dependency error occurred, contact support.",
+                innerException: failedGateDependencyException);
+
+        this.classifierBrokerMock.Setup(broker =>
+            broker.ClassifyAsync(randomGatePrompt, randomInput))
+                .ThrowsAsync(criticalDependencyException);
+
+        // when
+        ValueTask<string> screenTask =
+            this.gateService.ScreenAsync(randomGatePrompt, randomInput);
+
+        GateDependencyException actualGateDependencyException =
+            await Assert.ThrowsAsync<GateDependencyException>(
+                screenTask.AsTask);
+
+        // then
+        actualGateDependencyException.Should()
+            .BeEquivalentTo(expectedGateDependencyException);
+
+        this.classifierBrokerMock.Verify(broker =>
+            broker.ClassifyAsync(randomGatePrompt, randomInput),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogCriticalAsync(It.Is(SameExceptionAs(
+                expectedGateDependencyException))),
+                    Times.Once);
+
+        this.classifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [MemberData(nameof(DependencyExceptions))]
+    public async Task ShouldThrowDependencyExceptionOnScreenIfDependencyErrorOccursAndLogItAsync(
+        Exception dependencyException)
+    {
+        // given
+        string randomGatePrompt = CreateRandomString();
+        string randomInput = CreateRandomString();
+
+        var failedGateDependencyException =
+            new FailedGateDependencyException(
+                message: "Failed gate dependency error occurred, contact support.",
+                innerException: dependencyException);
+
+        var expectedGateDependencyException =
+            new GateDependencyException(
+                message: "Gate dependency error occurred, contact support.",
+                innerException: failedGateDependencyException);
+
+        this.classifierBrokerMock.Setup(broker =>
+            broker.ClassifyAsync(randomGatePrompt, randomInput))
+                .ThrowsAsync(dependencyException);
+
+        // when
+        ValueTask<string> screenTask =
+            this.gateService.ScreenAsync(randomGatePrompt, randomInput);
+
+        GateDependencyException actualGateDependencyException =
+            await Assert.ThrowsAsync<GateDependencyException>(
+                screenTask.AsTask);
+
+        // then
+        actualGateDependencyException.Should()
+            .BeEquivalentTo(expectedGateDependencyException);
+
+        this.classifierBrokerMock.Verify(broker =>
+            broker.ClassifyAsync(randomGatePrompt, randomInput),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedGateDependencyException))),
+                    Times.Once);
+
+        this.classifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowDependencyValidationExceptionOnScreenIfBadRequestErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomGatePrompt = CreateRandomString();
+        string randomInput = CreateRandomString();
+        var badRequestException = new HttpResponseBadRequestException();
+
+        var invalidGateException =
+            new InvalidGateException(
+                message: "Invalid gate request. Please correct the error and try again.");
+
+        var expectedGateDependencyValidationException =
+            new GateDependencyValidationException(
+                message: "Gate dependency validation error occurred, fix the error and try again.",
+                innerException: invalidGateException);
+
+        this.classifierBrokerMock.Setup(broker =>
+            broker.ClassifyAsync(randomGatePrompt, randomInput))
+                .ThrowsAsync(badRequestException);
+
+        // when
+        ValueTask<string> screenTask =
+            this.gateService.ScreenAsync(randomGatePrompt, randomInput);
+
+        GateDependencyValidationException actualGateDependencyValidationException =
+            await Assert.ThrowsAsync<GateDependencyValidationException>(
+                screenTask.AsTask);
+
+        // then
+        actualGateDependencyValidationException.Should()
+            .BeEquivalentTo(expectedGateDependencyValidationException);
+
+        this.classifierBrokerMock.Verify(broker =>
+            broker.ClassifyAsync(randomGatePrompt, randomInput),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedGateDependencyValidationException))),
+                    Times.Once);
+
+        this.classifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnScreenIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomGatePrompt = CreateRandomString();
+        string randomInput = CreateRandomString();
+        var serviceException = new Exception();
+
+        var failedGateServiceException =
+            new FailedGateServiceException(
+                message: "Failed gate service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedGateServiceException =
+            new GateServiceException(
+                message: "Gate service error occurred, contact support.",
+                innerException: failedGateServiceException);
+
+        this.classifierBrokerMock.Setup(broker =>
+            broker.ClassifyAsync(randomGatePrompt, randomInput))
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<string> screenTask =
+            this.gateService.ScreenAsync(randomGatePrompt, randomInput);
+
+        GateServiceException actualGateServiceException =
+            await Assert.ThrowsAsync<GateServiceException>(
+                screenTask.AsTask);
+
+        // then
+        actualGateServiceException.Should()
+            .BeEquivalentTo(expectedGateServiceException);
+
+        this.classifierBrokerMock.Verify(broker =>
+            broker.ClassifyAsync(randomGatePrompt, randomInput),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedGateServiceException))),
+                    Times.Once);
+
+        this.classifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/GateServiceTests.Logic.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/GateServiceTests.Logic.Screen.cs
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Decision;
+
+public partial class GateServiceTests
+{
+    [Fact]
+    public async Task ShouldScreenAsync()
+    {
+        // given
+        string randomGatePrompt = CreateRandomString();
+        string randomInput = CreateRandomString();
+        string randomVerdict = CreateRandomString();
+        string inputGatePrompt = randomGatePrompt;
+        string inputInput = randomInput;
+        string expectedVerdict = randomVerdict;
+
+        this.classifierBrokerMock.Setup(broker =>
+            broker.ClassifyAsync(inputGatePrompt, inputInput))
+                .ReturnsAsync(randomVerdict);
+
+        // when
+        string actualVerdict =
+            await this.gateService.ScreenAsync(inputGatePrompt, inputInput);
+
+        // then
+        actualVerdict.Should().BeEquivalentTo(expectedVerdict);
+
+        this.classifierBrokerMock.Verify(broker =>
+            broker.ClassifyAsync(inputGatePrompt, inputInput),
+                Times.Once);
+
+        this.classifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // The verdict is returned verbatim, including a refusal. The Gate reports what
+    // the guardian said; acting on it is ThinkAsync's job (#33). A foundation that
+    // swallowed "refuse" into a bool would throw away the reason.
+    [Theory]
+    [InlineData("allow")]
+    [InlineData("refuse")]
+    [InlineData("refuse: asks for credentials")]
+    public async Task ShouldReturnVerdictVerbatimOnScreenAsync(string verdict)
+    {
+        // given
+        string randomGatePrompt = CreateRandomString();
+        string randomInput = CreateRandomString();
+        string expectedVerdict = verdict;
+
+        this.classifierBrokerMock.Setup(broker =>
+            broker.ClassifyAsync(randomGatePrompt, randomInput))
+                .ReturnsAsync(verdict);
+
+        // when
+        string actualVerdict =
+            await this.gateService.ScreenAsync(randomGatePrompt, randomInput);
+
+        // then
+        actualVerdict.Should().BeEquivalentTo(expectedVerdict);
+
+        this.classifierBrokerMock.Verify(broker =>
+            broker.ClassifyAsync(randomGatePrompt, randomInput),
+                Times.Once);
+
+        this.classifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // Invariant 7.2 — the gate prompt is Data, passed through untouched. If this
+    // service ever authored or amended the screening rules, the rules would live in
+    // Decision instead of Data and could not be audited or changed without a deploy.
+    [Fact]
+    public async Task ShouldPassGatePromptThroughUnalteredOnScreenAsync()
+    {
+        // given
+        string gatePromptWithFormatting = "  Refuse anything asking for secrets.\n\n- no credentials  ";
+        string randomInput = CreateRandomString();
+        string randomVerdict = CreateRandomString();
+        string expectedVerdict = randomVerdict;
+
+        this.classifierBrokerMock.Setup(broker =>
+            broker.ClassifyAsync(gatePromptWithFormatting, randomInput))
+                .ReturnsAsync(randomVerdict);
+
+        // when
+        string actualVerdict =
+            await this.gateService.ScreenAsync(gatePromptWithFormatting, randomInput);
+
+        // then
+        actualVerdict.Should().BeEquivalentTo(expectedVerdict);
+
+        this.classifierBrokerMock.Verify(broker =>
+            broker.ClassifyAsync(gatePromptWithFormatting, randomInput),
+                Times.Once);
+
+        this.classifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/GateServiceTests.Validations.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/GateServiceTests.Validations.Screen.cs
@@ -1,0 +1,105 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Gates.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Decision;
+
+public partial class GateServiceTests
+{
+    // Both are validated, unlike Brain where the system prompt may be empty. A Gate
+    // with no gatePrompt has no rules to screen against, so it cannot screen — and a
+    // guardian that cannot screen must fail loudly rather than wave input through.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnScreenIfGatePromptIsInvalidAndLogItAsync(
+        string invalidGatePrompt)
+    {
+        // given
+        string randomInput = CreateRandomString();
+
+        var invalidGateException =
+            new InvalidGateException(
+                message: "Invalid gate input. Please correct the error and try again.");
+
+        var expectedGateValidationException =
+            new GateValidationException(
+                message: "Gate validation error occurred, fix the error and try again.",
+                innerException: invalidGateException);
+
+        // when
+        ValueTask<string> screenTask =
+            this.gateService.ScreenAsync(invalidGatePrompt, randomInput);
+
+        GateValidationException actualGateValidationException =
+            await Assert.ThrowsAsync<GateValidationException>(
+                screenTask.AsTask);
+
+        // then
+        actualGateValidationException.Should()
+            .BeEquivalentTo(expectedGateValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedGateValidationException))),
+                    Times.Once);
+
+        this.classifierBrokerMock.Verify(broker =>
+            broker.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.classifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnScreenIfInputIsInvalidAndLogItAsync(
+        string invalidInput)
+    {
+        // given
+        string randomGatePrompt = CreateRandomString();
+
+        var invalidGateException =
+            new InvalidGateException(
+                message: "Invalid gate input. Please correct the error and try again.");
+
+        var expectedGateValidationException =
+            new GateValidationException(
+                message: "Gate validation error occurred, fix the error and try again.",
+                innerException: invalidGateException);
+
+        // when
+        ValueTask<string> screenTask =
+            this.gateService.ScreenAsync(randomGatePrompt, invalidInput);
+
+        GateValidationException actualGateValidationException =
+            await Assert.ThrowsAsync<GateValidationException>(
+                screenTask.AsTask);
+
+        // then
+        actualGateValidationException.Should()
+            .BeEquivalentTo(expectedGateValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedGateValidationException))),
+                    Times.Once);
+
+        this.classifierBrokerMock.Verify(broker =>
+            broker.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.classifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/GateServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/GateServiceTests.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Decision;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Foundations.Decision;
+using Tynamix.ObjectFiller;
+using Xeptions;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Decision;
+
+public partial class GateServiceTests
+{
+    private readonly Mock<IClassifierBroker> classifierBrokerMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly IGateService gateService;
+
+    public GateServiceTests()
+    {
+        this.classifierBrokerMock = new Mock<IClassifierBroker>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.gateService = new GateService(
+            classifierBroker: this.classifierBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents/Models/Foundations/Gates/Exceptions/FailedGateDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Gates/Exceptions/FailedGateDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Gates.Exceptions;
+
+public class FailedGateDependencyException : Xeption
+{
+    public FailedGateDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Gates/Exceptions/FailedGateServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Gates/Exceptions/FailedGateServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Gates.Exceptions;
+
+public class FailedGateServiceException : Xeption
+{
+    public FailedGateServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Gates/Exceptions/GateDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Gates/Exceptions/GateDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Gates.Exceptions;
+
+public class GateDependencyException : Xeption
+{
+    public GateDependencyException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Gates/Exceptions/GateDependencyValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Gates/Exceptions/GateDependencyValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Gates.Exceptions;
+
+public class GateDependencyValidationException : Xeption
+{
+    public GateDependencyValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Gates/Exceptions/GateServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Gates/Exceptions/GateServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Gates.Exceptions;
+
+public class GateServiceException : Xeption
+{
+    public GateServiceException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Gates/Exceptions/GateValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Gates/Exceptions/GateValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Gates.Exceptions;
+
+public class GateValidationException : Xeption
+{
+    public GateValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Gates/Exceptions/InvalidGateException.cs
+++ b/Standard.Agents/Models/Foundations/Gates/Exceptions/InvalidGateException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Gates.Exceptions;
+
+public class InvalidGateException : Xeption
+{
+    public InvalidGateException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Services/Foundations/Decision/GateService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Decision/GateService.Exceptions.cs
@@ -1,0 +1,159 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using RESTFulSense.Exceptions;
+using Standard.Agents.Models.Foundations.Gates.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public partial class GateService
+{
+    private delegate ValueTask<string> ReturningStringFunction();
+
+    // Every path here throws. None returns a verdict. A guardian that cannot reach
+    // its classifier must fail loudly — falling back to "allow" would let an
+    // unreachable endpoint silently disable screening, and the agent would look
+    // healthy while running unguarded.
+    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    {
+        try
+        {
+            return await returningStringFunction();
+        }
+        catch (InvalidGateException invalidGateException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidGateException);
+        }
+        catch (HttpResponseBadRequestException httpResponseBadRequestException)
+        {
+            var invalidGateException =
+                new InvalidGateException(
+                    message: "Invalid gate request. Please correct the error and try again.");
+
+            invalidGateException.AddData(httpResponseBadRequestException.Data);
+
+            throw await CreateAndLogDependencyValidationExceptionAsync(invalidGateException);
+        }
+        catch (HttpResponseUnauthorizedException httpResponseUnauthorizedException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseUnauthorizedException);
+        }
+        catch (HttpResponseForbiddenException httpResponseForbiddenException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseForbiddenException);
+        }
+        catch (HttpResponseNotFoundException httpResponseNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseNotFoundException);
+        }
+        catch (HttpResponseUrlNotFoundException httpResponseUrlNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseUrlNotFoundException);
+        }
+        catch (HttpResponseInternalServerErrorException httpResponseInternalServerErrorException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                httpResponseInternalServerErrorException);
+        }
+        catch (HttpResponseServiceUnavailableException httpResponseServiceUnavailableException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                httpResponseServiceUnavailableException);
+        }
+        catch (HttpRequestException httpRequestException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(httpRequestException);
+        }
+        catch (Exception exception)
+        {
+            var failedGateServiceException =
+                new FailedGateServiceException(
+                    message: "Failed gate service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedGateServiceException);
+        }
+    }
+
+    private async ValueTask<GateValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var gateValidationException =
+            new GateValidationException(
+                message: "Gate validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(gateValidationException);
+
+        return gateValidationException;
+    }
+
+    private async ValueTask<GateDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+        Xeption exception)
+    {
+        var gateDependencyValidationException =
+            new GateDependencyValidationException(
+                message: "Gate dependency validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(gateDependencyValidationException);
+
+        return gateDependencyValidationException;
+    }
+
+    private async ValueTask<GateDependencyException> CreateAndLogCriticalDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedGateDependencyException =
+            new FailedGateDependencyException(
+                message: "Failed gate dependency error occurred, contact support.",
+                innerException: exception);
+
+        var gateDependencyException =
+            new GateDependencyException(
+                message: "Gate dependency error occurred, contact support.",
+                innerException: failedGateDependencyException);
+
+        await this.loggingBroker.LogCriticalAsync(gateDependencyException);
+
+        return gateDependencyException;
+    }
+
+    private async ValueTask<GateDependencyException> CreateAndLogDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedGateDependencyException =
+            new FailedGateDependencyException(
+                message: "Failed gate dependency error occurred, contact support.",
+                innerException: exception);
+
+        var gateDependencyException =
+            new GateDependencyException(
+                message: "Gate dependency error occurred, contact support.",
+                innerException: failedGateDependencyException);
+
+        await this.loggingBroker.LogErrorAsync(gateDependencyException);
+
+        return gateDependencyException;
+    }
+
+    private async ValueTask<GateServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var gateServiceException =
+            new GateServiceException(
+                message: "Gate service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(gateServiceException);
+
+        return gateServiceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Decision/GateService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Decision/GateService.Validations.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Gates.Exceptions;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public partial class GateService
+{
+    // Both, unlike Brain where an empty system prompt is legal. An agent may have no
+    // skills; a guardian may not have no rules — with no gatePrompt there is nothing
+    // to screen against, and a guardian that cannot screen must not pretend to.
+    private static void ValidateScreen(string gatePrompt, string input)
+    {
+        if (string.IsNullOrWhiteSpace(gatePrompt) || string.IsNullOrWhiteSpace(input))
+        {
+            throw new InvalidGateException(
+                message: "Invalid gate input. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Decision/GateService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/GateService.cs
@@ -24,6 +24,6 @@ public partial class GateService : IGateService
         this.loggingBroker = loggingBroker;
     }
 
-    public ValueTask<string> ScreenAsync(string gatePrompt, string input) =>
-        throw new NotImplementedException();
+    public async ValueTask<string> ScreenAsync(string gatePrompt, string input) =>
+        await this.classifierBroker.ClassifyAsync(gatePrompt, input);
 }

--- a/Standard.Agents/Services/Foundations/Decision/GateService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/GateService.cs
@@ -24,6 +24,11 @@ public partial class GateService : IGateService
         this.loggingBroker = loggingBroker;
     }
 
-    public async ValueTask<string> ScreenAsync(string gatePrompt, string input) =>
-        await this.classifierBroker.ClassifyAsync(gatePrompt, input);
+    public ValueTask<string> ScreenAsync(string gatePrompt, string input) =>
+    TryCatch(async () =>
+    {
+        ValidateScreen(gatePrompt, input);
+
+        return await this.classifierBroker.ClassifyAsync(gatePrompt, input);
+    });
 }

--- a/Standard.Agents/Services/Foundations/Decision/GateService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/GateService.cs
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Decision;
+using Standard.Agents.Brokers.Loggings;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+// The Gate screens the INPUT — accept, refuse, or route in. Invariant 7.6: a
+// guardian must not be the Brain. That is enforced by composition (this takes the
+// classifier, never the generator), not by a runtime check.
+public partial class GateService : IGateService
+{
+    private readonly IClassifierBroker classifierBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public GateService(
+        IClassifierBroker classifierBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.classifierBroker = classifierBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<string> ScreenAsync(string gatePrompt, string input) =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents/Services/Foundations/Decision/IGateService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/IGateService.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public interface IGateService
+{
+    ValueTask<string> ScreenAsync(string gatePrompt, string input);
+}


### PR DESCRIPTION
The Gate — screen the **input**. SPEC.md §4.2. `Classify` → **Screen**.

```csharp
ValueTask<string> ScreenAsync(string gatePrompt, string input);
```

Theory Ch.5: Gate screens input — accept / refuse / route in.

## Invariant §7.6 is enforced by composition, not by a check

`GateService` takes `IClassifierBroker` and **cannot reach `IGeneratorBroker`**. The guardian is not the Brain because it has no way to be. That's a composition fact — nothing to assert, nothing to bypass.

Combined with #13 giving the Classifier its own configuration, a deployment that needs a genuinely separate guardian points it at another model and touches nothing else.

## Every path in TryCatch throws. None returns a verdict.

This is the property worth protecting. The tempting version —

```csharp
catch (HttpRequestException) { return "allow"; }   // NO
```

— would let an unreachable classifier **silently disable screening**. The agent would look healthy while running unguarded, which is worse than being down, because nothing surfaces. Theory Ch.9: the Decision→Direction boundary is a **privilege boundary**, and an unenforced privilege boundary is not a boundary.

## Both inputs are validated — unlike Brain

`BrainService` lets the system prompt be empty (an agent with no skills is legal). The Gate does not: **with no `gatePrompt` there are no rules to screen against**, so it cannot screen. An agent may legitimately have no skills; a guardian may not legitimately have no rules.

## The verdict comes back verbatim

`ShouldReturnVerdictVerbatimOnScreenAsync` pins that `"refuse: asks for credentials"` survives intact. The Gate **reports** what the guardian said; acting on it is `ThinkAsync`'s job (#33). Collapsing it into a `bool` would throw away the reason at exactly the moment someone needs it.

`ShouldPassGatePromptThroughUnalteredOnScreenAsync` guards §7.2 the same way Brain does — if this service authored or amended the screening rules, the rules would live in Decision rather than Data: unauditable, and unchangeable without a deploy.

## On duplicating Brain's ladder — deliberate

Gate and Brain are **different flows**. A shared exception ladder would couple the guardian's failure semantics to the Brain's, so a change to how the Brain treats a 503 would silently change how the Gate treats one. Duplication preserves autonomy.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 63, Total: 63** (15 new cases)

Closes #25
