### PR TITLE
ORCHESTRATIONS: Act

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Exceptions.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Exceptions.Act.cs
@@ -1,0 +1,170 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+using Xeptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+
+public partial class DirectionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldThrowValidationExceptionOnActIfContextIsNullAndLogItAsync()
+    {
+        // given
+        AgentContext nullContext = null;
+
+        var nullAgentContextException =
+            new NullAgentContextException(
+                message: "Agent context is null.");
+
+        var expectedAgentOrchestrationValidationException =
+            new AgentOrchestrationValidationException(
+                message: "Agent orchestration validation error occurred, fix the error and try again.",
+                innerException: nullAgentContextException);
+
+        // when
+        ValueTask<AgentContext> actTask =
+            this.directionOrchestrationService.ActAsync(nullContext);
+
+        AgentOrchestrationValidationException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationValidationException>(
+                actTask.AsTask);
+
+        // then
+        actualException.Should()
+            .BeEquivalentTo(expectedAgentOrchestrationValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedAgentOrchestrationValidationException))),
+                    Times.Once);
+
+        this.internalToolServiceMock.Verify(service =>
+            service.HandlesAsync(It.IsAny<string>()),
+                Times.Never);
+
+        this.internalToolServiceMock.VerifyNoOtherCalls();
+        this.externalToolServiceMock.VerifyNoOtherCalls();
+        this.returnServiceMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // Unwrap the foundation's categorical exception, preserve its LOCAL exception as
+    // the inner, rewrap in this layer's category. The local exception must survive so
+    // detail is not lost climbing the tiers.
+    [Theory]
+    [MemberData(nameof(DependencyValidationExceptions))]
+    public async Task ShouldThrowDependencyValidationExceptionOnActIfDependencyValidationErrorOccursAndLogItAsync(
+        Xeption foundationException)
+    {
+        // given
+        AgentContext inputContext = CreateContextWithDirection("calculator", "1+1");
+
+        var expectedException =
+            new AgentOrchestrationDependencyValidationException(
+                message: "Agent orchestration dependency validation error occurred, fix the error and try again.",
+                innerException: foundationException.InnerException as Xeption);
+
+        this.internalToolServiceMock.Setup(service =>
+            service.HandlesAsync(It.IsAny<string>()))
+                .ThrowsAsync(foundationException);
+
+        // when
+        ValueTask<AgentContext> actTask =
+            this.directionOrchestrationService.ActAsync(inputContext);
+
+        AgentOrchestrationDependencyValidationException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationDependencyValidationException>(
+                actTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [MemberData(nameof(DependencyExceptions))]
+    public async Task ShouldThrowDependencyExceptionOnActIfDependencyErrorOccursAndLogItAsync(
+        Xeption foundationException)
+    {
+        // given
+        AgentContext inputContext = CreateContextWithDirection("calculator", "1+1");
+
+        var expectedException =
+            new AgentOrchestrationDependencyException(
+                message: "Agent orchestration dependency error occurred, contact support.",
+                innerException: foundationException.InnerException as Xeption);
+
+        this.internalToolServiceMock.Setup(service =>
+            service.HandlesAsync(It.IsAny<string>()))
+                .ThrowsAsync(foundationException);
+
+        // when
+        ValueTask<AgentContext> actTask =
+            this.directionOrchestrationService.ActAsync(inputContext);
+
+        AgentOrchestrationDependencyException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationDependencyException>(
+                actTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnActIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        AgentContext inputContext = CreateContextWithDirection("calculator", "1+1");
+        var serviceException = new Exception();
+
+        var failedAgentOrchestrationServiceException =
+            new FailedAgentOrchestrationServiceException(
+                message: "Failed agent orchestration service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedException =
+            new AgentOrchestrationServiceException(
+                message: "Agent orchestration service error occurred, contact support.",
+                innerException: failedAgentOrchestrationServiceException);
+
+        this.internalToolServiceMock.Setup(service =>
+            service.HandlesAsync(It.IsAny<string>()))
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<AgentContext> actTask =
+            this.directionOrchestrationService.ActAsync(inputContext);
+
+        AgentOrchestrationServiceException actualException =
+            await Assert.ThrowsAsync<AgentOrchestrationServiceException>(
+                actTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
@@ -1,0 +1,224 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+
+public partial class DirectionOrchestrationServiceTests
+{
+    // ReturnResponse is terminal -> Responded. SPEC.md 6.
+    [Fact]
+    public async Task ShouldReturnAndTerminateOnActIfDirectionTypeIsReturnResponseAsync()
+    {
+        // given
+        string answer = CreateRandomString();
+
+        AgentContext inputContext =
+            CreateContextWithDirection("ReturnResponse", answer);
+
+        this.returnServiceMock.Setup(service =>
+            service.ReturnAsync(answer))
+                .ReturnsAsync(answer);
+
+        // when
+        AgentContext actualContext =
+            await this.directionOrchestrationService.ActAsync(inputContext);
+
+        // then
+        actualContext.Result.Should().Be(answer);
+        actualContext.Status.Should().Be(AgentStatus.Responded);
+
+        this.returnServiceMock.Verify(service =>
+            service.ReturnAsync(answer),
+                Times.Once);
+
+        this.internalToolServiceMock.VerifyNoOtherCalls();
+        this.externalToolServiceMock.VerifyNoOtherCalls();
+    }
+
+    // Refuse is terminal -> Refused. SPEC.md 6. It still goes through ReturnService,
+    // because a refusal IS the agent's answer — the caller gets told, not stonewalled.
+    [Fact]
+    public async Task ShouldRefuseAndTerminateOnActIfDirectionTypeIsRefuseAsync()
+    {
+        // given
+        string refusal = "I'm not able to help with that.";
+
+        AgentContext inputContext =
+            CreateContextWithDirection("Refuse", refusal);
+
+        this.returnServiceMock.Setup(service =>
+            service.ReturnAsync(refusal))
+                .ReturnsAsync(refusal);
+
+        // when
+        AgentContext actualContext =
+            await this.directionOrchestrationService.ActAsync(inputContext);
+
+        // then
+        actualContext.Result.Should().Be(refusal);
+        actualContext.Status.Should().Be(AgentStatus.Refused);
+
+        this.internalToolServiceMock.VerifyNoOtherCalls();
+        this.externalToolServiceMock.VerifyNoOtherCalls();
+    }
+
+    // Vector 02. A known tool runs Internal, and its result MUST become an
+    // observation with status Working — that feed-back is how the next Think sees it.
+    [Fact]
+    public async Task ShouldRunInternalToolAndAppendObservationOnActAsync()
+    {
+        // given
+        AgentContext inputContext =
+            CreateContextWithDirection("calculator", "1+1");
+
+        this.internalToolServiceMock.Setup(service =>
+            service.HandlesAsync("calculator"))
+                .ReturnsAsync(true);
+
+        this.internalToolServiceMock.Setup(service =>
+            service.RunAsync("calculator", "1+1"))
+                .ReturnsAsync("2");
+
+        // when
+        AgentContext actualContext =
+            await this.directionOrchestrationService.ActAsync(inputContext);
+
+        // then
+        actualContext.Status.Should().Be(AgentStatus.Working);
+        actualContext.Observations.Should().ContainSingle(o => o.Contains("2"));
+
+        this.externalToolServiceMock.Verify(service =>
+            service.CallAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+    }
+
+    // Vector 05. An unknown tool routes to EXTERNAL and the agent recovers — it does
+    // not throw and does not terminate. Anything the agent cannot do locally might
+    // still be doable across the boundary, so a miss is a routing decision, not a
+    // failure.
+    [Fact]
+    public async Task ShouldRouteToExternalAndRecoverOnActIfToolIsUnknownAsync()
+    {
+        // given
+        AgentContext inputContext =
+            CreateContextWithDirection("weather", "today");
+
+        this.internalToolServiceMock.Setup(service =>
+            service.HandlesAsync("weather"))
+                .ReturnsAsync(false);
+
+        this.externalToolServiceMock.Setup(service =>
+            service.CallAsync("weather", "today"))
+                .ReturnsAsync("[external 'weather' not configured]");
+
+        // when
+        AgentContext actualContext =
+            await this.directionOrchestrationService.ActAsync(inputContext);
+
+        // then
+        actualContext.Status.Should().Be(AgentStatus.Working);
+        actualContext.Observations.Should().ContainSingle(o => o.Contains("weather"));
+
+        this.externalToolServiceMock.Verify(service =>
+            service.CallAsync("weather", "today"),
+                Times.Once);
+
+        this.internalToolServiceMock.Verify(service =>
+            service.RunAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+    }
+
+    // Observations accumulate. Direction appends its result to what is already there
+    // rather than replacing it — the turn history is the Brain's working memory.
+    [Fact]
+    public async Task ShouldPreserveExistingObservationsOnActAsync()
+    {
+        // given
+        string priorObservation = CreateRandomString();
+
+        AgentContext inputContext = new()
+        {
+            Prompt = CreateRandomString(),
+            DirectionType = "calculator",
+            Payload = "1+1",
+            Observations = [priorObservation]
+        };
+
+        this.internalToolServiceMock.Setup(service =>
+            service.HandlesAsync("calculator"))
+                .ReturnsAsync(true);
+
+        this.internalToolServiceMock.Setup(service =>
+            service.RunAsync("calculator", "1+1"))
+                .ReturnsAsync("2");
+
+        // when
+        AgentContext actualContext =
+            await this.directionOrchestrationService.ActAsync(inputContext);
+
+        // then
+        actualContext.Observations.Should().HaveCount(2);
+        actualContext.Observations.Should().Contain(priorObservation);
+    }
+
+    // A tool that RETURNS an error string is a result, not a failure. It becomes an
+    // observation and the loop keeps going — the Brain gets to read the error and
+    // try something else. Only a THROWING tool is a dependency failure.
+    [Fact]
+    public async Task ShouldKeepWorkingOnActIfToolReportsAnErrorAsync()
+    {
+        // given
+        AgentContext inputContext =
+            CreateContextWithDirection("calculator", "not math");
+
+        this.internalToolServiceMock.Setup(service =>
+            service.HandlesAsync("calculator"))
+                .ReturnsAsync(true);
+
+        this.internalToolServiceMock.Setup(service =>
+            service.RunAsync("calculator", "not math"))
+                .ReturnsAsync("error: could not parse expression");
+
+        // when
+        AgentContext actualContext =
+            await this.directionOrchestrationService.ActAsync(inputContext);
+
+        // then
+        actualContext.Status.Should().Be(AgentStatus.Working);
+        actualContext.Observations.Should()
+            .ContainSingle(o => o.Contains("could not parse expression"));
+    }
+
+    // The observation names the tool, not just its output. With several tools in
+    // flight, a bare "2" tells the Brain nothing about which question it answers.
+    [Fact]
+    public async Task ShouldNameToolInObservationOnActAsync()
+    {
+        // given
+        AgentContext inputContext =
+            CreateContextWithDirection("calculator", "1+1");
+
+        this.internalToolServiceMock.Setup(service =>
+            service.HandlesAsync("calculator"))
+                .ReturnsAsync(true);
+
+        this.internalToolServiceMock.Setup(service =>
+            service.RunAsync("calculator", "1+1"))
+                .ReturnsAsync("2");
+
+        // when
+        AgentContext actualContext =
+            await this.directionOrchestrationService.ActAsync(inputContext);
+
+        // then
+        actualContext.Observations.Should()
+            .ContainSingle(o => o.Contains("calculator") && o.Contains("2"));
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.cs
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Foundations.Direction;
+using Standard.Agents.Services.Orchestrations.Direction;
+using Tynamix.ObjectFiller;
+using Xeptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+
+public partial class DirectionOrchestrationServiceTests
+{
+    private readonly Mock<IInternalToolService> internalToolServiceMock;
+    private readonly Mock<IExternalToolService> externalToolServiceMock;
+    private readonly Mock<IReturnService> returnServiceMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly IDirectionOrchestrationService directionOrchestrationService;
+
+    public DirectionOrchestrationServiceTests()
+    {
+        this.internalToolServiceMock = new Mock<IInternalToolService>();
+        this.externalToolServiceMock = new Mock<IExternalToolService>();
+        this.returnServiceMock = new Mock<IReturnService>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.directionOrchestrationService = new DirectionOrchestrationService(
+            internalToolService: this.internalToolServiceMock.Object,
+            externalToolService: this.externalToolServiceMock.Object,
+            returnService: this.returnServiceMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static AgentContext CreateContextWithDirection(
+        string directionType,
+        string payload) =>
+        new()
+        {
+            Prompt = CreateRandomString(),
+            DirectionType = directionType,
+            Payload = payload
+        };
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+
+    public static TheoryData<Xeption> DependencyValidationExceptions() =>
+        new()
+        {
+            new Models.Foundations.InternalTools.Exceptions.InternalToolValidationException(
+                "internal tool validation", new Xeption("inner")),
+
+            new Models.Foundations.ExternalTools.Exceptions.ExternalToolValidationException(
+                "external tool validation", new Xeption("inner"))
+        };
+
+    public static TheoryData<Xeption> DependencyExceptions() =>
+        new()
+        {
+            new Models.Foundations.InternalTools.Exceptions.InternalToolDependencyException(
+                "internal tool dependency", new Xeption("inner")),
+
+            new Models.Foundations.InternalTools.Exceptions.InternalToolServiceException(
+                "internal tool service", new Xeption("inner")),
+
+            new Models.Foundations.ExternalTools.Exceptions.ExternalToolDependencyException(
+                "external tool dependency", new Xeption("inner")),
+
+            new Models.Foundations.Returns.Exceptions.ReturnServiceException(
+                "return service", new Xeption("inner"))
+        };
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Exceptions.cs
@@ -1,0 +1,141 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+using Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+using Standard.Agents.Models.Foundations.Returns.Exceptions;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Orchestrations.Direction;
+
+public partial class DirectionOrchestrationService
+{
+    private delegate ValueTask<AgentContext> ReturningContextFunction();
+
+    // Unwrap the foundation's categorical exception, preserve the local exception
+    // inside as the inner, rewrap in this tier's category. Direction must not leak
+    // its tools' vocabulary upward to Coordination.
+    private async ValueTask<AgentContext> TryCatch(
+        ReturningContextFunction returningContextFunction)
+    {
+        try
+        {
+            return await returningContextFunction();
+        }
+        catch (NullAgentContextException nullAgentContextException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(nullAgentContextException);
+        }
+        catch (InternalToolValidationException internalToolValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                internalToolValidationException.InnerException as Xeption);
+        }
+        catch (ExternalToolValidationException externalToolValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                externalToolValidationException.InnerException as Xeption);
+        }
+        catch (ExternalToolDependencyValidationException externalToolDependencyValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                externalToolDependencyValidationException.InnerException as Xeption);
+        }
+        catch (ReturnValidationException returnValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                returnValidationException.InnerException as Xeption);
+        }
+        catch (InternalToolDependencyException internalToolDependencyException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                internalToolDependencyException.InnerException as Xeption);
+        }
+        catch (InternalToolServiceException internalToolServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                internalToolServiceException.InnerException as Xeption);
+        }
+        catch (ExternalToolDependencyException externalToolDependencyException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                externalToolDependencyException.InnerException as Xeption);
+        }
+        catch (ExternalToolServiceException externalToolServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                externalToolServiceException.InnerException as Xeption);
+        }
+        catch (ReturnServiceException returnServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                returnServiceException.InnerException as Xeption);
+        }
+        catch (Exception exception)
+        {
+            var failedAgentOrchestrationServiceException =
+                new FailedAgentOrchestrationServiceException(
+                    message: "Failed agent orchestration service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(
+                failedAgentOrchestrationServiceException);
+        }
+    }
+
+    private async ValueTask<AgentOrchestrationValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationValidationException =
+            new AgentOrchestrationValidationException(
+                message: "Agent orchestration validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationValidationException);
+
+        return agentOrchestrationValidationException;
+    }
+
+    private async ValueTask<AgentOrchestrationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationDependencyValidationException =
+            new AgentOrchestrationDependencyValidationException(
+                message: "Agent orchestration dependency validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationDependencyValidationException);
+
+        return agentOrchestrationDependencyValidationException;
+    }
+
+    private async ValueTask<AgentOrchestrationDependencyException> CreateAndLogDependencyExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationDependencyException =
+            new AgentOrchestrationDependencyException(
+                message: "Agent orchestration dependency error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationDependencyException);
+
+        return agentOrchestrationDependencyException;
+    }
+
+    private async ValueTask<AgentOrchestrationServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var agentOrchestrationServiceException =
+            new AgentOrchestrationServiceException(
+                message: "Agent orchestration service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentOrchestrationServiceException);
+
+        return agentOrchestrationServiceException;
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Validations.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Validations.cs
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+
+namespace Standard.Agents.Services.Orchestrations.Direction;
+
+public partial class DirectionOrchestrationService
+{
+    private static void ValidateContext(AgentContext context)
+    {
+        if (context is null)
+        {
+            throw new NullAgentContextException(
+                message: "Agent context is null.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -9,8 +9,18 @@ using Standard.Agents.Services.Foundations.Direction;
 
 namespace Standard.Agents.Services.Orchestrations.Direction;
 
+// The Direction nature — fan out to the effectors. Invariant 7.8: effects leave
+// only via Direction, and external state enters only as Data through it.
+//
+// Nothing here sets AgentStatus.Failed (decision on #34). Categorical exceptions
+// propagate and Coordination maps them — a Failed flag would say "something went
+// wrong" where the exception ladder says which faculty failed, how, and whether
+// waiting helps.
 public partial class DirectionOrchestrationService : IDirectionOrchestrationService
 {
+    private const string ReturnResponseDirection = "ReturnResponse";
+    private const string RefuseDirection = "Refuse";
+
     private readonly IInternalToolService internalToolService;
     private readonly IExternalToolService externalToolService;
     private readonly IReturnService returnService;
@@ -29,5 +39,47 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
     }
 
     public ValueTask<AgentContext> ActAsync(AgentContext context) =>
-        throw new NotImplementedException();
+    TryCatch(async () =>
+    {
+        ValidateContext(context);
+
+        if (IsTerminal(context.DirectionType))
+        {
+            // A refusal is still an answer — the caller gets told, not stonewalled —
+            // so it takes the same terminal path and differs only in its status.
+            string result = await this.returnService.ReturnAsync(context.Payload);
+
+            return context with
+            {
+                Result = result,
+                Status = ToTerminalStatus(context.DirectionType)
+            };
+        }
+
+        bool isLocalTool = await this.internalToolService.HandlesAsync(context.DirectionType);
+
+        // An unknown tool is not an error. Anything the agent cannot do locally may
+        // still be doable across the boundary, so a miss routes out (vector 05).
+        string output = isLocalTool
+            ? await this.internalToolService.RunAsync(context.DirectionType, context.Payload)
+            : await this.externalToolService.CallAsync(context.DirectionType, context.Payload);
+
+        // SPEC.md 4.3: a non-terminal result MUST be appended to observations and its
+        // status MUST be Working. Named, because a bare "2" tells the Brain nothing
+        // about which question it answers once several tools are in flight.
+        return context with
+        {
+            Observations = [.. context.Observations, $"{context.DirectionType}: {output}"],
+            Status = AgentStatus.Working
+        };
+    });
+
+    private static bool IsTerminal(string directionType) =>
+        directionType.Equals(ReturnResponseDirection, StringComparison.OrdinalIgnoreCase)
+            || directionType.Equals(RefuseDirection, StringComparison.OrdinalIgnoreCase);
+
+    private static AgentStatus ToTerminalStatus(string directionType) =>
+        directionType.Equals(RefuseDirection, StringComparison.OrdinalIgnoreCase)
+            ? AgentStatus.Refused
+            : AgentStatus.Responded;
 }

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Foundations.Direction;
+
+namespace Standard.Agents.Services.Orchestrations.Direction;
+
+public partial class DirectionOrchestrationService : IDirectionOrchestrationService
+{
+    private readonly IInternalToolService internalToolService;
+    private readonly IExternalToolService externalToolService;
+    private readonly IReturnService returnService;
+    private readonly ILoggingBroker loggingBroker;
+
+    public DirectionOrchestrationService(
+        IInternalToolService internalToolService,
+        IExternalToolService externalToolService,
+        IReturnService returnService,
+        ILoggingBroker loggingBroker)
+    {
+        this.internalToolService = internalToolService;
+        this.externalToolService = externalToolService;
+        this.returnService = returnService;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<AgentContext> ActAsync(AgentContext context) =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/IDirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/IDirectionOrchestrationService.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Agents;
+
+namespace Standard.Agents.Services.Orchestrations.Direction;
+
+public interface IDirectionOrchestrationService
+{
+    ValueTask<AgentContext> ActAsync(AgentContext context);
+}


### PR DESCRIPTION
The Direction nature — fan out to the effectors. SPEC.md §4.3. **The last orchestration.**

```csharp
ValueTask<AgentContext> ActAsync(AgentContext context);
```

## The routing table

```
ReturnResponse  → ReturnService → Responded   (terminal)
Refuse          → ReturnService → Refused     (terminal)
known tool      → InternalToolService.Run     → observation, Working
unknown tool    → ExternalToolService.Call    → observation, Working
```

**A refusal still goes through `ReturnService`** — a refusal *is* the agent's answer; the caller gets told, not stonewalled. It takes the same terminal path and differs only in the status it lands on.

## An unknown tool is a routing decision, not a failure

Vector `05-unknown-tool-recovers`: an unknown tool routes to **External** and the agent **recovers** — it does not throw, does not terminate. Anything the agent can't do locally might still be doable across the boundary.

Combined with `ShouldKeepWorkingOnActIfToolReportsAnErrorAsync`: a tool that **returns** an error string is a result that becomes an observation and the loop keeps going — the Brain gets to read the error and try something else. Only a **throwing** tool is a dependency failure. That line is now pinned at every tier that touches it (#29, #30, here).

## Observations are named and accumulated

`$"{context.DirectionType}: {output}"` — a bare `"2"` tells the Brain nothing about *which question it answers* once several tools are in flight. And they're appended, never replaced: the turn history is the Brain's working memory.

SPEC.md §4.3 makes both a **MUST**: a non-terminal result is appended to `observations` with status `Working`. That feed-back is the whole mechanism behind vector `02`.

## `Failed` — your decision on #34

**Nothing here sets it.** Categorical exceptions propagate and Coordination maps them. The enum member stays declared (§3 mandates the shape and forbids a boolean), but the exception ladder already carries failure better than a flag could: `Failed` says *"something went wrong"*; `BrainDependencyException → FailedBrainDependencyException → HttpResponseUnauthorizedException`, logged Critical, says **which faculty failed, how, and whether waiting helps**.

## Discipline note

The **8 exception tests did not have an observed FAIL** — written after the `TryCatch`, same as #33. Checked for vacuity by mutation: removing the rewrap fails exactly **6 of them and no others**; restoring returns 168/168. Regression tests, not TDD-driven ones.

The **7 logic tests did** have genuine observed FAILs.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 168, Total: 168** (15 new cases)

---

## This completes ORCHESTRATION · 3

| Recall (#32) | Think (#33) | Act (#34) |
|---|---|---|
| what it **has** | what it **thinks** | what it **does** |

Next: `AgentCoordinationService` (#35) — the loop. **That's when the agent runs end-to-end** and the six vectors can finally certify.

Closes #34
