### PR TITLE
ORCHESTRATIONS: Recall

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Exceptions.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Exceptions.Recall.cs
@@ -41,6 +41,11 @@ public partial class DataOrchestrationServiceTests
         actualException.Should()
             .BeEquivalentTo(expectedAgentOrchestrationValidationException);
 
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedAgentOrchestrationValidationException))),
+                    Times.Once);
+
         this.skillServiceMock.Verify(service =>
             service.RetrieveSkillsAsync(),
                 Times.Never);
@@ -48,6 +53,7 @@ public partial class DataOrchestrationServiceTests
         this.skillServiceMock.VerifyNoOtherCalls();
         this.memoryServiceMock.VerifyNoOtherCalls();
         this.knowledgeServiceMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
     // Unwrap the foundation's categorical exception, preserve its LOCAL exception as
@@ -80,6 +86,12 @@ public partial class DataOrchestrationServiceTests
 
         // then
         actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
     [Theory]
@@ -109,6 +121,12 @@ public partial class DataOrchestrationServiceTests
 
         // then
         actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
     [Fact]
@@ -142,5 +160,11 @@ public partial class DataOrchestrationServiceTests
 
         // then
         actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Exceptions.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Exceptions.Recall.cs
@@ -1,0 +1,146 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+using Xeptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Data;
+
+public partial class DataOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldThrowValidationExceptionOnRecallIfContextIsNullAndLogItAsync()
+    {
+        // given
+        AgentContext nullContext = null;
+
+        var nullAgentContextException =
+            new NullAgentContextException(
+                message: "Agent context is null.");
+
+        var expectedAgentOrchestrationValidationException =
+            new AgentOrchestrationValidationException(
+                message: "Agent orchestration validation error occurred, fix the error and try again.",
+                innerException: nullAgentContextException);
+
+        // when
+        ValueTask<AgentContext> recallTask =
+            this.dataOrchestrationService.RecallAsync(nullContext);
+
+        AgentOrchestrationValidationException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationValidationException>(
+                recallTask.AsTask);
+
+        // then
+        actualException.Should()
+            .BeEquivalentTo(expectedAgentOrchestrationValidationException);
+
+        this.skillServiceMock.Verify(service =>
+            service.RetrieveSkillsAsync(),
+                Times.Never);
+
+        this.skillServiceMock.VerifyNoOtherCalls();
+        this.memoryServiceMock.VerifyNoOtherCalls();
+        this.knowledgeServiceMock.VerifyNoOtherCalls();
+    }
+
+    // Unwrap the foundation's categorical exception, preserve its LOCAL exception as
+    // the inner, rewrap in this layer's category. The local exception must survive so
+    // detail is not lost climbing the tiers.
+    [Theory]
+    [MemberData(nameof(DependencyValidationExceptions))]
+    public async Task ShouldThrowDependencyValidationExceptionOnRecallIfDependencyValidationErrorOccursAndLogItAsync(
+        Xeption foundationException)
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        var expectedException =
+            new AgentOrchestrationDependencyValidationException(
+                message: "Agent orchestration dependency validation error occurred, fix the error and try again.",
+                innerException: foundationException.InnerException as Xeption);
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync())
+                .ThrowsAsync(foundationException);
+
+        // when
+        ValueTask<AgentContext> recallTask =
+            this.dataOrchestrationService.RecallAsync(inputContext);
+
+        AgentOrchestrationDependencyValidationException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationDependencyValidationException>(
+                recallTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+    }
+
+    [Theory]
+    [MemberData(nameof(DependencyExceptions))]
+    public async Task ShouldThrowDependencyExceptionOnRecallIfDependencyErrorOccursAndLogItAsync(
+        Xeption foundationException)
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        var expectedException =
+            new AgentOrchestrationDependencyException(
+                message: "Agent orchestration dependency error occurred, contact support.",
+                innerException: foundationException.InnerException as Xeption);
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync())
+                .ThrowsAsync(foundationException);
+
+        // when
+        ValueTask<AgentContext> recallTask =
+            this.dataOrchestrationService.RecallAsync(inputContext);
+
+        AgentOrchestrationDependencyException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationDependencyException>(
+                recallTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnRecallIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        var serviceException = new Exception();
+
+        var failedAgentOrchestrationServiceException =
+            new FailedAgentOrchestrationServiceException(
+                message: "Failed agent orchestration service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedException =
+            new AgentOrchestrationServiceException(
+                message: "Agent orchestration service error occurred, contact support.",
+                innerException: failedAgentOrchestrationServiceException);
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync())
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<AgentContext> recallTask =
+            this.dataOrchestrationService.RecallAsync(inputContext);
+
+        AgentOrchestrationServiceException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationServiceException>(
+                recallTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Recall.cs
@@ -1,0 +1,134 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Data;
+
+public partial class DataOrchestrationServiceTests
+{
+    // SPEC.md 4.3: recall MUST set systemPrompt from SkillService.
+    [Fact]
+    public async Task ShouldSetSystemPromptFromSkillServiceOnRecallAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        string randomSkills = CreateRandomString();
+        string expectedSystemPrompt = randomSkills;
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync())
+                .ReturnsAsync(randomSkills);
+
+        this.memoryServiceMock.Setup(service =>
+            service.RecallMemoriesAsync())
+                .ReturnsAsync([]);
+
+        // when
+        AgentContext actualContext =
+            await this.dataOrchestrationService.RecallAsync(inputContext);
+
+        // then
+        actualContext.SystemPrompt.Should().BeEquivalentTo(expectedSystemPrompt);
+
+        this.skillServiceMock.Verify(service =>
+            service.RetrieveSkillsAsync(),
+                Times.Once);
+    }
+
+    // Copy-on-write: SPEC.md 3 makes it a MUST. The input instance must come back
+    // untouched, and the returned one must be a different object.
+    [Fact]
+    public async Task ShouldNotMutateInputContextOnRecallAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        string originalPrompt = inputContext.Prompt;
+        string randomSkills = CreateRandomString();
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync())
+                .ReturnsAsync(randomSkills);
+
+        this.memoryServiceMock.Setup(service =>
+            service.RecallMemoriesAsync())
+                .ReturnsAsync([]);
+
+        // when
+        AgentContext actualContext =
+            await this.dataOrchestrationService.RecallAsync(inputContext);
+
+        // then
+        inputContext.SystemPrompt.Should().BeEmpty();
+        inputContext.Prompt.Should().BeEquivalentTo(originalPrompt);
+        actualContext.Should().NotBeSameAs(inputContext);
+        actualContext.Prompt.Should().BeEquivalentTo(originalPrompt);
+    }
+
+    // recall MAY seed observations from Memory. Memories arrive as observations the
+    // Brain can read on the next Think.
+    [Fact]
+    public async Task ShouldSeedObservationsFromMemoriesOnRecallAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        string randomSkills = CreateRandomString();
+        List<string> randomMemories = [CreateRandomString(), CreateRandomString()];
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync())
+                .ReturnsAsync(randomSkills);
+
+        this.memoryServiceMock.Setup(service =>
+            service.RecallMemoriesAsync())
+                .ReturnsAsync(randomMemories);
+
+        // when
+        AgentContext actualContext =
+            await this.dataOrchestrationService.RecallAsync(inputContext);
+
+        // then
+        actualContext.Observations.Should().Contain(randomMemories);
+
+        this.memoryServiceMock.Verify(service =>
+            service.RecallMemoriesAsync(),
+                Times.Once);
+    }
+
+    // Observations accumulate across turns. Recall runs EVERY turn (SPEC.md 5), so
+    // if it replaced observations instead of preserving them, every tool result
+    // Direction fed back would be wiped before the Brain ever saw it — and vector
+    // 02 (tool-then-final) could never pass.
+    [Fact]
+    public async Task ShouldPreserveExistingObservationsOnRecallAsync()
+    {
+        // given
+        string priorObservation = CreateRandomString();
+
+        AgentContext inputContext = new()
+        {
+            Prompt = CreateRandomString(),
+            Observations = [priorObservation]
+        };
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync())
+                .ReturnsAsync(CreateRandomString());
+
+        this.memoryServiceMock.Setup(service =>
+            service.RecallMemoriesAsync())
+                .ReturnsAsync([]);
+
+        // when
+        AgentContext actualContext =
+            await this.dataOrchestrationService.RecallAsync(inputContext);
+
+        // then
+        actualContext.Observations.Should().Contain(priorObservation);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
@@ -5,6 +5,7 @@
 
 using System.Linq.Expressions;
 using Moq;
