### PR TITLE
FOUNDATIONS: Call External Tool

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ExternalToolServiceTests.Exceptions.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ExternalToolServiceTests.Exceptions.Call.cs
@@ -1,0 +1,224 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using RESTFulSense.Exceptions;
+using Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class ExternalToolServiceTests
+{
+    public static TheoryData<Exception> CriticalDependencyExceptions() =>
+        new()
+        {
+            new HttpResponseUnauthorizedException(),
+            new HttpResponseForbiddenException(),
+            new HttpResponseNotFoundException(),
+            new HttpResponseUrlNotFoundException(),
+            new HttpRequestException()
+        };
+
+    public static TheoryData<Exception> DependencyExceptions() =>
+        new()
+        {
+            new HttpResponseInternalServerErrorException(),
+            new HttpResponseServiceUnavailableException()
+        };
+
+    // A THROWING external tool is a dependency failure — distinct from one that
+    // returns an error string, which ShouldReturnToolOutputOnCallEvenIfToolReports-
+    // AnError pins as a normal result.
+    [Theory]
+    [MemberData(nameof(CriticalDependencyExceptions))]
+    public async Task ShouldThrowCriticalDependencyExceptionOnCallIfCriticalErrorOccursAndLogItAsync(
+        Exception criticalDependencyException)
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomInput = CreateRandomString();
+
+        var failedExternalToolDependencyException =
+            new FailedExternalToolDependencyException(
+                message: "Failed external tool dependency error occurred, contact support.",
+                innerException: criticalDependencyException);
+
+        var expectedExternalToolDependencyException =
+            new ExternalToolDependencyException(
+                message: "External tool dependency error occurred, contact support.",
+                innerException: failedExternalToolDependencyException);
+
+        this.mcpBrokerMock.Setup(broker =>
+            broker.CallAsync(randomName, randomInput))
+                .ThrowsAsync(criticalDependencyException);
+
+        // when
+        ValueTask<string> callTask =
+            this.externalToolService.CallAsync(randomName, randomInput);
+
+        ExternalToolDependencyException actualExternalToolDependencyException =
+            await Assert.ThrowsAsync<ExternalToolDependencyException>(
+                callTask.AsTask);
+
+        // then
+        actualExternalToolDependencyException.Should()
+            .BeEquivalentTo(expectedExternalToolDependencyException);
+
+        this.mcpBrokerMock.Verify(broker =>
+            broker.CallAsync(randomName, randomInput),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogCriticalAsync(It.Is(SameExceptionAs(
+                expectedExternalToolDependencyException))),
+                    Times.Once);
+
+        this.mcpBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [MemberData(nameof(DependencyExceptions))]
+    public async Task ShouldThrowDependencyExceptionOnCallIfDependencyErrorOccursAndLogItAsync(
+        Exception dependencyException)
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomInput = CreateRandomString();
+
+        var failedExternalToolDependencyException =
+            new FailedExternalToolDependencyException(
+                message: "Failed external tool dependency error occurred, contact support.",
+                innerException: dependencyException);
+
+        var expectedExternalToolDependencyException =
+            new ExternalToolDependencyException(
+                message: "External tool dependency error occurred, contact support.",
+                innerException: failedExternalToolDependencyException);
+
+        this.mcpBrokerMock.Setup(broker =>
+            broker.CallAsync(randomName, randomInput))
+                .ThrowsAsync(dependencyException);
+
+        // when
+        ValueTask<string> callTask =
+            this.externalToolService.CallAsync(randomName, randomInput);
+
+        ExternalToolDependencyException actualExternalToolDependencyException =
+            await Assert.ThrowsAsync<ExternalToolDependencyException>(
+                callTask.AsTask);
+
+        // then
+        actualExternalToolDependencyException.Should()
+            .BeEquivalentTo(expectedExternalToolDependencyException);
+
+        this.mcpBrokerMock.Verify(broker =>
+            broker.CallAsync(randomName, randomInput),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedExternalToolDependencyException))),
+                    Times.Once);
+
+        this.mcpBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowDependencyValidationExceptionOnCallIfBadRequestErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomInput = CreateRandomString();
+        var badRequestException = new HttpResponseBadRequestException();
+
+        var invalidExternalToolException =
+            new InvalidExternalToolException(
+                message: "Invalid external tool request. Please correct the error and try again.");
+
+        var expectedExternalToolDependencyValidationException =
+            new ExternalToolDependencyValidationException(
+                message: "External tool dependency validation error occurred, fix the error and try again.",
+                innerException: invalidExternalToolException);
+
+        this.mcpBrokerMock.Setup(broker =>
+            broker.CallAsync(randomName, randomInput))
+                .ThrowsAsync(badRequestException);
+
+        // when
+        ValueTask<string> callTask =
+            this.externalToolService.CallAsync(randomName, randomInput);
+
+        ExternalToolDependencyValidationException actualExternalToolDependencyValidationException =
+            await Assert.ThrowsAsync<ExternalToolDependencyValidationException>(
+                callTask.AsTask);
+
+        // then
+        actualExternalToolDependencyValidationException.Should()
+            .BeEquivalentTo(expectedExternalToolDependencyValidationException);
+
+        this.mcpBrokerMock.Verify(broker =>
+            broker.CallAsync(randomName, randomInput),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedExternalToolDependencyValidationException))),
+                    Times.Once);
+
+        this.mcpBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnCallIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomInput = CreateRandomString();
+        var serviceException = new Exception();
+
+        var failedExternalToolServiceException =
+            new FailedExternalToolServiceException(
+                message: "Failed external tool service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedExternalToolServiceException =
+            new ExternalToolServiceException(
+                message: "External tool service error occurred, contact support.",
+                innerException: failedExternalToolServiceException);
+
+        this.mcpBrokerMock.Setup(broker =>
+            broker.CallAsync(randomName, randomInput))
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<string> callTask =
+            this.externalToolService.CallAsync(randomName, randomInput);
+
+        ExternalToolServiceException actualExternalToolServiceException =
+            await Assert.ThrowsAsync<ExternalToolServiceException>(
+                callTask.AsTask);
+
+        // then
+        actualExternalToolServiceException.Should()
+            .BeEquivalentTo(expectedExternalToolServiceException);
+
+        this.mcpBrokerMock.Verify(broker =>
+            broker.CallAsync(randomName, randomInput),
+                Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedExternalToolServiceException))),
+                    Times.Once);
+
+        this.mcpBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ExternalToolServiceTests.Logic.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ExternalToolServiceTests.Logic.Call.cs
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class ExternalToolServiceTests
+{
+    [Fact]
+    public async Task ShouldCallAsync()
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomInput = CreateRandomString();
+        string randomOutput = CreateRandomString();
+        string inputName = randomName;
+        string inputInput = randomInput;
+        string expectedOutput = randomOutput;
+
+        this.mcpBrokerMock.Setup(broker =>
+            broker.CallAsync(inputName, inputInput))
+                .ReturnsAsync(randomOutput);
+
+        // when
+        string actualOutput =
+            await this.externalToolService.CallAsync(inputName, inputInput);
+
+        // then
+        actualOutput.Should().BeEquivalentTo(expectedOutput);
+
+        this.mcpBrokerMock.Verify(broker =>
+            broker.CallAsync(inputName, inputInput),
+                Times.Once);
+
+        this.mcpBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // Same rule as InternalToolService: a tool that RETURNS an error string is a
+    // result, not a failure. It becomes an observation and the loop carries on.
+    [Fact]
+    public async Task ShouldReturnToolOutputOnCallEvenIfToolReportsAnErrorAsync()
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomInput = CreateRandomString();
+        string toolReportedError = "error: upstream returned no data";
+        string expectedOutput = toolReportedError;
+
+        this.mcpBrokerMock.Setup(broker =>
+            broker.CallAsync(randomName, randomInput))
+                .ReturnsAsync(toolReportedError);
+
+        // when
+        string actualOutput =
+            await this.externalToolService.CallAsync(randomName, randomInput);
+
+        // then
+        actualOutput.Should().BeEquivalentTo(expectedOutput);
+
+        this.mcpBrokerMock.Verify(broker =>
+            broker.CallAsync(randomName, randomInput),
+                Times.Once);
+
+        this.mcpBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ExternalToolServiceTests.Validations.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ExternalToolServiceTests.Validations.Call.cs
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class ExternalToolServiceTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnCallIfNameIsInvalidAndLogItAsync(
+        string invalidName)
+    {
+        // given
+        string randomInput = CreateRandomString();
+
+        var invalidExternalToolException =
+            new InvalidExternalToolException(
+                message: "Invalid external tool. Please correct the error and try again.");
+
+        var expectedExternalToolValidationException =
+            new ExternalToolValidationException(
+                message: "External tool validation error occurred, fix the error and try again.",
+                innerException: invalidExternalToolException);
+
+        // when
+        ValueTask<string> callTask =
+            this.externalToolService.CallAsync(invalidName, randomInput);
+
+        ExternalToolValidationException actualExternalToolValidationException =
+            await Assert.ThrowsAsync<ExternalToolValidationException>(
+                callTask.AsTask);
+
+        // then
+        actualExternalToolValidationException.Should()
+            .BeEquivalentTo(expectedExternalToolValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedExternalToolValidationException))),
+                    Times.Once);
+
+        // Validation before the dependency call — nothing crosses the boundary on a
+        // request we already know is malformed.
+        this.mcpBrokerMock.Verify(broker =>
+            broker.CallAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.mcpBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ExternalToolServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ExternalToolServiceTests.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Direction;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Foundations.Direction;
+using Tynamix.ObjectFiller;
+using Xeptions;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Direction;
+
+public partial class ExternalToolServiceTests
+{
+    private readonly Mock<IMcpBroker> mcpBrokerMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly IExternalToolService externalToolService;
+
+    public ExternalToolServiceTests()
+    {
+        this.mcpBrokerMock = new Mock<IMcpBroker>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.externalToolService = new ExternalToolService(
+            mcpBroker: this.mcpBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+
+public class ExternalToolDependencyException : Xeption
+{
+    public ExternalToolDependencyException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolDependencyValidationException.cs
+++ b/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolDependencyValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+
+public class ExternalToolDependencyValidationException : Xeption
+{
+    public ExternalToolDependencyValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolServiceException.cs
+++ b/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+
+public class ExternalToolServiceException : Xeption
+{
+    public ExternalToolServiceException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolValidationException.cs
+++ b/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+
+public class ExternalToolValidationException : Xeption
+{
+    public ExternalToolValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/FailedExternalToolDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/FailedExternalToolDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+
+public class FailedExternalToolDependencyException : Xeption
+{
+    public FailedExternalToolDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/FailedExternalToolServiceException.cs
+++ b/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/FailedExternalToolServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+
+public class FailedExternalToolServiceException : Xeption
+{
+    public FailedExternalToolServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/InvalidExternalToolException.cs
+++ b/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/InvalidExternalToolException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+
+public class InvalidExternalToolException : Xeption
+{
+    public InvalidExternalToolException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Services/Foundations/Direction/ExternalToolService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ExternalToolService.Exceptions.cs
@@ -1,0 +1,158 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using RESTFulSense.Exceptions;
+using Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public partial class ExternalToolService
+{
+    private delegate ValueTask<string> ReturningStringFunction();
+
+    // A throwing tool is a dependency failure. A tool that RETURNS an error string
+    // never reaches here — that is a result, and it becomes an observation so the
+    // loop can recover (vector 05).
+    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    {
+        try
+        {
+            return await returningStringFunction();
+        }
+        catch (InvalidExternalToolException invalidExternalToolException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidExternalToolException);
+        }
+        catch (HttpResponseBadRequestException httpResponseBadRequestException)
+        {
+            var invalidExternalToolException =
+                new InvalidExternalToolException(
+                    message: "Invalid external tool request. Please correct the error and try again.");
+
+            invalidExternalToolException.AddData(httpResponseBadRequestException.Data);
+
+            throw await CreateAndLogDependencyValidationExceptionAsync(invalidExternalToolException);
+        }
+        catch (HttpResponseUnauthorizedException httpResponseUnauthorizedException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseUnauthorizedException);
+        }
+        catch (HttpResponseForbiddenException httpResponseForbiddenException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseForbiddenException);
+        }
+        catch (HttpResponseNotFoundException httpResponseNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseNotFoundException);
+        }
+        catch (HttpResponseUrlNotFoundException httpResponseUrlNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(
+                httpResponseUrlNotFoundException);
+        }
+        catch (HttpResponseInternalServerErrorException httpResponseInternalServerErrorException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                httpResponseInternalServerErrorException);
+        }
+        catch (HttpResponseServiceUnavailableException httpResponseServiceUnavailableException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                httpResponseServiceUnavailableException);
+        }
+        catch (HttpRequestException httpRequestException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(httpRequestException);
+        }
+        catch (Exception exception)
+        {
+            var failedExternalToolServiceException =
+                new FailedExternalToolServiceException(
+                    message: "Failed external tool service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedExternalToolServiceException);
+        }
+    }
+
+    private async ValueTask<ExternalToolValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var externalToolValidationException =
+            new ExternalToolValidationException(
+                message: "External tool validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(externalToolValidationException);
+
+        return externalToolValidationException;
+    }
+
+    private async ValueTask<ExternalToolDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+        Xeption exception)
+    {
+        var externalToolDependencyValidationException =
+            new ExternalToolDependencyValidationException(
+                message: "External tool dependency validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(externalToolDependencyValidationException);
+
+        return externalToolDependencyValidationException;
+    }
+
+    private async ValueTask<ExternalToolDependencyException> CreateAndLogCriticalDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedExternalToolDependencyException =
+            new FailedExternalToolDependencyException(
+                message: "Failed external tool dependency error occurred, contact support.",
+                innerException: exception);
+
+        var externalToolDependencyException =
+            new ExternalToolDependencyException(
+                message: "External tool dependency error occurred, contact support.",
+                innerException: failedExternalToolDependencyException);
+
+        await this.loggingBroker.LogCriticalAsync(externalToolDependencyException);
+
+        return externalToolDependencyException;
+    }
+
+    private async ValueTask<ExternalToolDependencyException> CreateAndLogDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedExternalToolDependencyException =
+            new FailedExternalToolDependencyException(
+                message: "Failed external tool dependency error occurred, contact support.",
+                innerException: exception);
+
+        var externalToolDependencyException =
+            new ExternalToolDependencyException(
+                message: "External tool dependency error occurred, contact support.",
+                innerException: failedExternalToolDependencyException);
+
+        await this.loggingBroker.LogErrorAsync(externalToolDependencyException);
+
+        return externalToolDependencyException;
+    }
+
+    private async ValueTask<ExternalToolServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var externalToolServiceException =
+            new ExternalToolServiceException(
+                message: "External tool service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(externalToolServiceException);
+
+        return externalToolServiceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Direction/ExternalToolService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ExternalToolService.Validations.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public partial class ExternalToolService
+{
+    // Only the name. An external tool may legitimately take no arguments, so
+    // validating the input would reject valid work — same reasoning as
+    // InternalToolService.
+    private static void ValidateName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new InvalidExternalToolException(
+                message: "Invalid external tool. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Direction/ExternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ExternalToolService.cs
@@ -24,5 +24,10 @@ public partial class ExternalToolService : IExternalToolService
     }
 
     public ValueTask<string> CallAsync(string name, string input) =>
-        throw new NotImplementedException();
+    TryCatch(async () =>
+    {
+        ValidateName(name);
+
+        return await this.mcpBroker.CallAsync(name, input);
+    });
 }

--- a/Standard.Agents/Services/Foundations/Direction/ExternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ExternalToolService.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Direction;
+using Standard.Agents.Brokers.Loggings;
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+// Act outward, across the boundary. Invariant 7.8: external state enters only as
+// Data via a Direction that reached out, and effects leave only via Direction.
+public partial class ExternalToolService : IExternalToolService
+{
+    private readonly IMcpBroker mcpBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public ExternalToolService(
+        IMcpBroker mcpBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.mcpBroker = mcpBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<string> CallAsync(string name, string input) =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents/Services/Foundations/Direction/IExternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/Direction/IExternalToolService.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Foundations.Direction;
+
+public interface IExternalToolService
+{
+    ValueTask<string> CallAsync(string name, string input);
+}


### PR DESCRIPTION
Act outward, across the boundary. SPEC.md §4.2. **The ninth and last foundation.**

```csharp
ValueTask<string> CallAsync(string name, string input);
```

Invariant §7.8: *external state MUST enter only as Data (via a Direction that reached out) and effects MUST leave only via Direction.*

## The error-vs-failure line holds on both sides of the boundary

`ShouldReturnToolOutputOnCallEvenIfToolReportsAnErrorAsync` repeats `InternalToolService`'s rule:

| Tool behaviour | Meaning |
|---|---|
| **returns** an error string | a result → becomes an observation, loop carries on |
| **throws** | a dependency failure → categorised, logged, propagated |

This has to hold **identically on both loci**, because Direction routes to whichever one has the tool (#34) and the loop must behave the same either way. Vector `05-unknown-tool-recovers` depends on it.

A JSON-RPC error surfaces as `HttpRequestException` from the broker (#18) and is categorised **Critical** here — the endpoint is unreachable or refusing, which is configuration, not weather.

## Seven exception models, like Brains

An HTTP dependency can answer *"your request was malformed"* → `DependencyValidation`. A filesystem cannot, which is why Skills/Memories/Knowledges carry six.

## Only the name is validated

An external tool may legitimately take no arguments — same reasoning as `InternalToolService` (#29). Validation runs before the dependency call, so **nothing crosses the boundary on a request we already know is malformed**.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 113, Total: 113** (14 new cases)

---

## This completes the FOUNDATION · 9 tier

| Data | Decision | Direction |
|---|---|---|
| Skills #21 | Gate #25 | Internal #28 #29 |
| Memory #22 #23 | Brain #26 | External #30 |
| Knowledge #24 | Judge #27 | Return #31 |

*What I was taught, remember, and can look up → screened, thought, and verified → acted out, in, or not at all.*

Next: the three orchestrations, which is where `Intent` (#33) and `Failed`/`AwaitingInput` (#34) need decisions the spec doesn't make.

Closes #30
