### PR TITLE
MINOR FIX: Act Must Write Result On Every Turn

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
@@ -196,6 +196,37 @@ public partial class DirectionOrchestrationServiceTests
             .ContainSingle(o => o.Contains("could not parse expression"));
     }
 
+    // ⚠️ Result is written on EVERY turn, not only terminal ones. SPEC.md 3 says
+    // "result: written by Act" with no terminal-only qualifier.
+    //
+    // Vector 06 is what needs this: a Brain that never terminates is capped by the
+    // loop, and SPEC.md 5 then returns context.result. If Act only wrote Result on a
+    // terminal turn, a capped loop would return "" — the vector expects the last
+    // tool output. Result always holds the most recent thing Direction produced.
+    [Fact]
+    public async Task ShouldSetResultToToolOutputOnActEvenIfNonTerminalAsync()
+    {
+        // given
+        AgentContext inputContext =
+            CreateContextWithDirection("loop", "x");
+
+        this.internalToolServiceMock.Setup(service =>
+            service.HandlesAsync("loop"))
+                .ReturnsAsync(true);
+
+        this.internalToolServiceMock.Setup(service =>
+            service.RunAsync("loop", "x"))
+                .ReturnsAsync("again");
+
+        // when
+        AgentContext actualContext =
+            await this.directionOrchestrationService.ActAsync(inputContext);
+
+        // then
+        actualContext.Result.Should().Be("again");
+        actualContext.Status.Should().Be(AgentStatus.Working);
+    }
+
     // The observation names the tool, not just its output. With several tools in
     // flight, a bare "2" tells the Brain nothing about which question it answers.
     [Fact]

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -67,8 +67,14 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
         // SPEC.md 4.3: a non-terminal result MUST be appended to observations and its
         // status MUST be Working. Named, because a bare "2" tells the Brain nothing
         // about which question it answers once several tools are in flight.
+        //
+        // Result is written here too, not only on terminal turns. SPEC.md 3 says
+        // "result: written by Act" with no qualifier, and vector 06 depends on it: a
+        // capped loop never reaches a terminal turn, and SPEC.md 5 still returns
+        // context.result. Result holds the most recent thing Direction produced.
         return context with
         {
+            Result = output,
             Observations = [.. context.Observations, $"{context.DirectionType}: {output}"],
             Status = AgentStatus.Working
         };


### PR DESCRIPTION
`ActAsync` wrote `Result` **only on terminal directions**, which makes conformance vector `06-max-turns-cap` unpassable. Found while building #35.

## The bug

```json
{ "generatorReplies": ["ACTION: loop: x"], "tools": { "loop": "again" },
  "expect": { "result": "again" } }
```

The scripted Brain **never terminates** — CONFORMANCE.md repeats the last reply when exhausted, *"so a single non-terminal reply exercises the turn cap."* Every turn runs the tool; the loop hits `MAX_TURNS` and exits; SPEC.md §5 then does `return context.result`.

With `Result` unwritten on non-terminal turns that's **`""`**. The vector expects **`"again"`**.

## The spec never said terminal-only

```
result : Text          // DIRECTION: written by Act
```

No qualifier. The restriction was invented by the implementation.

## Fix

```csharp
return context with
{
    Result = output,                    // <-- one line
    Observations = [.. context.Observations, $"{context.DirectionType}: {output}"],
    Status = AgentStatus.Working
};
```

`Result` now holds *the most recent thing Direction produced* — the answer on a terminal turn, the last tool output on a capped one.

## Why this stayed invisible

**Every other vector terminates**, so `Result` gets overwritten by the final answer and the defect never shows. Only the turn cap ever reads `Result` from a non-terminal turn.

Without this test it would have surfaced as the conformance runner returning empty on vector 06 — **after #35 and #39 had landed, far from the cause, and looking like a bug in the loop rather than in Act.**

## Verification

FAIL observed (`expected "again"`, Result empty) → fix → `dotnet test` **169/169**.

Closes #73