+using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Foundations.Data;
 using Standard.Agents.Services.Orchestrations.Data;
@@ -19,6 +20,7 @@ public partial class DataOrchestrationServiceTests
     private readonly Mock<ISkillService> skillServiceMock;
     private readonly Mock<IMemoryService> memoryServiceMock;
     private readonly Mock<IKnowledgeService> knowledgeServiceMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
     private readonly IDataOrchestrationService dataOrchestrationService;
 
     public DataOrchestrationServiceTests()
@@ -26,11 +28,13 @@ public partial class DataOrchestrationServiceTests
         this.skillServiceMock = new Mock<ISkillService>();
         this.memoryServiceMock = new Mock<IMemoryService>();
         this.knowledgeServiceMock = new Mock<IKnowledgeService>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
 
         this.dataOrchestrationService = new DataOrchestrationService(
             skillService: this.skillServiceMock.Object,
             memoryService: this.memoryServiceMock.Object,
-            knowledgeService: this.knowledgeServiceMock.Object);
+            knowledgeService: this.knowledgeServiceMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
     }
 
     private static string CreateRandomString() =>

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Foundations.Data;
+using Standard.Agents.Services.Orchestrations.Data;
+using Tynamix.ObjectFiller;
+using Xeptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Data;
+
+public partial class DataOrchestrationServiceTests
+{
+    private readonly Mock<ISkillService> skillServiceMock;
+    private readonly Mock<IMemoryService> memoryServiceMock;
+    private readonly Mock<IKnowledgeService> knowledgeServiceMock;
+    private readonly IDataOrchestrationService dataOrchestrationService;
+
+    public DataOrchestrationServiceTests()
+    {
+        this.skillServiceMock = new Mock<ISkillService>();
+        this.memoryServiceMock = new Mock<IMemoryService>();
+        this.knowledgeServiceMock = new Mock<IKnowledgeService>();
+
+        this.dataOrchestrationService = new DataOrchestrationService(
+            skillService: this.skillServiceMock.Object,
+            memoryService: this.memoryServiceMock.Object,
+            knowledgeService: this.knowledgeServiceMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static AgentContext CreateRandomAgentContext() =>
+        new() { Prompt = CreateRandomString() };
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+
+    // Exceptions from any of the three foundations, unified into one orchestration
+    // category. Theory-driven so one test covers all of them, per The Standard.
+    //
+    // No SkillValidationException here — RetrieveSkillsAsync takes no input, so
+    // Skills has no validation category at all. The asymmetry is real, not an
+    // oversight; asserting on a type that does not exist would be inventing a
+    // failure the system cannot produce.
+    public static TheoryData<Xeption> DependencyValidationExceptions() =>
+        new()
+        {
+            new Models.Foundations.Memories.Exceptions.MemoryValidationException(
+                "memory validation", new Xeption("inner")),
+
+            new Models.Foundations.Knowledges.Exceptions.KnowledgeValidationException(
+                "knowledge validation", new Xeption("inner"))
+        };
+
+    public static TheoryData<Xeption> DependencyExceptions() =>
+        new()
+        {
+            new Models.Foundations.Skills.Exceptions.SkillDependencyException(
+                "skill dependency", new Xeption("inner")),
+
+            new Models.Foundations.Skills.Exceptions.SkillServiceException(
+                "skill service", new Xeption("inner")),
+
+            new Models.Foundations.Memories.Exceptions.MemoryDependencyException(
+                "memory dependency", new Xeption("inner")),
+
+            new Models.Foundations.Knowledges.Exceptions.KnowledgeDependencyException(
+                "knowledge dependency", new Xeption("inner"))
+        };
+}

--- a/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationDependencyException.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+
+public class AgentOrchestrationDependencyException : Xeption
+{
+    public AgentOrchestrationDependencyException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationDependencyValidationException.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationDependencyValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+
+public class AgentOrchestrationDependencyValidationException : Xeption
+{
+    public AgentOrchestrationDependencyValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationServiceException.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+
+public class AgentOrchestrationServiceException : Xeption
+{
+    public AgentOrchestrationServiceException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationValidationException.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+
+public class AgentOrchestrationValidationException : Xeption
+{
+    public AgentOrchestrationValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Orchestrations/Agents/Exceptions/FailedAgentOrchestrationServiceException.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/Exceptions/FailedAgentOrchestrationServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+
+public class FailedAgentOrchestrationServiceException : Xeption
+{
+    public FailedAgentOrchestrationServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Orchestrations/Agents/Exceptions/NullAgentContextException.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/Exceptions/NullAgentContextException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+
+public class NullAgentContextException : Xeption
+{
+    public NullAgentContextException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Exceptions.cs
@@ -1,0 +1,137 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Knowledges.Exceptions;
+using Standard.Agents.Models.Foundations.Memories.Exceptions;
+using Standard.Agents.Models.Foundations.Skills.Exceptions;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Orchestrations.Data;
+
+public partial class DataOrchestrationService
+{
+    private delegate ValueTask<AgentContext> ReturningContextFunction();
+
+    // An orchestration does not localize natives — its foundations already did that.
+    // It UNWRAPS each foundation's categorical exception, PRESERVES the local
+    // exception inside as the inner, and REWRAPS in this tier's category. Data must
+    // not leak Skills' or Memory's vocabulary upward to Coordination.
+    private async ValueTask<AgentContext> TryCatch(
+        ReturningContextFunction returningContextFunction)
+    {
+        try
+        {
+            return await returningContextFunction();
+        }
+        catch (NullAgentContextException nullAgentContextException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(nullAgentContextException);
+        }
+        catch (MemoryValidationException memoryValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                memoryValidationException.InnerException as Xeption);
+        }
+        catch (KnowledgeValidationException knowledgeValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                knowledgeValidationException.InnerException as Xeption);
+        }
+        catch (SkillDependencyException skillDependencyException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                skillDependencyException.InnerException as Xeption);
+        }
+        catch (SkillServiceException skillServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                skillServiceException.InnerException as Xeption);
+        }
+        catch (MemoryDependencyException memoryDependencyException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                memoryDependencyException.InnerException as Xeption);
+        }
+        catch (MemoryServiceException memoryServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                memoryServiceException.InnerException as Xeption);
+        }
+        catch (KnowledgeDependencyException knowledgeDependencyException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                knowledgeDependencyException.InnerException as Xeption);
+        }
+        catch (KnowledgeServiceException knowledgeServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                knowledgeServiceException.InnerException as Xeption);
+        }
+        catch (Exception exception)
+        {
+            var failedAgentOrchestrationServiceException =
+                new FailedAgentOrchestrationServiceException(
+                    message: "Failed agent orchestration service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(
+                failedAgentOrchestrationServiceException);
+        }
+    }
+
+    private async ValueTask<AgentOrchestrationValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationValidationException =
+            new AgentOrchestrationValidationException(
+                message: "Agent orchestration validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationValidationException);
+
+        return agentOrchestrationValidationException;
+    }
+
+    private async ValueTask<AgentOrchestrationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationDependencyValidationException =
+            new AgentOrchestrationDependencyValidationException(
+                message: "Agent orchestration dependency validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationDependencyValidationException);
+
+        return agentOrchestrationDependencyValidationException;
+    }
+
+    private async ValueTask<AgentOrchestrationDependencyException> CreateAndLogDependencyExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationDependencyException =
+            new AgentOrchestrationDependencyException(
+                message: "Agent orchestration dependency error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationDependencyException);
+
+        return agentOrchestrationDependencyException;
+    }
+
+    private async ValueTask<AgentOrchestrationServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationServiceException =
+            new AgentOrchestrationServiceException(
+                message: "Agent orchestration service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationServiceException);
+
+        return agentOrchestrationServiceException;
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Validations.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Validations.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+
+namespace Standard.Agents.Services.Orchestrations.Data;
+
+public partial class DataOrchestrationService
+{
+    // Circuit-breaking: a null context has nothing to read and nothing to copy, so
+    // continuing would only produce a null-reference somewhere less obvious.
+    private static void ValidateContext(AgentContext context)
+    {
+        if (context is null)
+        {
+            throw new NullAgentContextException(
+                message: "Agent context is null.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -26,6 +26,18 @@ public partial class DataOrchestrationService : IDataOrchestrationService
         this.knowledgeService = knowledgeService;
     }
 
-    public ValueTask<AgentContext> RecallAsync(AgentContext context) =>
-        throw new NotImplementedException();
+    public async ValueTask<AgentContext> RecallAsync(AgentContext context)
+    {
+        string systemPrompt = await this.skillService.RetrieveSkillsAsync();
+        IReadOnlyList<string> memories = await this.memoryService.RecallMemoriesAsync();
+
+        // Appended, never replaced. Recall runs every turn (SPEC.md 5), so replacing
+        // observations would wipe the tool results Direction fed back before the
+        // Brain ever read them — and vector 02 could not pass.
+        return context with
+        {
+            SystemPrompt = systemPrompt,
+            Observations = [.. context.Observations, .. memories]
+        };
+    }
 }

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Foundations.Data;
 
@@ -15,19 +16,25 @@ public partial class DataOrchestrationService : IDataOrchestrationService
     private readonly ISkillService skillService;
     private readonly IMemoryService memoryService;
     private readonly IKnowledgeService knowledgeService;
+    private readonly ILoggingBroker loggingBroker;
 
     public DataOrchestrationService(
         ISkillService skillService,
         IMemoryService memoryService,
-        IKnowledgeService knowledgeService)
+        IKnowledgeService knowledgeService,
+        ILoggingBroker loggingBroker)
     {
         this.skillService = skillService;
         this.memoryService = memoryService;
         this.knowledgeService = knowledgeService;
+        this.loggingBroker = loggingBroker;
     }
 
-    public async ValueTask<AgentContext> RecallAsync(AgentContext context)
+    public ValueTask<AgentContext> RecallAsync(AgentContext context) =>
+    TryCatch(async () =>
     {
+        ValidateContext(context);
+
         string systemPrompt = await this.skillService.RetrieveSkillsAsync();
         IReadOnlyList<string> memories = await this.memoryService.RecallMemoriesAsync();
 
@@ -39,5 +46,5 @@ public partial class DataOrchestrationService : IDataOrchestrationService
             SystemPrompt = systemPrompt,
             Observations = [.. context.Observations, .. memories]
         };
-    }
+    });
 }

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Foundations.Data;
+
+namespace Standard.Agents.Services.Orchestrations.Data;
+
+// The Data nature — refresh what the agent HAS. Three foundations, which satisfies
+// the Two-Three rule exactly.
+public partial class DataOrchestrationService : IDataOrchestrationService
+{
+    private readonly ISkillService skillService;
+    private readonly IMemoryService memoryService;
+    private readonly IKnowledgeService knowledgeService;
+
+    public DataOrchestrationService(
+        ISkillService skillService,
+        IMemoryService memoryService,
+        IKnowledgeService knowledgeService)
+    {
+        this.skillService = skillService;
+        this.memoryService = memoryService;
+        this.knowledgeService = knowledgeService;
+    }
+
+    public ValueTask<AgentContext> RecallAsync(AgentContext context) =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents/Services/Orchestrations/Data/IDataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/IDataOrchestrationService.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Agents;
+
+namespace Standard.Agents.Services.Orchestrations.Data;
+
+public interface IDataOrchestrationService
+{
+    ValueTask<AgentContext> RecallAsync(AgentContext context);
+}


### PR DESCRIPTION
The Data nature — refresh what the agent **has**. SPEC.md §4.3. The first orchestration.

```csharp
ValueTask<AgentContext> RecallAsync(AgentContext context);
```

Three foundations by constructor injection — **Two-Three satisfied exactly**.

## Recall runs EVERY turn, not once

SPEC.md §5 calls it at the top of each loop iteration. That makes `ShouldPreserveExistingObservationsOnRecallAsync` the test that matters most here:

```csharp
Observations = [.. context.Observations, .. memories]   // appended, never replaced
```

If Recall **replaced** observations, every tool result Direction fed back would be wiped before the Brain ever read it — and vector `02-tool-then-final` could never pass. The bug would present as *"the model ignores its tools."*

## Copy-on-write is asserted, not assumed

`ShouldNotMutateInputContextOnRecallAsync` checks the input instance comes back untouched **and** that the returned object is a different one. A service that mutated in place and returned `this` would pass a weaker assertion. SPEC.md §3 makes copy-on-write a **MUST**.

## Unwrap → preserve → rewrap

An orchestration doesn't localize natives — its foundations already did. It **unwraps** each foundation's categorical exception, **preserves the local exception inside** as the inner, and **rewraps** in this tier's category. Data must not leak Skills' or Memory's vocabulary up to Coordination.

The tests assert on `foundationException.InnerException`, not on the foundation exception itself — asserting the outer survived would be asserting the *opposite* of the rule.

## A real mistake, caught and fixed in-branch

The `CreateAndLog*` helpers were named CreateAndLog but **only created** — the orchestration had no `ILoggingBroker` at all, and the tests said `AndLogItAsync` **without verifying any log**.

Both corrected. The Standard requires every layer to log before rethrowing, and **a test that names a behaviour it doesn't assert is worse than no test**, because it reads as covered.

`ILoggingBroker` is a fourth constructor parameter; Two-Three still holds — it counts entity/business dependencies, and utility brokers are allowed in addition.

## Note: no `SkillValidationException` in the Theory

`RetrieveSkillsAsync` takes no input, so Skills has **no validation category at all**. The asymmetry across the three foundations is real; asserting on a type that doesn't exist would be inventing a failure the system cannot produce.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 125, Total: 125** (8 new cases)

Closes #32
