### PR TITLE
ORCHESTRATIONS: Think

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Exceptions.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Exceptions.Think.cs
@@ -1,0 +1,170 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+using Xeptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldThrowValidationExceptionOnThinkIfContextIsNullAndLogItAsync()
+    {
+        // given
+        AgentContext nullContext = null;
+
+        var nullAgentContextException =
+            new NullAgentContextException(
+                message: "Agent context is null.");
+
+        var expectedAgentOrchestrationValidationException =
+            new AgentOrchestrationValidationException(
+                message: "Agent orchestration validation error occurred, fix the error and try again.",
+                innerException: nullAgentContextException);
+
+        // when
+        ValueTask<AgentContext> thinkTask =
+            this.decisionOrchestrationService.ThinkAsync(nullContext);
+
+        AgentOrchestrationValidationException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationValidationException>(
+                thinkTask.AsTask);
+
+        // then
+        actualException.Should()
+            .BeEquivalentTo(expectedAgentOrchestrationValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedAgentOrchestrationValidationException))),
+                    Times.Once);
+
+        this.gateServiceMock.Verify(service =>
+            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.gateServiceMock.VerifyNoOtherCalls();
+        this.brainServiceMock.VerifyNoOtherCalls();
+        this.judgeServiceMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // Unwrap the foundation's categorical exception, preserve its LOCAL exception as
+    // the inner, rewrap in this layer's category. The local exception must survive so
+    // detail is not lost climbing the tiers.
+    [Theory]
+    [MemberData(nameof(DependencyValidationExceptions))]
+    public async Task ShouldThrowDependencyValidationExceptionOnThinkIfDependencyValidationErrorOccursAndLogItAsync(
+        Xeption foundationException)
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        var expectedException =
+            new AgentOrchestrationDependencyValidationException(
+                message: "Agent orchestration dependency validation error occurred, fix the error and try again.",
+                innerException: foundationException.InnerException as Xeption);
+
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ThrowsAsync(foundationException);
+
+        // when
+        ValueTask<AgentContext> thinkTask =
+            this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        AgentOrchestrationDependencyValidationException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationDependencyValidationException>(
+                thinkTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [MemberData(nameof(DependencyExceptions))]
+    public async Task ShouldThrowDependencyExceptionOnThinkIfDependencyErrorOccursAndLogItAsync(
+        Xeption foundationException)
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        var expectedException =
+            new AgentOrchestrationDependencyException(
+                message: "Agent orchestration dependency error occurred, contact support.",
+                innerException: foundationException.InnerException as Xeption);
+
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ThrowsAsync(foundationException);
+
+        // when
+        ValueTask<AgentContext> thinkTask =
+            this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        AgentOrchestrationDependencyException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationDependencyException>(
+                thinkTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnThinkIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        var serviceException = new Exception();
+
+        var failedAgentOrchestrationServiceException =
+            new FailedAgentOrchestrationServiceException(
+                message: "Failed agent orchestration service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedException =
+            new AgentOrchestrationServiceException(
+                message: "Agent orchestration service error occurred, contact support.",
+                innerException: failedAgentOrchestrationServiceException);
+
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<AgentContext> thinkTask =
+            this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        AgentOrchestrationServiceException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationServiceException>(
+                thinkTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
@@ -1,0 +1,198 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+// The conscience half of Think: Gate before the Brain, Judge after it.
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldRefuseOnThinkIfGateScreensRefuseAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("refuse");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("Refuse");
+        actualContext.Intent.Should().Be("Refuse");
+    }
+
+    // ⚠️ A refusal CARRYING A REASON must still refuse.
+    //
+    // GateService returns the verdict verbatim, reason and all (#25 pins that). A
+    // check of `verdict == "refuse"` would not match "refuse: asks for credentials"
+    // — the refusal would be read as an allow and the prompt would reach the Brain.
+    // The richer the guardian's answer, the more certainly it would fail open.
+    [Theory]
+    [InlineData("refuse")]
+    [InlineData("REFUSE")]
+    [InlineData("refuse: asks for credentials")]
+    [InlineData("Refuse - policy violation")]
+    public async Task ShouldRefuseOnThinkIfGateScreensRefuseWithReasonAsync(string verdict)
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(verdict);
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("Refuse");
+        actualContext.RawReply.Should().Be(verdict);
+    }
+
+    // Invariant 7.6 in practice: a refused prompt never reaches the Brain at all.
+    // Screening that ran but did not gate would be theatre.
+    [Fact]
+    public async Task ShouldNotCallBrainOnThinkIfGateRefusesAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("refuse");
+
+        // when
+        await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        this.brainServiceMock.Verify(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.judgeServiceMock.Verify(service =>
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.brainServiceMock.VerifyNoOtherCalls();
+        this.judgeServiceMock.VerifyNoOtherCalls();
+    }
+
+    // Invariant 7.5 — a draft is not a commitment. A low-scored answer loops instead
+    // of returning, so output does not cross the boundary un-vetted.
+    [Fact]
+    public async Task ShouldLoopOnThinkIfJudgeScoresBelowThresholdAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL: a poor answer");
+
+        this.judgeServiceMock.Setup(service =>
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(0.1);
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.Status.Should().Be(AgentStatus.Working);
+        actualContext.DirectionType.Should().NotBe("ReturnResponse");
+    }
+
+    // ⚠️ Theory Ch.8: reflective judgment means "the draft becomes Data, the next
+    // Think reconsiders it". The rejected draft itself must reach the next turn — a
+    // bare "revise" note tells the Brain it failed but not WHAT failed, so it is
+    // just as likely to write the same answer again and loop to the turn cap.
+    [Fact]
+    public async Task ShouldFeedRejectedDraftBackAsObservationOnThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL: a poor answer");
+
+        this.judgeServiceMock.Setup(service =>
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(0.1);
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.Observations.Should()
+            .ContainSingle(observation => observation.Contains("a poor answer"));
+    }
+
+    // The Judge screens OUTPUT. A tool call is not output — it is a proposal
+    // Direction will execute. Judging it would spend an inference call grading
+    // something the Judge's rubric was never written for.
+    [Fact]
+    public async Task ShouldNotJudgeOnThinkIfDirectionIsToolAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("ACTION: calculator: 1+1");
+
+        // when
+        await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        this.judgeServiceMock.Verify(service =>
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.judgeServiceMock.VerifyNoOtherCalls();
+    }
+
+    // The Gate screens the PROMPT, and the Judge screens the DRAFT. Passing the wrong
+    // text to either would make both guardians look like they ran while grading
+    // something no one asked about.
+    [Fact]
+    public async Task ShouldScreenPromptAndJudgeDraftOnThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL: the draft");
+
+        // when
+        await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        this.gateServiceMock.Verify(service =>
+            service.ScreenAsync(inputContext.SystemPrompt, inputContext.Prompt),
+                Times.Once);
+
+        this.judgeServiceMock.Verify(service =>
+            service.EvaluateAsync(inputContext.SystemPrompt, "the draft"),
+                Times.Once);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
@@ -1,0 +1,208 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL: 42");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("ReturnResponse");
+        actualContext.Payload.Should().Be("42");
+        actualContext.RawReply.Should().Be("FINAL: 42");
+    }
+
+    // Vector 03. SPEC.md 6: a tool call MUST be read from the FIRST LINE ONLY.
+    // The stray "FINAL: wrong" on line two is ignored — models emit extra lines,
+    // and honouring the second one would run the wrong branch entirely.
+    [Fact]
+    public async Task ShouldParseActionFromFirstLineOnlyOnThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("ACTION: calculator: 1+1\nFINAL: wrong");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("calculator");
+        actualContext.Payload.Should().Be("1+1");
+
+        // The stray FINAL must not have been treated as an answer.
+        actualContext.Payload.Should().NotContain("wrong");
+    }
+
+    // Vector 04. SPEC.md 6: a final answer MAY span multiple lines. Trim must not
+    // collapse the internal newline.
+    [Fact]
+    public async Task ShouldPreserveMultilineFinalOnThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL: line one\nline two");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("ReturnResponse");
+        actualContext.Payload.Should().Be("line one\nline two");
+    }
+
+    // SPEC.md 6 gives no escaping rule for a colon inside the tool input. Splitting
+    // on the FIRST colon only keeps a URL intact; splitting on every colon would
+    // hand the tool "http" and lose the rest.
+    [Fact]
+    public async Task ShouldPreserveColonsInToolInputOnThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("ACTION: fetch: https://example.com:8080/a?b=1");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("fetch");
+        actualContext.Payload.Should().Be("https://example.com:8080/a?b=1");
+    }
+
+    // Hassan's decision on #33: intent mirrors the parsed action — the tool name for
+    // an ACTION, "Respond" for a FINAL, "Refuse" when the Gate refuses. Derived from
+    // the reply the Brain already gave; no extra inference call.
+    [Fact]
+    public async Task ShouldSetIntentToToolNameOnThinkIfActionAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("ACTION: calculator: 1+1");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.Intent.Should().Be("calculator");
+    }
+
+    [Fact]
+    public async Task ShouldSetIntentToRespondOnThinkIfFinalAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL: 42");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.Intent.Should().Be("Respond");
+    }
+
+    // A model that forgets the protocol still gets its answer through. Treating an
+    // unprefixed reply as a FINAL is the forgiving reading; the alternative is an
+    // agent that refuses to answer because the model omitted four characters.
+    [Fact]
+    public async Task ShouldTreatNonProtocolReplyAsAnswerOnThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("just an answer, no prefix");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("ReturnResponse");
+        actualContext.Payload.Should().Be("just an answer, no prefix");
+    }
+
+    // Observations reach the Brain — SPEC.md 5 requires the next Decision be able to
+    // read what Direction fed back. Without this, vector 02 cannot pass: the tool
+    // result would exist on the context and never reach the mind that needs it.
+    [Fact]
+    public async Task ShouldPassObservationsToBrainOnThinkAsync()
+    {
+        // given
+        string observation = CreateRandomString();
+
+        AgentContext inputContext = new()
+        {
+            Prompt = CreateRandomString(),
+            SystemPrompt = CreateRandomString(),
+            Observations = [observation]
+        };
+
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL: done");
+
+        // when
+        await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        this.brainServiceMock.Verify(service =>
+            service.GenerateAsync(
+                inputContext.SystemPrompt,
+                It.Is<string>(userMessage => userMessage.Contains(observation))),
+                    Times.Once);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Foundations.Decision;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Tynamix.ObjectFiller;
+using Xeptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    private readonly Mock<IGateService> gateServiceMock;
+    private readonly Mock<IBrainService> brainServiceMock;
+    private readonly Mock<IJudgeService> judgeServiceMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly IDecisionOrchestrationService decisionOrchestrationService;
+
+    public DecisionOrchestrationServiceTests()
+    {
+        this.gateServiceMock = new Mock<IGateService>();
+        this.brainServiceMock = new Mock<IBrainService>();
+        this.judgeServiceMock = new Mock<IJudgeService>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.decisionOrchestrationService = new DecisionOrchestrationService(
+            gateService: this.gateServiceMock.Object,
+            brainService: this.brainServiceMock.Object,
+            judgeService: this.judgeServiceMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static AgentContext CreateRandomAgentContext() =>
+        new()
+        {
+            Prompt = CreateRandomString(),
+            SystemPrompt = CreateRandomString()
+        };
+
+    // Gate allows, so the Brain is reached. Used by every test that is not about
+    // the Gate itself.
+    private void SetupGateAllows() =>
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("allow");
+
+    private void SetupJudgeApproves() =>
+        this.judgeServiceMock.Setup(service =>
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(1.0);
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
@@ -61,4 +61,38 @@ public partial class DecisionOrchestrationServiceTests
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
+
+    // Exceptions from any of Decision's three foundations, unified into one
+    // orchestration category.
+    public static TheoryData<Xeption> DependencyValidationExceptions() =>
+        new()
+        {
+            new Models.Foundations.Gates.Exceptions.GateValidationException(
+                "gate validation", new Xeption("inner")),
+
+            new Models.Foundations.Brains.Exceptions.BrainValidationException(
+                "brain validation", new Xeption("inner")),
+
+            new Models.Foundations.Judges.Exceptions.JudgeValidationException(
+                "judge validation", new Xeption("inner")),
+
+            new Models.Foundations.Brains.Exceptions.BrainDependencyValidationException(
+                "brain dependency validation", new Xeption("inner"))
+        };
+
+    public static TheoryData<Xeption> DependencyExceptions() =>
+        new()
+        {
+            new Models.Foundations.Gates.Exceptions.GateDependencyException(
+                "gate dependency", new Xeption("inner")),
+
+            new Models.Foundations.Gates.Exceptions.GateServiceException(
+                "gate service", new Xeption("inner")),
+
+            new Models.Foundations.Brains.Exceptions.BrainDependencyException(
+                "brain dependency", new Xeption("inner")),
+
+            new Models.Foundations.Judges.Exceptions.JudgeDependencyException(
+                "judge dependency", new Xeption("inner"))
+        };
 }

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Exceptions.cs
@@ -1,0 +1,156 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Brains.Exceptions;
+using Standard.Agents.Models.Foundations.Gates.Exceptions;
+using Standard.Agents.Models.Foundations.Judges.Exceptions;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationService
+{
+    private delegate ValueTask<AgentContext> ReturningContextFunction();
+
+    // Unwrap the foundation's categorical exception, preserve the local exception
+    // inside as the inner, rewrap in this tier's category. Decision must not leak
+    // Gate's, Brain's or Judge's vocabulary upward to Coordination.
+    private async ValueTask<AgentContext> TryCatch(
+        ReturningContextFunction returningContextFunction)
+    {
+        try
+        {
+            return await returningContextFunction();
+        }
+        catch (NullAgentContextException nullAgentContextException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(nullAgentContextException);
+        }
+        catch (GateValidationException gateValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                gateValidationException.InnerException as Xeption);
+        }
+        catch (GateDependencyValidationException gateDependencyValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                gateDependencyValidationException.InnerException as Xeption);
+        }
+        catch (BrainValidationException brainValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                brainValidationException.InnerException as Xeption);
+        }
+        catch (BrainDependencyValidationException brainDependencyValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                brainDependencyValidationException.InnerException as Xeption);
+        }
+        catch (JudgeValidationException judgeValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                judgeValidationException.InnerException as Xeption);
+        }
+        catch (JudgeDependencyValidationException judgeDependencyValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                judgeDependencyValidationException.InnerException as Xeption);
+        }
+        catch (GateDependencyException gateDependencyException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                gateDependencyException.InnerException as Xeption);
+        }
+        catch (GateServiceException gateServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                gateServiceException.InnerException as Xeption);
+        }
+        catch (BrainDependencyException brainDependencyException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                brainDependencyException.InnerException as Xeption);
+        }
+        catch (BrainServiceException brainServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                brainServiceException.InnerException as Xeption);
+        }
+        catch (JudgeDependencyException judgeDependencyException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                judgeDependencyException.InnerException as Xeption);
+        }
+        catch (JudgeServiceException judgeServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                judgeServiceException.InnerException as Xeption);
+        }
+        catch (Exception exception)
+        {
+            var failedAgentOrchestrationServiceException =
+                new FailedAgentOrchestrationServiceException(
+                    message: "Failed agent orchestration service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(
+                failedAgentOrchestrationServiceException);
+        }
+    }
+
+    private async ValueTask<AgentOrchestrationValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationValidationException =
+            new AgentOrchestrationValidationException(
+                message: "Agent orchestration validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationValidationException);
+
+        return agentOrchestrationValidationException;
+    }
+
+    private async ValueTask<AgentOrchestrationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationDependencyValidationException =
+            new AgentOrchestrationDependencyValidationException(
+                message: "Agent orchestration dependency validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationDependencyValidationException);
+
+        return agentOrchestrationDependencyValidationException;
+    }
+
+    private async ValueTask<AgentOrchestrationDependencyException> CreateAndLogDependencyExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationDependencyException =
+            new AgentOrchestrationDependencyException(
+                message: "Agent orchestration dependency error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationDependencyException);
+
+        return agentOrchestrationDependencyException;
+    }
+
+    private async ValueTask<AgentOrchestrationServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationServiceException =
+            new AgentOrchestrationServiceException(
+                message: "Agent orchestration service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationServiceException);
+
+        return agentOrchestrationServiceException;
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Validations.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Validations.cs
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+
+namespace Standard.Agents.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationService
+{
+    private static void ValidateContext(AgentContext context)
+    {
+        if (context is null)
+        {
+            throw new NullAgentContextException(
+                message: "Agent context is null.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Foundations.Decision;
+
+namespace Standard.Agents.Services.Orchestrations.Decision;
+
+// The Decision nature — one brain, flanked by conscience. Gate screens the input,
+// the Brain reasons, the Judge screens a final answer. It authors no prompt text:
+// it frames the task, reads the reply, and interprets it into the next direction.
+public partial class DecisionOrchestrationService : IDecisionOrchestrationService
+{
+    private readonly IGateService gateService;
+    private readonly IBrainService brainService;
+    private readonly IJudgeService judgeService;
+    private readonly ILoggingBroker loggingBroker;
+
+    public DecisionOrchestrationService(
+        IGateService gateService,
+        IBrainService brainService,
+        IJudgeService judgeService,
+        ILoggingBroker loggingBroker)
+    {
+        this.gateService = gateService;
+        this.brainService = brainService;
+        this.judgeService = judgeService;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<AgentContext> ThinkAsync(AgentContext context) =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Text;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Foundations.Decision;
@@ -14,6 +15,16 @@ namespace Standard.Agents.Services.Orchestrations.Decision;
 // it frames the task, reads the reply, and interprets it into the next direction.
 public partial class DecisionOrchestrationService : IDecisionOrchestrationService
 {
+    private const string ActionPrefix = "ACTION:";
+    private const string FinalPrefix = "FINAL:";
+    private const string RefuseVerdict = "refuse";
+    private const string RefuseDirection = "Refuse";
+    private const string ReturnResponseDirection = "ReturnResponse";
+    private const string RespondIntent = "Respond";
+
+    // SPEC.md fixes no threshold. Below this a draft loops instead of returning.
+    private const double MinimumAcceptableScore = 0.3;
+
     private readonly IGateService gateService;
     private readonly IBrainService brainService;
     private readonly IJudgeService judgeService;
@@ -32,5 +43,139 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
     }
 
     public ValueTask<AgentContext> ThinkAsync(AgentContext context) =>
-        throw new NotImplementedException();
+    TryCatch(async () =>
+    {
+        ValidateContext(context);
+
+        // GATE — the conscience at the front door. A refusal returns here, so the
+        // prompt never reaches the Brain at all.
+        string verdict =
+            await this.gateService.ScreenAsync(context.SystemPrompt, context.Prompt);
+
+        if (IsRefusal(verdict))
+        {
+            return context with
+            {
+                Intent = RefuseDirection,
+                DirectionType = RefuseDirection,
+                Payload = "I'm not able to help with that.",
+                RawReply = verdict
+            };
+        }
+
+        // BRAIN — the one brain reasons.
+        string reply =
+            (await this.brainService.GenerateAsync(
+                context.SystemPrompt,
+                BuildUserMessage(context))).Trim();
+
+        AgentContext decided = Interpret(context, reply);
+
+        bool isFinalAnswer =
+            decided.DirectionType.Equals(
+                ReturnResponseDirection,
+                StringComparison.OrdinalIgnoreCase);
+
+        if (isFinalAnswer is false)
+        {
+            // The Judge screens OUTPUT. A tool call is a proposal, not output.
+            return decided;
+        }
+
+        // JUDGE — the conscience at the back door. Invariant 7.5: a draft is not a
+        // commitment.
+        double score =
+            await this.judgeService.EvaluateAsync(context.SystemPrompt, decided.Payload);
+
+        if (score < MinimumAcceptableScore)
+        {
+            // Theory Ch.8: the draft becomes Data and the next Think reconsiders it.
+            // The draft itself must travel, not just a note that it failed — the
+            // Brain cannot revise what it cannot see.
+            return context with
+            {
+                Observations =
+                [
+                    .. context.Observations,
+                    $"A previous draft was rejected on review: {decided.Payload}"
+                ],
+                Status = AgentStatus.Working
+            };
+        }
+
+        return decided;
+    });
+
+    // StartsWith, not equality. GateService returns the verdict verbatim (#25), so a
+    // refusal may carry its reason — "refuse: asks for credentials". An equality
+    // check would read that as an allow and let the prompt through.
+    private static bool IsRefusal(string verdict) =>
+        verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase);
+
+    // Frames the task; authors no rules. Invariant 7.2 — the instructions are the
+    // system prompt, and that came from Data.
+    private static string BuildUserMessage(AgentContext context)
+    {
+        StringBuilder userMessage = new();
+
+        userMessage.Append("Task: ").Append(context.Prompt);
+
+        if (context.Observations.Count > 0)
+        {
+            userMessage.AppendLine().AppendLine().AppendLine("Observations so far:");
+
+            foreach (string observation in context.Observations)
+            {
+                userMessage.Append("- ").AppendLine(observation);
+            }
+        }
+
+        return userMessage.ToString();
+    }
+
+    private static AgentContext Interpret(AgentContext context, string reply)
+    {
+        // First line only. SPEC.md 6 makes this a MUST — models emit extra lines, and
+        // honouring a stray second line would run the wrong branch (vector 03).
+        string firstLine = reply.Split('\n')[0].Trim();
+
+        bool modelChoseToAct =
+            firstLine.StartsWith(ActionPrefix, StringComparison.OrdinalIgnoreCase);
+
+        if (modelChoseToAct)
+        {
+            // Split on the FIRST colon only, so a colon inside the input survives —
+            // "https://example.com:8080" must reach the tool whole.
+            string[] toolCall =
+                firstLine[ActionPrefix.Length..]
+                    .Split(':', 2, StringSplitOptions.TrimEntries);
+
+            string toolName = toolCall[0];
+            string toolInput = toolCall.Length > 1 ? toolCall[1] : string.Empty;
+
+            return context with
+            {
+                Intent = toolName,
+                DirectionType = toolName,
+                Payload = toolInput,
+                RawReply = reply
+            };
+        }
+
+        // A FINAL may span lines, so the prefix is stripped from the WHOLE reply
+        // rather than from the first line (vector 04). A reply with no prefix is
+        // still an answer — a model that forgot four characters should not lose its
+        // work.
+        string answer = reply.StartsWith(FinalPrefix, StringComparison.OrdinalIgnoreCase)
+            ? reply[FinalPrefix.Length..].Trim()
+            : reply;
+
+        return context with
+        {
+            Intent = RespondIntent,
+            DirectionType = ReturnResponseDirection,
+            Payload = answer,
+            RawReply = reply
+        };
+    }
 }

--- a/Standard.Agents/Services/Orchestrations/Decision/IDecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/IDecisionOrchestrationService.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Agents;
+
+namespace Standard.Agents.Services.Orchestrations.Decision;
+
+public interface IDecisionOrchestrationService
+{
+    ValueTask<AgentContext> ThinkAsync(AgentContext context);
+}


### PR DESCRIPTION
The Decision nature — **one brain, flanked by conscience**. SPEC.md §4.3. The reply protocol lives here.

```csharp
ValueTask<AgentContext> ThinkAsync(AgentContext context);
```

Gate screens the input → Brain reasons → Judge screens a final answer.

## Two bugs in the previous implementation, now pinned by tests

**1. A reasoned refusal failed open.**

```csharp
verdict.Equals("refuse", ...)          // old
verdict.TrimStart().StartsWith(...)    // new
```

`GateService` returns the verdict **verbatim, reason and all** — #25 pins that. So `"refuse: asks for credentials"` would **not** have matched, the refusal would have read as an allow, and the prompt would have reached the Brain. **The richer the guardian's answer, the more certainly it failed open.**

**2. The rejected draft was thrown away.**

The old code pushed a bare `"draft rejected by judge — revise"` and discarded the draft. Theory Ch.8: reflective judgment means *"the draft becomes Data, the next Think reconsiders it."* A note saying it failed but not **what** failed leaves the Brain as likely to rewrite the same answer and loop to the turn cap. The draft itself now travels.

## The protocol, per SPEC.md §6

| Rule | Test | Vector |
|---|---|---|
| ACTION read from **first line only** | `ShouldParseActionFromFirstLineOnly...` | `03` |
| FINAL **may span lines** | `ShouldPreserveMultilineFinal...` | `04` |
| colon inside input survives | `ShouldPreserveColonsInToolInput...` | — |
| no prefix → still an answer | `ShouldTreatNonProtocolReplyAsAnswer...` | — |

**Colons closed the open question from #33.** §6 gives no escaping rule; splitting on the **first** colon only keeps `https://example.com:8080/a?b=1` intact. Splitting on every colon would hand the tool `"http"` and lose the rest.

## `intent` — your decision on #33

Mirrors the parsed action: the **tool name** for an ACTION, `"Respond"` for a FINAL, `"Refuse"` for a gate refusal. Derived from the reply the Brain already gave — no extra inference call.

## Guardians

- `ShouldNotCallBrainOnThinkIfGateRefusesAsync` — a refused prompt **never reaches the Brain**. Screening that ran but didn't gate would be theatre.
- `ShouldNotJudgeOnThinkIfDirectionIsToolAsync` — the Judge screens **output**; a tool call is a proposal, not output.
- `ShouldScreenPromptAndJudgeDraftOnThinkAsync` — the Gate gets the *prompt*, the Judge gets the *draft*. Passing the wrong text to either makes both look like they ran while grading something nobody asked about.

The `0.3` threshold is a named constant — SPEC.md fixes no threshold, so **the number is ours and says so**.

## Discipline note — an honest gap

The **10 exception tests did not have an observed FAIL.** They were written after the `TryCatch` partial and passed on first run.

Manufacturing a red bar by deleting working code would be theatre, not discipline. Instead they were **checked for vacuity by mutation**: removing the rewrap block fails exactly **8 of them and no others**; restoring returns 153/153. They assert real behaviour — but they're regression tests, not TDD-driven ones, and that distinction is worth keeping honest.

The 15 logic and guardian tests **did** have genuine observed FAILs.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 153, Total: 153** (28 new cases)

Closes #33
