### PR TITLE
FOUNDATIONS: Recall Memories And Remember

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.Exceptions.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.Exceptions.cs
@@ -1,0 +1,207 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Memories.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class MemoryServiceTests
+{
+    // The store is unreachable or unwritable — deployment or permissions, not a blip.
+    public static TheoryData<Exception> CriticalDependencyExceptions() =>
+        new()
+        {
+            new FileNotFoundException(),
+            new DirectoryNotFoundException(),
+            new UnauthorizedAccessException()
+        };
+
+    [Theory]
+    [MemberData(nameof(CriticalDependencyExceptions))]
+    public async Task ShouldThrowDependencyExceptionOnRecallMemoriesIfCriticalErrorOccursAndLogItAsync(
+        Exception criticalDependencyException)
+    {
+        // given
+        var failedMemoryDependencyException =
+            new FailedMemoryDependencyException(
+                message: "Failed memory dependency error occurred, contact support.",
+                innerException: criticalDependencyException);
+
+        var expectedMemoryDependencyException =
+            new MemoryDependencyException(
+                message: "Memory dependency error occurred, contact support.",
+                innerException: failedMemoryDependencyException);
+
+        this.memoryBrokerMock.Setup(broker =>
+            broker.SelectMemoriesAsync())
+                .ThrowsAsync(criticalDependencyException);
+
+        // when
+        ValueTask<IReadOnlyList<string>> recallTask =
+            this.memoryService.RecallMemoriesAsync();
+
+        MemoryDependencyException actualMemoryDependencyException =
+            await Assert.ThrowsAsync<MemoryDependencyException>(
+                recallTask.AsTask);
+
+        // then
+        actualMemoryDependencyException.Should()
+            .BeEquivalentTo(expectedMemoryDependencyException);
+
+        this.memoryBrokerMock.Verify(broker =>
+            broker.SelectMemoriesAsync(),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogCriticalAsync(It.Is(SameExceptionAs(
+                expectedMemoryDependencyException))),
+                    Times.Once);
+
+        this.memoryBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowDependencyExceptionOnRecallMemoriesIfIOErrorOccursAndLogItAsync()
+    {
+        // given
+        var ioException = new IOException();
+
+        var failedMemoryDependencyException =
+            new FailedMemoryDependencyException(
+                message: "Failed memory dependency error occurred, contact support.",
+                innerException: ioException);
+
+        var expectedMemoryDependencyException =
+            new MemoryDependencyException(
+                message: "Memory dependency error occurred, contact support.",
+                innerException: failedMemoryDependencyException);
+
+        this.memoryBrokerMock.Setup(broker =>
+            broker.SelectMemoriesAsync())
+                .ThrowsAsync(ioException);
+
+        // when
+        ValueTask<IReadOnlyList<string>> recallTask =
+            this.memoryService.RecallMemoriesAsync();
+
+        MemoryDependencyException actualMemoryDependencyException =
+            await Assert.ThrowsAsync<MemoryDependencyException>(
+                recallTask.AsTask);
+
+        // then
+        actualMemoryDependencyException.Should()
+            .BeEquivalentTo(expectedMemoryDependencyException);
+
+        this.memoryBrokerMock.Verify(broker =>
+            broker.SelectMemoriesAsync(),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedMemoryDependencyException))),
+                    Times.Once);
+
+        this.memoryBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnRecallMemoriesIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        var serviceException = new Exception();
+
+        var failedMemoryServiceException =
+            new FailedMemoryServiceException(
+                message: "Failed memory service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedMemoryServiceException =
+            new MemoryServiceException(
+                message: "Memory service error occurred, contact support.",
+                innerException: failedMemoryServiceException);
+
+        this.memoryBrokerMock.Setup(broker =>
+            broker.SelectMemoriesAsync())
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<IReadOnlyList<string>> recallTask =
+            this.memoryService.RecallMemoriesAsync();
+
+        MemoryServiceException actualMemoryServiceException =
+            await Assert.ThrowsAsync<MemoryServiceException>(
+                recallTask.AsTask);
+
+        // then
+        actualMemoryServiceException.Should()
+            .BeEquivalentTo(expectedMemoryServiceException);
+
+        this.memoryBrokerMock.Verify(broker =>
+            broker.SelectMemoriesAsync(),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedMemoryServiceException))),
+                    Times.Once);
+
+        this.memoryBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // A failed write must throw, never be swallowed. Invariant 7.4 puts memory
+    // outside the agent — if a write is lost silently, the agent believes it
+    // remembered something it did not, and only discovers otherwise next session.
+    [Fact]
+    public async Task ShouldThrowDependencyExceptionOnRememberIfDependencyErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomMemory = CreateRandomString();
+        var ioException = new IOException();
+
+        var failedMemoryDependencyException =
+            new FailedMemoryDependencyException(
+                message: "Failed memory dependency error occurred, contact support.",
+                innerException: ioException);
+
+        var expectedMemoryDependencyException =
+            new MemoryDependencyException(
+                message: "Memory dependency error occurred, contact support.",
+                innerException: failedMemoryDependencyException);
+
+        this.memoryBrokerMock.Setup(broker =>
+            broker.InsertMemoryAsync(randomMemory))
+                .ThrowsAsync(ioException);
+
+        // when
+        ValueTask rememberTask =
+            this.memoryService.RememberAsync(randomMemory);
+
+        MemoryDependencyException actualMemoryDependencyException =
+            await Assert.ThrowsAsync<MemoryDependencyException>(
+                rememberTask.AsTask);
+
+        // then
+        actualMemoryDependencyException.Should()
+            .BeEquivalentTo(expectedMemoryDependencyException);
+
+        this.memoryBrokerMock.Verify(broker =>
+            broker.InsertMemoryAsync(randomMemory),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedMemoryDependencyException))),
+                    Times.Once);
+
+        this.memoryBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.Logic.RecallMemories.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.Logic.RecallMemories.cs
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class MemoryServiceTests
+{
+    [Fact]
+    public async Task ShouldRecallMemoriesAsync()
+    {
+        // given
+        List<string> randomMemories = CreateRandomMemories();
+        IReadOnlyList<string> retrievedMemories = randomMemories;
+        IReadOnlyList<string> expectedMemories = retrievedMemories;
+
+        this.memoryBrokerMock.Setup(broker =>
+            broker.SelectMemoriesAsync())
+                .ReturnsAsync(retrievedMemories);
+
+        // when
+        IReadOnlyList<string> actualMemories =
+            await this.memoryService.RecallMemoriesAsync();
+
+        // then
+        actualMemories.Should().BeEquivalentTo(expectedMemories);
+
+        this.memoryBrokerMock.Verify(broker =>
+            broker.SelectMemoriesAsync(),
+                Times.Once);
+
+        this.memoryBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // An agent that has never remembered anything recalls nothing. That is a
+    // legitimate state, not a failure — every agent starts here on its first run.
+    [Fact]
+    public async Task ShouldRecallNoMemoriesOnRecallMemoriesIfStoreIsEmptyAsync()
+    {
+        // given
+        IReadOnlyList<string> noMemories = [];
+        IReadOnlyList<string> expectedMemories = noMemories;
+
+        this.memoryBrokerMock.Setup(broker =>
+            broker.SelectMemoriesAsync())
+                .ReturnsAsync(noMemories);
+
+        // when
+        IReadOnlyList<string> actualMemories =
+            await this.memoryService.RecallMemoriesAsync();
+
+        // then
+        actualMemories.Should().BeEmpty();
+        actualMemories.Should().BeEquivalentTo(expectedMemories);
+
+        this.memoryBrokerMock.Verify(broker =>
+            broker.SelectMemoriesAsync(),
+                Times.Once);
+
+        this.memoryBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.Logic.Remember.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.Logic.Remember.cs
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class MemoryServiceTests
+{
+    [Fact]
+    public async Task ShouldRememberAsync()
+    {
+        // given
+        string randomMemory = CreateRandomString();
+        string inputMemory = randomMemory;
+
+        // when
+        await this.memoryService.RememberAsync(inputMemory);
+
+        // then
+        this.memoryBrokerMock.Verify(broker =>
+            broker.InsertMemoryAsync(inputMemory),
+                Times.Once);
+
+        this.memoryBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.Validations.Remember.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.Validations.Remember.cs
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Memories.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class MemoryServiceTests
+{
+    // An empty memory is not a memory. Writing one would append a blank line the
+    // store would read back forever as a memory that says nothing.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnRememberIfMemoryIsInvalidAndLogItAsync(
+        string invalidMemory)
+    {
+        // given
+        var invalidMemoryException =
+            new InvalidMemoryException(
+                message: "Invalid memory. Please correct the error and try again.");
+
+        var expectedMemoryValidationException =
+            new MemoryValidationException(
+                message: "Memory validation error occurred, fix the error and try again.",
+                innerException: invalidMemoryException);
+
+        // when
+        ValueTask rememberTask =
+            this.memoryService.RememberAsync(invalidMemory);
+
+        MemoryValidationException actualMemoryValidationException =
+            await Assert.ThrowsAsync<MemoryValidationException>(
+                rememberTask.AsTask);
+
+        // then
+        actualMemoryValidationException.Should()
+            .BeEquivalentTo(expectedMemoryValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedMemoryValidationException))),
+                    Times.Once);
+
+        this.memoryBrokerMock.Verify(broker =>
+            broker.InsertMemoryAsync(It.IsAny<string>()),
+                Times.Never);
+
+        this.memoryBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.cs
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Data;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Foundations.Data;
+using Tynamix.ObjectFiller;
+using Xeptions;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class MemoryServiceTests
+{
+    private readonly Mock<IMemoryBroker> memoryBrokerMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly IMemoryService memoryService;
+
+    public MemoryServiceTests()
+    {
+        this.memoryBrokerMock = new Mock<IMemoryBroker>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.memoryService = new MemoryService(
+            memoryBroker: this.memoryBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static List<string> CreateRandomMemories() =>
+        Enumerable.Range(0, 3).Select(_ => CreateRandomString()).ToList();
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents/Models/Foundations/Memories/Exceptions/FailedMemoryDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Memories/Exceptions/FailedMemoryDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Memories.Exceptions;
+
+public class FailedMemoryDependencyException : Xeption
+{
+    public FailedMemoryDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Memories/Exceptions/FailedMemoryServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Memories/Exceptions/FailedMemoryServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Memories.Exceptions;
+
+public class FailedMemoryServiceException : Xeption
+{
+    public FailedMemoryServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Memories/Exceptions/InvalidMemoryException.cs
+++ b/Standard.Agents/Models/Foundations/Memories/Exceptions/InvalidMemoryException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Memories.Exceptions;
+
+public class InvalidMemoryException : Xeption
+{
+    public InvalidMemoryException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Memories.Exceptions;
+
+public class MemoryDependencyException : Xeption
+{
+    public MemoryDependencyException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Memories.Exceptions;
+
+public class MemoryServiceException : Xeption
+{
+    public MemoryServiceException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Memories.Exceptions;
+
+public class MemoryValidationException : Xeption
+{
+    public MemoryValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Services/Foundations/Data/IMemoryService.cs
+++ b/Standard.Agents/Services/Foundations/Data/IMemoryService.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+public interface IMemoryService
+{
+    ValueTask<IReadOnlyList<string>> RecallMemoriesAsync();
+
+    ValueTask RememberAsync(string memory);
+}

--- a/Standard.Agents/Services/Foundations/Data/MemoryService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Data/MemoryService.Exceptions.cs
@@ -1,0 +1,157 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Memories.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+public partial class MemoryService
+{
+    private delegate ValueTask<IReadOnlyList<string>> ReturningMemoriesFunction();
+    private delegate ValueTask ReturningNothingFunction();
+
+    private async ValueTask<IReadOnlyList<string>> TryCatch(
+        ReturningMemoriesFunction returningMemoriesFunction)
+    {
+        try
+        {
+            return await returningMemoriesFunction();
+        }
+        catch (InvalidMemoryException invalidMemoryException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidMemoryException);
+        }
+        catch (FileNotFoundException fileNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(fileNotFoundException);
+        }
+        catch (DirectoryNotFoundException directoryNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(directoryNotFoundException);
+        }
+        catch (UnauthorizedAccessException unauthorizedAccessException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(unauthorizedAccessException);
+        }
+        // Below the three above — they all derive from IOException and would be
+        // swallowed here, downgrading a deployment fault to a transient error.
+        catch (IOException ioException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(ioException);
+        }
+        catch (Exception exception)
+        {
+            var failedMemoryServiceException =
+                new FailedMemoryServiceException(
+                    message: "Failed memory service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedMemoryServiceException);
+        }
+    }
+
+    // RememberAsync returns nothing, so it needs its own overload. The catch list is
+    // identical by necessity, not by copy-paste: a shared generic TryCatch cannot
+    // span ValueTask and ValueTask<T>.
+    private async ValueTask TryCatch(ReturningNothingFunction returningNothingFunction)
+    {
+        try
+        {
+            await returningNothingFunction();
+        }
+        catch (InvalidMemoryException invalidMemoryException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidMemoryException);
+        }
+        catch (FileNotFoundException fileNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(fileNotFoundException);
+        }
+        catch (DirectoryNotFoundException directoryNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(directoryNotFoundException);
+        }
+        catch (UnauthorizedAccessException unauthorizedAccessException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(unauthorizedAccessException);
+        }
+        catch (IOException ioException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(ioException);
+        }
+        catch (Exception exception)
+        {
+            var failedMemoryServiceException =
+                new FailedMemoryServiceException(
+                    message: "Failed memory service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedMemoryServiceException);
+        }
+    }
+
+    private async ValueTask<MemoryValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var memoryValidationException =
+            new MemoryValidationException(
+                message: "Memory validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(memoryValidationException);
+
+        return memoryValidationException;
+    }
+
+    private async ValueTask<MemoryDependencyException> CreateAndLogCriticalDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedMemoryDependencyException =
+            new FailedMemoryDependencyException(
+                message: "Failed memory dependency error occurred, contact support.",
+                innerException: exception);
+
+        var memoryDependencyException =
+            new MemoryDependencyException(
+                message: "Memory dependency error occurred, contact support.",
+                innerException: failedMemoryDependencyException);
+
+        await this.loggingBroker.LogCriticalAsync(memoryDependencyException);
+
+        return memoryDependencyException;
+    }
+
+    private async ValueTask<MemoryDependencyException> CreateAndLogDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedMemoryDependencyException =
+            new FailedMemoryDependencyException(
+                message: "Failed memory dependency error occurred, contact support.",
+                innerException: exception);
+
+        var memoryDependencyException =
+            new MemoryDependencyException(
+                message: "Memory dependency error occurred, contact support.",
+                innerException: failedMemoryDependencyException);
+
+        await this.loggingBroker.LogErrorAsync(memoryDependencyException);
+
+        return memoryDependencyException;
+    }
+
+    private async ValueTask<MemoryServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var memoryServiceException =
+            new MemoryServiceException(
+                message: "Memory service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(memoryServiceException);
+
+        return memoryServiceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Data/MemoryService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Data/MemoryService.Validations.cs
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Memories.Exceptions;
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+public partial class MemoryService
+{
+    // Only the write. An empty memory is not a memory — writing one appends a blank
+    // line the store reads back forever as a memory that says nothing.
+    private static void ValidateMemory(string memory)
+    {
+        if (string.IsNullOrWhiteSpace(memory))
+        {
+            throw new InvalidMemoryException(
+                message: "Invalid memory. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Data/MemoryService.cs
+++ b/Standard.Agents/Services/Foundations/Data/MemoryService.cs
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Data;
+using Standard.Agents.Brokers.Loggings;
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+public partial class MemoryService : IMemoryService
+{
+    private readonly IMemoryBroker memoryBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public MemoryService(
+        IMemoryBroker memoryBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.memoryBroker = memoryBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<IReadOnlyList<string>> RecallMemoriesAsync() =>
+        throw new NotImplementedException();
+
+    public ValueTask RememberAsync(string memory) =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents/Services/Foundations/Data/MemoryService.cs
+++ b/Standard.Agents/Services/Foundations/Data/MemoryService.cs
@@ -21,9 +21,15 @@ public partial class MemoryService : IMemoryService
         this.loggingBroker = loggingBroker;
     }
 
-    public async ValueTask<IReadOnlyList<string>> RecallMemoriesAsync() =>
-        await this.memoryBroker.SelectMemoriesAsync();
+    public ValueTask<IReadOnlyList<string>> RecallMemoriesAsync() =>
+    TryCatch(async () =>
+        await this.memoryBroker.SelectMemoriesAsync());
 
-    public async ValueTask RememberAsync(string memory) =>
+    public ValueTask RememberAsync(string memory) =>
+    TryCatch(async () =>
+    {
+        ValidateMemory(memory);
+
         await this.memoryBroker.InsertMemoryAsync(memory);
+    });
 }

--- a/Standard.Agents/Services/Foundations/Data/MemoryService.cs
+++ b/Standard.Agents/Services/Foundations/Data/MemoryService.cs
@@ -21,9 +21,9 @@ public partial class MemoryService : IMemoryService
         this.loggingBroker = loggingBroker;
     }
 
-    public ValueTask<IReadOnlyList<string>> RecallMemoriesAsync() =>
-        throw new NotImplementedException();
+    public async ValueTask<IReadOnlyList<string>> RecallMemoriesAsync() =>
+        await this.memoryBroker.SelectMemoriesAsync();
 
-    public ValueTask RememberAsync(string memory) =>
-        throw new NotImplementedException();
+    public async ValueTask RememberAsync(string memory) =>
+        await this.memoryBroker.InsertMemoryAsync(memory);
 }


### PR DESCRIPTION
The Memory foundation — both sides. SPEC.md §4.2. `SelectMemories` → **Recall**, `InsertMemory` → **Remember**.

```csharp
ValueTask<IReadOnlyList<string>> RecallMemoriesAsync();
ValueTask RememberAsync(string memory);
```

Theory Ch.7: *"The agent instance is ephemeral compute. Memory is a durable, external resource."*

## TDD

```
ShouldRecallMemoriesAsync                                          -> FAIL / PASS
ShouldRecallNoMemoriesOnRecallMemoriesIfStoreIsEmptyAsync          -> FAIL / PASS
ShouldRememberAsync                                                -> FAIL / PASS
ShouldThrowValidationExceptionOnRememberIfMemoryIsInvalid...       -> FAIL / PASS  (3 cases)
ShouldThrowDependencyExceptionOnRecallMemories...CriticalError...  -> FAIL / PASS  (3 cases)
ShouldThrowDependencyExceptionOnRecallMemories...IOError...        -> FAIL / PASS
ShouldThrowServiceExceptionOnRecallMemories...ServiceError...      -> FAIL / PASS
ShouldThrowDependencyExceptionOnRemember...DependencyError...      -> FAIL / PASS
```

## An empty recall is a state, not a failure

Every agent starts there on its first run. The broker guarantees the store exists (#10), so absence never reaches this service as an exception — **the empty list is the honest answer, not a fallback**. The test passes with no special case, which is the point.

## A failed write must throw, never be swallowed

Invariant §7.4 puts memory *outside* the agent. If a write is lost silently, **the agent believes it remembered something it did not** — and only finds out next session, when the memory is simply absent and nothing explains why.

## Only the write is validated

An empty memory is not a memory — writing one appends a blank line the store reads back forever as *a memory that says nothing*. `RecallMemoriesAsync` takes no input, so it has nothing to validate.

## Two TryCatch overloads

One for `ValueTask<IReadOnlyList<string>>`, one for bare `ValueTask`. The catch lists are identical **by necessity, not copy-paste** — a single generic `TryCatch` cannot span `ValueTask` and `ValueTask<T>`, because the non-generic one has nothing to return.

## Catch order, same trap as SkillService

`FileNotFound` / `DirectoryNotFound` / `UnauthorizedAccess` sit **above** `IOException` — the first two derive from it. Above, they log Critical; below, they'd be swallowed and a missing directory would report as a transient error. Commented in place.

**Six exception models, not Brains' seven** — no `DependencyValidation`. A file store has no equivalent of *"your request was malformed"*: you either read the file or you don't.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 89, Total: 89**

Closes #22, closes #23
