### PR TITLE
FOUNDATIONS: Evaluate

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/JudgeServiceTests.Logic.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/JudgeServiceTests.Logic.Evaluate.cs
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Decision;
+
+public partial class JudgeServiceTests
+{
+    // The bounds are legal values, not edge cases to be nudged inward.
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.3)]
+    [InlineData(1.0)]
+    public async Task ShouldEvaluateAsync(double score)
+    {
+        // given
+        string randomJudgePrompt = CreateRandomString();
+        string randomCandidate = CreateRandomString();
+        double expectedScore = score;
+
+        this.verifierBrokerMock.Setup(broker =>
+            broker.VerifyAsync(randomJudgePrompt, randomCandidate))
+                .ReturnsAsync(score);
+
+        // when
+        double actualScore =
+            await this.judgeService.EvaluateAsync(randomJudgePrompt, randomCandidate);
+
+        // then
+        actualScore.Should().Be(expectedScore);
+
+        this.verifierBrokerMock.Verify(broker =>
+            broker.VerifyAsync(randomJudgePrompt, randomCandidate),
+                Times.Once);
+
+        this.verifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // Invariant 7.2 — the rubric is Data. A Judge that authored its own rubric would
+    // be grading against rules nobody can inspect or change without a deploy.
+    [Fact]
+    public async Task ShouldPassJudgePromptThroughUnalteredOnEvaluateAsync()
+    {
+        // given
+        string judgePromptWithFormatting = "  Score 0..1 for groundedness.\n\n- cite sources  ";
+        string randomCandidate = CreateRandomString();
+        double expectedScore = 0.75;
+
+        this.verifierBrokerMock.Setup(broker =>
+            broker.VerifyAsync(judgePromptWithFormatting, randomCandidate))
+                .ReturnsAsync(expectedScore);
+
+        // when
+        double actualScore = await this.judgeService.EvaluateAsync(
+            judgePromptWithFormatting,
+            randomCandidate);
+
+        // then
+        actualScore.Should().Be(expectedScore);
+
+        this.verifierBrokerMock.Verify(broker =>
+            broker.VerifyAsync(judgePromptWithFormatting, randomCandidate),
+                Times.Once);
+
+        this.verifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/JudgeServiceTests.Validations.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/JudgeServiceTests.Validations.Evaluate.cs
@@ -1,0 +1,159 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Judges.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Decision;
+
+public partial class JudgeServiceTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnEvaluateIfJudgePromptIsInvalidAndLogItAsync(
+        string invalidJudgePrompt)
+    {
+        // given
+        string randomCandidate = CreateRandomString();
+
+        var invalidJudgeException =
+            new InvalidJudgeException(
+                message: "Invalid judge input. Please correct the error and try again.");
+
+        var expectedJudgeValidationException =
+            new JudgeValidationException(
+                message: "Judge validation error occurred, fix the error and try again.",
+                innerException: invalidJudgeException);
+
+        // when
+        ValueTask<double> evaluateTask =
+            this.judgeService.EvaluateAsync(invalidJudgePrompt, randomCandidate);
+
+        JudgeValidationException actualJudgeValidationException =
+            await Assert.ThrowsAsync<JudgeValidationException>(
+                evaluateTask.AsTask);
+
+        // then
+        actualJudgeValidationException.Should()
+            .BeEquivalentTo(expectedJudgeValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedJudgeValidationException))),
+                    Times.Once);
+
+        this.verifierBrokerMock.Verify(broker =>
+            broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.verifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnEvaluateIfCandidateIsInvalidAndLogItAsync(
+        string invalidCandidate)
+    {
+        // given
+        string randomJudgePrompt = CreateRandomString();
+
+        var invalidJudgeException =
+            new InvalidJudgeException(
+                message: "Invalid judge input. Please correct the error and try again.");
+
+        var expectedJudgeValidationException =
+            new JudgeValidationException(
+                message: "Judge validation error occurred, fix the error and try again.",
+                innerException: invalidJudgeException);
+
+        // when
+        ValueTask<double> evaluateTask =
+            this.judgeService.EvaluateAsync(randomJudgePrompt, invalidCandidate);
+
+        JudgeValidationException actualJudgeValidationException =
+            await Assert.ThrowsAsync<JudgeValidationException>(
+                evaluateTask.AsTask);
+
+        // then
+        actualJudgeValidationException.Should()
+            .BeEquivalentTo(expectedJudgeValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedJudgeValidationException))),
+                    Times.Once);
+
+        this.verifierBrokerMock.Verify(broker =>
+            broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.verifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // ⭐ An OUTGOING validation — the only one in the codebase. The Standard:
+    // "Validate outgoing data when the current routine uses it." 0.0..1.0 is
+    // normative in SPEC.md 4.1, and the broker cannot enforce it (no flow control).
+    //
+    // This is not pedantry. ThinkAsync gates on `score < 0.3` (#33). A verifier
+    // returning 87 — a model answering out of 100 instead of 0..1 — would sail past
+    // that gate and every draft would pass review forever, silently.
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(1.1)]
+    [InlineData(87)]
+    [InlineData(double.NaN)]
+    public async Task ShouldThrowValidationExceptionOnEvaluateIfScoreIsOutOfRangeAndLogItAsync(
+        double outOfRangeScore)
+    {
+        // given
+        string randomJudgePrompt = CreateRandomString();
+        string randomCandidate = CreateRandomString();
+
+        var invalidJudgeScoreException =
+            new InvalidJudgeScoreException(
+                message: "Invalid judge score. Score must be between 0.0 and 1.0.");
+
+        var expectedJudgeValidationException =
+            new JudgeValidationException(
+                message: "Judge validation error occurred, fix the error and try again.",
+                innerException: invalidJudgeScoreException);
+
+        this.verifierBrokerMock.Setup(broker =>
+            broker.VerifyAsync(randomJudgePrompt, randomCandidate))
+                .ReturnsAsync(outOfRangeScore);
+
+        // when
+        ValueTask<double> evaluateTask =
+            this.judgeService.EvaluateAsync(randomJudgePrompt, randomCandidate);
+
+        JudgeValidationException actualJudgeValidationException =
+            await Assert.ThrowsAsync<JudgeValidationException>(
+                evaluateTask.AsTask);
+
+        // then
+        actualJudgeValidationException.Should()
+            .BeEquivalentTo(expectedJudgeValidationException);
+
+        this.verifierBrokerMock.Verify(broker =>
+            broker.VerifyAsync(randomJudgePrompt, randomCandidate),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedJudgeValidationException))),
+                    Times.Once);
+
+        this.verifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/JudgeServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/JudgeServiceTests.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Decision;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Foundations.Decision;
+using Tynamix.ObjectFiller;
+using Xeptions;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Decision;
+
+public partial class JudgeServiceTests
+{
+    private readonly Mock<IVerifierBroker> verifierBrokerMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly IJudgeService judgeService;
+
+    public JudgeServiceTests()
+    {
+        this.verifierBrokerMock = new Mock<IVerifierBroker>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.judgeService = new JudgeService(
+            verifierBroker: this.verifierBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/FailedJudgeDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/FailedJudgeDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
+
+public class FailedJudgeDependencyException : Xeption
+{
+    public FailedJudgeDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/FailedJudgeServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/FailedJudgeServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
+
+public class FailedJudgeServiceException : Xeption
+{
+    public FailedJudgeServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/InvalidJudgeException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/InvalidJudgeException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
+
+public class InvalidJudgeException : Xeption
+{
+    public InvalidJudgeException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/InvalidJudgeScoreException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/InvalidJudgeScoreException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
+
+public class InvalidJudgeScoreException : Xeption
+{
+    public InvalidJudgeScoreException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
+
+public class JudgeDependencyException : Xeption
+{
+    public JudgeDependencyException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeDependencyValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeDependencyValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
+
+public class JudgeDependencyValidationException : Xeption
+{
+    public JudgeDependencyValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
+
+public class JudgeServiceException : Xeption
+{
+    public JudgeServiceException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
+
+public class JudgeValidationException : Xeption
+{
+    public JudgeValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Services/Foundations/Decision/IJudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/IJudgeService.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public interface IJudgeService
+{
+    ValueTask<double> EvaluateAsync(string judgePrompt, string candidate);
+}

--- a/Standard.Agents/Services/Foundations/Decision/JudgeService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Decision/JudgeService.Exceptions.cs
@@ -1,0 +1,162 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using RESTFulSense.Exceptions;
+using Standard.Agents.Models.Foundations.Judges.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public partial class JudgeService
+{
+    private delegate ValueTask<double> ReturningScoreFunction();
+
+    // Every path throws; none returns a score. A Judge that fell back to 1.0 when its
+    // verifier was unreachable would approve every draft — invariant 7.5 says output
+    // must not cross a boundary un-vetted, and a fabricated pass is not vetting.
+    private async ValueTask<double> TryCatch(ReturningScoreFunction returningScoreFunction)
+    {
+        try
+        {
+            return await returningScoreFunction();
+        }
+        catch (InvalidJudgeException invalidJudgeException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidJudgeException);
+        }
+        catch (InvalidJudgeScoreException invalidJudgeScoreException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidJudgeScoreException);
+        }
+        catch (HttpResponseBadRequestException httpResponseBadRequestException)
+        {
+            var invalidJudgeException =
+                new InvalidJudgeException(
+                    message: "Invalid judge request. Please correct the error and try again.");
+
+            invalidJudgeException.AddData(httpResponseBadRequestException.Data);
+
+            throw await CreateAndLogDependencyValidationExceptionAsync(invalidJudgeException);
+        }
+        catch (HttpResponseUnauthorizedException httpResponseUnauthorizedException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseUnauthorizedException);
+        }
+        catch (HttpResponseForbiddenException httpResponseForbiddenException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseForbiddenException);
+        }
+        catch (HttpResponseNotFoundException httpResponseNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseNotFoundException);
+        }
+        catch (HttpResponseUrlNotFoundException httpResponseUrlNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseUrlNotFoundException);
+        }
+        catch (HttpResponseInternalServerErrorException httpResponseInternalServerErrorException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                httpResponseInternalServerErrorException);
+        }
+        catch (HttpResponseServiceUnavailableException httpResponseServiceUnavailableException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                httpResponseServiceUnavailableException);
+        }
+        catch (HttpRequestException httpRequestException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(httpRequestException);
+        }
+        catch (Exception exception)
+        {
+            var failedJudgeServiceException =
+                new FailedJudgeServiceException(
+                    message: "Failed judge service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedJudgeServiceException);
+        }
+    }
+
+    private async ValueTask<JudgeValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var gateValidationException =
+            new JudgeValidationException(
+                message: "Judge validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(gateValidationException);
+
+        return gateValidationException;
+    }
+
+    private async ValueTask<JudgeDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+        Xeption exception)
+    {
+        var gateDependencyValidationException =
+            new JudgeDependencyValidationException(
+                message: "Judge dependency validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(gateDependencyValidationException);
+
+        return gateDependencyValidationException;
+    }
+
+    private async ValueTask<JudgeDependencyException> CreateAndLogCriticalDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedJudgeDependencyException =
+            new FailedJudgeDependencyException(
+                message: "Failed judge dependency error occurred, contact support.",
+                innerException: exception);
+
+        var gateDependencyException =
+            new JudgeDependencyException(
+                message: "Judge dependency error occurred, contact support.",
+                innerException: failedJudgeDependencyException);
+
+        await this.loggingBroker.LogCriticalAsync(gateDependencyException);
+
+        return gateDependencyException;
+    }
+
+    private async ValueTask<JudgeDependencyException> CreateAndLogDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedJudgeDependencyException =
+            new FailedJudgeDependencyException(
+                message: "Failed judge dependency error occurred, contact support.",
+                innerException: exception);
+
+        var gateDependencyException =
+            new JudgeDependencyException(
+                message: "Judge dependency error occurred, contact support.",
+                innerException: failedJudgeDependencyException);
+
+        await this.loggingBroker.LogErrorAsync(gateDependencyException);
+
+        return gateDependencyException;
+    }
+
+    private async ValueTask<JudgeServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var gateServiceException =
+            new JudgeServiceException(
+                message: "Judge service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(gateServiceException);
+
+        return gateServiceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Decision/JudgeService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Decision/JudgeService.Validations.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Judges.Exceptions;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+public partial class JudgeService
+{
+    private const double MinimumScore = 0.0;
+    private const double MaximumScore = 1.0;
+
+    private static void ValidateEvaluate(string judgePrompt, string candidate)
+    {
+        if (string.IsNullOrWhiteSpace(judgePrompt) || string.IsNullOrWhiteSpace(candidate))
+        {
+            throw new InvalidJudgeException(
+                message: "Invalid judge input. Please correct the error and try again.");
+        }
+    }
+
+    // Outgoing validation — the only one here. SPEC.md 4.1 makes 0.0..1.0 normative,
+    // and the broker cannot enforce it (no flow control), so it lands here or nowhere.
+    //
+    // Written as "not within range" rather than "outside range" on purpose: NaN fails
+    // every comparison, so `score < 0.0 || score > 1.0` would let it through. NaN then
+    // also fails ThinkAsync's `score < 0.3` gate, making a garbage score
+    // unrejectable rather than merely wrong.
+    private static void ValidateScore(double score)
+    {
+        bool isWithinRange = score >= MinimumScore && score <= MaximumScore;
+
+        if (isWithinRange is false)
+        {
+            throw new InvalidJudgeScoreException(
+                message: "Invalid judge score. Score must be between 0.0 and 1.0.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Decision/JudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/JudgeService.cs
@@ -25,5 +25,14 @@ public partial class JudgeService : IJudgeService
     }
 
     public ValueTask<double> EvaluateAsync(string judgePrompt, string candidate) =>
-        throw new NotImplementedException();
+    TryCatch(async () =>
+    {
+        ValidateEvaluate(judgePrompt, candidate);
+
+        double score = await this.verifierBroker.VerifyAsync(judgePrompt, candidate);
+
+        ValidateScore(score);
+
+        return score;
+    });
 }

--- a/Standard.Agents/Services/Foundations/Decision/JudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Decision/JudgeService.cs
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Decision;
+using Standard.Agents.Brokers.Loggings;
+
+namespace Standard.Agents.Services.Foundations.Decision;
+
+// The Judge screens the OUTPUT. Invariant 7.6 is enforced by composition: this
+// takes the verifier and cannot reach the generator, so a draft is never graded by
+// the mind that wrote it.
+public partial class JudgeService : IJudgeService
+{
+    private readonly IVerifierBroker verifierBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public JudgeService(
+        IVerifierBroker verifierBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.verifierBroker = verifierBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<double> EvaluateAsync(string judgePrompt, string candidate) =>
+        throw new NotImplementedException();
+}


### PR DESCRIPTION
The Judge — screen the **output**. SPEC.md §4.2. `Verify` → **Evaluate**.

```csharp
ValueTask<double> EvaluateAsync(string judgePrompt, string candidate);
```

## The only outgoing validation in the codebase

The Standard: *"Validate outgoing data when the current routine uses it."* 0.0–1.0 is normative in SPEC.md §4.1, and the broker **cannot** enforce it (no flow control). So it lands here or nowhere.

**This is not pedantry.** `ThinkAsync` gates on `score < 0.3` (#33). A verifier returning **87** — a model answering out of 100 instead of 0..1, a very ordinary way for a prompt to be misread — sails past that gate. Every draft passes review, forever. Nothing errors. Nothing logs. The Judge simply **stops judging while appearing to work** — the same failure shape as the always-allow Gate that #50 killed.

`Judges` gets an eighth exception model no other foundation needs — `InvalidJudgeScoreException` — because the thing being rejected here is not an input.

## `NaN` is in the theory for a reason

```csharp
bool isWithinRange = score >= 0.0 && score <= 1.0;
if (isWithinRange is false) throw ...
```

Written as **"not within range"**, not "outside range". `NaN` fails *every* comparison, so `score < 0.0 || score > 1.0` would **wave it through**. And `NaN` also fails `ThinkAsync`'s `score < 0.3` gate — making a garbage score **unrejectable** rather than merely wrong.

## Every path throws; none returns a score

A Judge falling back to `1.0` on an unreachable verifier would approve every draft. Invariant §7.5: *a draft is not a commitment* — output must not cross a boundary un-vetted, and **a fabricated pass is not vetting**.

Invariant §7.6 is enforced by composition: this takes `IVerifierBroker` and cannot reach the generator, so **a draft is never graded by the mind that wrote it**.

## `0.0` and `1.0` are legal values

They're in the happy path, not the validation theory. The bounds are inclusive — a Judge that rejected a perfect or a zero score would reject its own valid verdicts.

## Note on a near-miss

`sed 's/gate/judge/g'` to adapt the Gate's ladder silently rewrote **dele`gate`** → `delejudge`. Caught by the build, regenerated with word-boundary matching. Worth knowing if anyone adapts these ladders the same way.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 77, Total: 77** (14 new cases)

**This completes the Decision tri-nature** — Gate, Brain, Judge. One brain, flanked by conscience.

Closes #27
