### PR TITLE
FOUNDATIONS: Retrieve Knowledge

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/KnowledgeServiceTests.Exceptions.RetrieveKnowledge.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/KnowledgeServiceTests.Exceptions.RetrieveKnowledge.cs
@@ -1,0 +1,166 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Knowledges.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class KnowledgeServiceTests
+{
+    // The store is unreachable or unwritable — deployment or permissions, not a blip.
+    public static TheoryData<Exception> CriticalDependencyExceptions() =>
+        new()
+        {
+            new FileNotFoundException(),
+            new DirectoryNotFoundException(),
+            new UnauthorizedAccessException()
+        };
+
+    [Theory]
+    [MemberData(nameof(CriticalDependencyExceptions))]
+    public async Task ShouldThrowDependencyExceptionOnRetrieveKnowledgeIfCriticalErrorOccursAndLogItAsync(
+        Exception criticalDependencyException)
+    {
+        // given
+        string randomQuery = CreateRandomString();
+
+        var failedKnowledgeDependencyException =
+            new FailedKnowledgeDependencyException(
+                message: "Failed knowledge dependency error occurred, contact support.",
+                innerException: criticalDependencyException);
+
+        var expectedKnowledgeDependencyException =
+            new KnowledgeDependencyException(
+                message: "Knowledge dependency error occurred, contact support.",
+                innerException: failedKnowledgeDependencyException);
+
+        this.knowledgeBrokerMock.Setup(broker =>
+            broker.SelectKnowledgeAsync(randomQuery))
+                .ThrowsAsync(criticalDependencyException);
+
+        // when
+        ValueTask<IReadOnlyList<string>> retrieveTask =
+            this.knowledgeService.RetrieveKnowledgeAsync(randomQuery);
+
+        KnowledgeDependencyException actualKnowledgeDependencyException =
+            await Assert.ThrowsAsync<KnowledgeDependencyException>(
+                retrieveTask.AsTask);
+
+        // then
+        actualKnowledgeDependencyException.Should()
+            .BeEquivalentTo(expectedKnowledgeDependencyException);
+
+        this.knowledgeBrokerMock.Verify(broker =>
+            broker.SelectKnowledgeAsync(randomQuery),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogCriticalAsync(It.Is(SameExceptionAs(
+                expectedKnowledgeDependencyException))),
+                    Times.Once);
+
+        this.knowledgeBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowDependencyExceptionOnRetrieveKnowledgeIfIOErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomQuery = CreateRandomString();
+        var ioException = new IOException();
+
+        var failedKnowledgeDependencyException =
+            new FailedKnowledgeDependencyException(
+                message: "Failed knowledge dependency error occurred, contact support.",
+                innerException: ioException);
+
+        var expectedKnowledgeDependencyException =
+            new KnowledgeDependencyException(
+                message: "Knowledge dependency error occurred, contact support.",
+                innerException: failedKnowledgeDependencyException);
+
+        this.knowledgeBrokerMock.Setup(broker =>
+            broker.SelectKnowledgeAsync(randomQuery))
+                .ThrowsAsync(ioException);
+
+        // when
+        ValueTask<IReadOnlyList<string>> retrieveTask =
+            this.knowledgeService.RetrieveKnowledgeAsync(randomQuery);
+
+        KnowledgeDependencyException actualKnowledgeDependencyException =
+            await Assert.ThrowsAsync<KnowledgeDependencyException>(
+                retrieveTask.AsTask);
+
+        // then
+        actualKnowledgeDependencyException.Should()
+            .BeEquivalentTo(expectedKnowledgeDependencyException);
+
+        this.knowledgeBrokerMock.Verify(broker =>
+            broker.SelectKnowledgeAsync(randomQuery),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedKnowledgeDependencyException))),
+                    Times.Once);
+
+        this.knowledgeBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnRetrieveKnowledgeIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomQuery = CreateRandomString();
+        var serviceException = new Exception();
+
+        var failedKnowledgeServiceException =
+            new FailedKnowledgeServiceException(
+                message: "Failed knowledge service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedKnowledgeServiceException =
+            new KnowledgeServiceException(
+                message: "Knowledge service error occurred, contact support.",
+                innerException: failedKnowledgeServiceException);
+
+        this.knowledgeBrokerMock.Setup(broker =>
+            broker.SelectKnowledgeAsync(randomQuery))
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<IReadOnlyList<string>> retrieveTask =
+            this.knowledgeService.RetrieveKnowledgeAsync(randomQuery);
+
+        KnowledgeServiceException actualKnowledgeServiceException =
+            await Assert.ThrowsAsync<KnowledgeServiceException>(
+                retrieveTask.AsTask);
+
+        // then
+        actualKnowledgeServiceException.Should()
+            .BeEquivalentTo(expectedKnowledgeServiceException);
+
+        this.knowledgeBrokerMock.Verify(broker =>
+            broker.SelectKnowledgeAsync(randomQuery),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedKnowledgeServiceException))),
+                    Times.Once);
+
+        this.knowledgeBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // A failed write must throw, never be swallowed. Invariant 7.4 puts knowledge
+    // outside the agent — if a write is lost silently, the agent believes it
+    // remembered something it did not, and only discovers otherwise next session.
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/KnowledgeServiceTests.Logic.RetrieveKnowledge.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/KnowledgeServiceTests.Logic.RetrieveKnowledge.cs
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class KnowledgeServiceTests
+{
+    [Fact]
+    public async Task ShouldRetrieveKnowledgeAsync()
+    {
+        // given
+        string randomQuery = CreateRandomString();
+        List<string> randomDocuments = CreateRandomDocuments();
+        string inputQuery = randomQuery;
+        IReadOnlyList<string> retrievedDocuments = randomDocuments;
+        IReadOnlyList<string> expectedDocuments = retrievedDocuments;
+
+        this.knowledgeBrokerMock.Setup(broker =>
+            broker.SelectKnowledgeAsync(inputQuery))
+                .ReturnsAsync(retrievedDocuments);
+
+        // when
+        IReadOnlyList<string> actualDocuments =
+            await this.knowledgeService.RetrieveKnowledgeAsync(inputQuery);
+
+        // then
+        actualDocuments.Should().BeEquivalentTo(expectedDocuments);
+
+        this.knowledgeBrokerMock.Verify(broker =>
+            broker.SelectKnowledgeAsync(inputQuery),
+                Times.Once);
+
+        this.knowledgeBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // Finding nothing is an answer, not a failure. A query with no hits means the
+    // agent looked and there was nothing there — which is exactly what Recall should
+    // report, rather than throwing and killing a turn that could proceed without it.
+    [Fact]
+    public async Task ShouldRetrieveNoKnowledgeOnRetrieveKnowledgeIfNothingMatchesAsync()
+    {
+        // given
+        string randomQuery = CreateRandomString();
+        IReadOnlyList<string> noDocuments = [];
+        IReadOnlyList<string> expectedDocuments = noDocuments;
+
+        this.knowledgeBrokerMock.Setup(broker =>
+            broker.SelectKnowledgeAsync(randomQuery))
+                .ReturnsAsync(noDocuments);
+
+        // when
+        IReadOnlyList<string> actualDocuments =
+            await this.knowledgeService.RetrieveKnowledgeAsync(randomQuery);
+
+        // then
+        actualDocuments.Should().BeEmpty();
+        actualDocuments.Should().BeEquivalentTo(expectedDocuments);
+
+        this.knowledgeBrokerMock.Verify(broker =>
+            broker.SelectKnowledgeAsync(randomQuery),
+                Times.Once);
+
+        this.knowledgeBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/KnowledgeServiceTests.Validations.RetrieveKnowledge.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/KnowledgeServiceTests.Validations.RetrieveKnowledge.cs
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Knowledges.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class KnowledgeServiceTests
+{
+    // An empty query is not a search. The default broker matches by substring, and
+    // every document contains the empty string — so an unvalidated empty query would
+    // return the entire corpus and quietly flood the context window.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnRetrieveKnowledgeIfQueryIsInvalidAndLogItAsync(
+        string invalidQuery)
+    {
+        // given
+        var invalidKnowledgeException =
+            new InvalidKnowledgeException(
+                message: "Invalid knowledge query. Please correct the error and try again.");
+
+        var expectedKnowledgeValidationException =
+            new KnowledgeValidationException(
+                message: "Knowledge validation error occurred, fix the error and try again.",
+                innerException: invalidKnowledgeException);
+
+        // when
+        ValueTask<IReadOnlyList<string>> retrieveTask =
+            this.knowledgeService.RetrieveKnowledgeAsync(invalidQuery);
+
+        KnowledgeValidationException actualKnowledgeValidationException =
+            await Assert.ThrowsAsync<KnowledgeValidationException>(
+                retrieveTask.AsTask);
+
+        // then
+        actualKnowledgeValidationException.Should()
+            .BeEquivalentTo(expectedKnowledgeValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedKnowledgeValidationException))),
+                    Times.Once);
+
+        this.knowledgeBrokerMock.Verify(broker =>
+            broker.SelectKnowledgeAsync(It.IsAny<string>()),
+                Times.Never);
+
+        this.knowledgeBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/KnowledgeServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/KnowledgeServiceTests.cs
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Data;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Foundations.Data;
+using Tynamix.ObjectFiller;
+using Xeptions;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Data;
+
+public partial class KnowledgeServiceTests
+{
+    private readonly Mock<IKnowledgeBroker> knowledgeBrokerMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly IKnowledgeService knowledgeService;
+
+    public KnowledgeServiceTests()
+    {
+        this.knowledgeBrokerMock = new Mock<IKnowledgeBroker>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.knowledgeService = new KnowledgeService(
+            knowledgeBroker: this.knowledgeBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static List<string> CreateRandomDocuments() =>
+        Enumerable.Range(0, 3).Select(_ => CreateRandomString()).ToList();
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents/Models/Foundations/Knowledges/Exceptions/FailedKnowledgeDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Knowledges/Exceptions/FailedKnowledgeDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Knowledges.Exceptions;
+
+public class FailedKnowledgeDependencyException : Xeption
+{
+    public FailedKnowledgeDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Knowledges/Exceptions/FailedKnowledgeServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Knowledges/Exceptions/FailedKnowledgeServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Knowledges.Exceptions;
+
+public class FailedKnowledgeServiceException : Xeption
+{
+    public FailedKnowledgeServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Knowledges/Exceptions/InvalidKnowledgeException.cs
+++ b/Standard.Agents/Models/Foundations/Knowledges/Exceptions/InvalidKnowledgeException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Knowledges.Exceptions;
+
+public class InvalidKnowledgeException : Xeption
+{
+    public InvalidKnowledgeException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Knowledges.Exceptions;
+
+public class KnowledgeDependencyException : Xeption
+{
+    public KnowledgeDependencyException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Knowledges.Exceptions;
+
+public class KnowledgeServiceException : Xeption
+{
+    public KnowledgeServiceException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Knowledges.Exceptions;
+
+public class KnowledgeValidationException : Xeption
+{
+    public KnowledgeValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Services/Foundations/Data/IKnowledgeService.cs
+++ b/Standard.Agents/Services/Foundations/Data/IKnowledgeService.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+public interface IKnowledgeService
+{
+    ValueTask<IReadOnlyList<string>> RetrieveKnowledgeAsync(string query);
+}

--- a/Standard.Agents/Services/Foundations/Data/KnowledgeService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Data/KnowledgeService.Exceptions.cs
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Knowledges.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+public partial class KnowledgeService
+{
+    private delegate ValueTask<IReadOnlyList<string>> ReturningDocumentsFunction();
+    
+    private async ValueTask<IReadOnlyList<string>> TryCatch(
+        ReturningDocumentsFunction returningDocumentsFunction)
+    {
+        try
+        {
+            return await returningDocumentsFunction();
+        }
+        catch (InvalidKnowledgeException invalidKnowledgeException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidKnowledgeException);
+        }
+        catch (FileNotFoundException fileNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(fileNotFoundException);
+        }
+        catch (DirectoryNotFoundException directoryNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(directoryNotFoundException);
+        }
+        catch (UnauthorizedAccessException unauthorizedAccessException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(unauthorizedAccessException);
+        }
+        // Below the three above — they all derive from IOException and would be
+        // swallowed here, downgrading a deployment fault to a transient error.
+        catch (IOException ioException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(ioException);
+        }
+        catch (Exception exception)
+        {
+            var failedKnowledgeServiceException =
+                new FailedKnowledgeServiceException(
+                    message: "Failed knowledge service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedKnowledgeServiceException);
+        }
+    }
+
+    private async ValueTask<KnowledgeValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var knowledgeValidationException =
+            new KnowledgeValidationException(
+                message: "Knowledge validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(knowledgeValidationException);
+
+        return knowledgeValidationException;
+    }
+
+    private async ValueTask<KnowledgeDependencyException> CreateAndLogCriticalDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedKnowledgeDependencyException =
+            new FailedKnowledgeDependencyException(
+                message: "Failed knowledge dependency error occurred, contact support.",
+                innerException: exception);
+
+        var knowledgeDependencyException =
+            new KnowledgeDependencyException(
+                message: "Knowledge dependency error occurred, contact support.",
+                innerException: failedKnowledgeDependencyException);
+
+        await this.loggingBroker.LogCriticalAsync(knowledgeDependencyException);
+
+        return knowledgeDependencyException;
+    }
+
+    private async ValueTask<KnowledgeDependencyException> CreateAndLogDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedKnowledgeDependencyException =
+            new FailedKnowledgeDependencyException(
+                message: "Failed knowledge dependency error occurred, contact support.",
+                innerException: exception);
+
+        var knowledgeDependencyException =
+            new KnowledgeDependencyException(
+                message: "Knowledge dependency error occurred, contact support.",
+                innerException: failedKnowledgeDependencyException);
+
+        await this.loggingBroker.LogErrorAsync(knowledgeDependencyException);
+
+        return knowledgeDependencyException;
+    }
+
+    private async ValueTask<KnowledgeServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var knowledgeServiceException =
+            new KnowledgeServiceException(
+                message: "Knowledge service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(knowledgeServiceException);
+
+        return knowledgeServiceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Data/KnowledgeService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Data/KnowledgeService.Validations.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Knowledges.Exceptions;
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+public partial class KnowledgeService
+{
+    // An empty query is not a search. The default broker matches by substring and
+    // every document contains the empty string, so an unvalidated empty query would
+    // return the whole corpus and flood the context window.
+    private static void ValidateQuery(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            throw new InvalidKnowledgeException(
+                message: "Invalid knowledge query. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Data/KnowledgeService.cs
+++ b/Standard.Agents/Services/Foundations/Data/KnowledgeService.cs
@@ -22,5 +22,10 @@ public partial class KnowledgeService : IKnowledgeService
     }
 
     public ValueTask<IReadOnlyList<string>> RetrieveKnowledgeAsync(string query) =>
-        throw new NotImplementedException();
+    TryCatch(async () =>
+    {
+        ValidateQuery(query);
+
+        return await this.knowledgeBroker.SelectKnowledgeAsync(query);
+    });
 }

--- a/Standard.Agents/Services/Foundations/Data/KnowledgeService.cs
+++ b/Standard.Agents/Services/Foundations/Data/KnowledgeService.cs
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Data;
+using Standard.Agents.Brokers.Loggings;
+
+namespace Standard.Agents.Services.Foundations.Data;
+
+public partial class KnowledgeService : IKnowledgeService
+{
+    private readonly IKnowledgeBroker knowledgeBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public KnowledgeService(
+        IKnowledgeBroker knowledgeBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.knowledgeBroker = knowledgeBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<IReadOnlyList<string>> RetrieveKnowledgeAsync(string query) =>
+        throw new NotImplementedException();
+}


### PR DESCRIPTION
The Knowledge foundation. SPEC.md §4.2. `SelectKnowledge` → **Retrieve**.

```csharp
ValueTask<IReadOnlyList<string>> RetrieveKnowledgeAsync(string query);
```

Theory Ch.5: Knowledge is *"what I can look up now."* The theory doc listed it under *"theory until wired"* — **wired now**, on top of the real broker from #12.

## Why an empty query is rejected

The consequence is specific to the default broker: it **matches by substring, and every document contains the empty string**. An unvalidated empty query would return the **entire corpus** and quietly flood the context window — no error, no log, just an agent drowning in its own documents.

## Finding nothing is an answer

`ShouldRetrieveNoKnowledgeOnRetrieveKnowledgeIfNothingMatchesAsync` — the agent looked and there was nothing there. Throwing would kill a turn that could proceed perfectly well without the lookup. Passes with no special case.

## One TryCatch overload

Knowledge is **read-only**, so unlike `MemoryService` there's no void variant. Same file-store surface otherwise — six exception models, no `DependencyValidation` (a filesystem has no *"your request was malformed"*).

Same `IOException` trap, same fix: `FileNotFound` / `DirectoryNotFound` / `UnauthorizedAccess` sit **above** it, or the derived types get swallowed and a missing directory logs as transient.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 99, Total: 99** (10 new cases)

**This completes the Data tri-nature** — Skills, Memory, Knowledge. *What I was taught, what I remember, what I can look up.*

Closes #24
