### PR TITLE
COORDINATIONS: Process Prompt

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Exceptions.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Exceptions.ProcessPrompt.cs
@@ -1,0 +1,127 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Coordinations.Agents.Exceptions;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xeptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Coordinations;
+
+public partial class AgentCoordinationServiceTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnProcessPromptIfPromptIsInvalidAndLogItAsync(
+        string invalidPrompt)
+    {
+        // given
+        var invalidAgentException =
+            new InvalidAgentException(
+                message: "Invalid prompt. Please correct the error and try again.");
+
+        var expectedException =
+            new AgentCoordinationValidationException(
+                message: "Agent coordination validation error occurred, fix the error and try again.",
+                innerException: invalidAgentException);
+
+        // when
+        ValueTask<string> processTask =
+            this.agentCoordinationService.ProcessPromptAsync(invalidPrompt);
+
+        AgentCoordinationValidationException actualException =
+            await Assert.ThrowsAsync<AgentCoordinationValidationException>(
+                processTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+
+        // Nothing ran — not even the log reset. An empty prompt is rejected before
+        // the loop touches anything.
+        this.logBrokerMock.VerifyNoOtherCalls();
+        this.dataOrchestrationServiceMock.VerifyNoOtherCalls();
+    }
+
+    // An unrecoverable failure reaches the caller as one typed exception. This is the
+    // other half of the #34 decision: nothing sets AgentStatus.Failed, so THIS is
+    // where a failed turn surfaces.
+    [Theory]
+    [MemberData(nameof(DependencyExceptions))]
+    public async Task ShouldThrowDependencyExceptionOnProcessPromptIfDependencyErrorOccursAndLogItAsync(
+        Xeption orchestrationException)
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+
+        var expectedException =
+            new AgentCoordinationDependencyException(
+                message: "Agent coordination dependency error occurred, contact support.",
+                innerException: orchestrationException.InnerException as Xeption);
+
+        this.dataOrchestrationServiceMock.Setup(service =>
+            service.RecallAsync(It.IsAny<AgentContext>()))
+                .ThrowsAsync(orchestrationException);
+
+        // when
+        ValueTask<string> processTask =
+            this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        AgentCoordinationDependencyException actualException =
+            await Assert.ThrowsAsync<AgentCoordinationDependencyException>(
+                processTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnProcessPromptIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        var serviceException = new Exception();
+
+        var failedAgentCoordinationServiceException =
+            new FailedAgentCoordinationServiceException(
+                message: "Failed agent coordination service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedException =
+            new AgentCoordinationServiceException(
+                message: "Agent coordination service error occurred, contact support.",
+                innerException: failedAgentCoordinationServiceException);
+
+        this.dataOrchestrationServiceMock.Setup(service =>
+            service.RecallAsync(It.IsAny<AgentContext>()))
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<string> processTask =
+            this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        AgentCoordinationServiceException actualException =
+            await Assert.ThrowsAsync<AgentCoordinationServiceException>(
+                processTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
+                Times.Once);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
@@ -1,0 +1,271 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Coordinations;
+
+public partial class AgentCoordinationServiceTests
+{
+    // Vector 01 in miniature: one turn, terminal, answer returned.
+    [Fact]
+    public async Task ShouldProcessPromptAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        string expectedResult = CreateRandomString();
+
+        SetupOrchestrationsPassThrough();
+        SetupDirectionTerminates(expectedResult);
+
+        // when
+        string actualResult =
+            await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        actualResult.Should().Be(expectedResult);
+    }
+
+    // The prompt reaches Recall as the context's Prompt, and Status starts Working —
+    // SPEC.md 3 requires Working to be the initial value, and 5 starts the loop from
+    // a fresh context carrying only the prompt.
+    [Fact]
+    public async Task ShouldSeedContextWithPromptOnProcessPromptAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+
+        SetupOrchestrationsPassThrough();
+        SetupDirectionTerminates(CreateRandomString());
+
+        // when
+        await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        this.dataOrchestrationServiceMock.Verify(service =>
+            service.RecallAsync(It.Is<AgentContext>(context =>
+                context.Prompt == randomPrompt
+                    && context.Status == AgentStatus.Working)),
+                        Times.Once);
+    }
+
+    // Enforced order. All three take and return AgentContext, so the sequence is NOT
+    // encoded in their signatures — nothing would stop Act running before Think and
+    // the types would still line up. The Standard requires an explicit order test
+    // exactly when order is not naturally encoded.
+    [Fact]
+    public async Task ShouldCallRecallThinkActInOrderOnProcessPromptAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        var sequence = new MockSequence();
+
+        this.dataOrchestrationServiceMock.InSequence(sequence)
+            .Setup(service => service.RecallAsync(It.IsAny<AgentContext>()))
+            .ReturnsAsync((AgentContext context) => context);
+
+        this.decisionOrchestrationServiceMock.InSequence(sequence)
+            .Setup(service => service.ThinkAsync(It.IsAny<AgentContext>()))
+            .ReturnsAsync((AgentContext context) => context);
+
+        this.directionOrchestrationServiceMock.InSequence(sequence)
+            .Setup(service => service.ActAsync(It.IsAny<AgentContext>()))
+            .ReturnsAsync((AgentContext context) =>
+                context with { Result = "done", Status = AgentStatus.Responded });
+
+        // when
+        string actualResult =
+            await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        actualResult.Should().Be("done");
+    }
+
+    // The loop stops on any non-Working status. SPEC.md 3: "continues while
+    // status == Working and stops on any other value" — so a new terminal state can
+    // be added to the enum without touching the loop.
+    [Theory]
+    [InlineData(AgentStatus.Responded)]
+    [InlineData(AgentStatus.Refused)]
+    [InlineData(AgentStatus.Failed)]
+    [InlineData(AgentStatus.AwaitingInput)]
+    public async Task ShouldBreakLoopOnProcessPromptIfStatusIsNotWorkingAsync(
+        AgentStatus terminalStatus)
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        SetupOrchestrationsPassThrough();
+
+        this.directionOrchestrationServiceMock.Setup(service =>
+            service.ActAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) =>
+                    context with { Result = "stopped", Status = terminalStatus });
+
+        // when
+        string actualResult =
+            await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        actualResult.Should().Be("stopped");
+
+        this.dataOrchestrationServiceMock.Verify(service =>
+            service.RecallAsync(It.IsAny<AgentContext>()),
+                Times.Once);
+    }
+
+    // Vector 06. A Brain that never terminates MUST be capped — SPEC.md 5 makes the
+    // cap a MUST. Without it this test would hang forever rather than fail, which is
+    // why the loop is the one place a bound is not optional.
+    [Fact]
+    public async Task ShouldCapTurnsOnProcessPromptIfBrainNeverTerminatesAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        SetupOrchestrationsPassThrough();
+        SetupDirectionNeverTerminates("again");
+
+        // when
+        string actualResult =
+            await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        actualResult.Should().Be("again");
+
+        // Capped, not infinite. The exact bound is ours (SPEC.md 5: finite, SHOULD be
+        // small); what matters is that it is finite and the same on every path.
+        this.dataOrchestrationServiceMock.Verify(service =>
+            service.RecallAsync(It.IsAny<AgentContext>()),
+                Times.Exactly(7));
+
+        this.decisionOrchestrationServiceMock.Verify(service =>
+            service.ThinkAsync(It.IsAny<AgentContext>()),
+                Times.Exactly(7));
+    }
+
+    // Recall runs every turn, not once. SPEC.md 5 puts it inside the loop so skills
+    // refresh per turn; hoisting it out as an optimisation would break that.
+    [Fact]
+    public async Task ShouldRecallEveryTurnOnProcessPromptAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        int turn = 0;
+
+        this.dataOrchestrationServiceMock.Setup(service =>
+            service.RecallAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) => context);
+
+        this.decisionOrchestrationServiceMock.Setup(service =>
+            service.ThinkAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) => context);
+
+        // Two working turns, then terminate.
+        this.directionOrchestrationServiceMock.Setup(service =>
+            service.ActAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) =>
+                {
+                    turn++;
+
+                    return turn < 3
+                        ? context with { Result = "working", Status = AgentStatus.Working }
+                        : context with { Result = "done", Status = AgentStatus.Responded };
+                });
+
+        // when
+        string actualResult =
+            await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        actualResult.Should().Be("done");
+
+        this.dataOrchestrationServiceMock.Verify(service =>
+            service.RecallAsync(It.IsAny<AgentContext>()),
+                Times.Exactly(3));
+    }
+
+    // The log is reset once per prompt, at the top — SPEC.md 5. Each prompt's trace
+    // is its own narrative, not an append to the last one's.
+    [Fact]
+    public async Task ShouldResetLogOnProcessPromptAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        SetupOrchestrationsPassThrough();
+        SetupDirectionTerminates(CreateRandomString());
+
+        // when
+        await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        this.logBrokerMock.Verify(broker =>
+            broker.ResetAsync(),
+                Times.Once);
+    }
+
+    // SPEC.md 4.4: Coordination MUST hold no nature logic beyond sequencing and
+    // observing. This is the observing half — one line per turn.
+    [Fact]
+    public async Task ShouldWriteTurnToLogOnProcessPromptAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        SetupOrchestrationsPassThrough();
+        SetupDirectionTerminates(CreateRandomString());
+
+        // when
+        await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        this.logBrokerMock.Verify(broker =>
+            broker.WriteAsync(It.IsAny<string>()),
+                Times.AtLeastOnce);
+    }
+
+    // ⭐ Invariant 7.4 — the agent instance is ephemeral and MUST be stateless across
+    // prompts. Two sequential prompts on the SAME instance must not leak: if the
+    // second saw the first's observations, the agent would answer a question nobody
+    // asked and the leak would grow with every prompt.
+    [Fact]
+    public async Task ShouldNotLeakStateBetweenPromptsOnProcessPromptAsync()
+    {
+        // given
+        string firstPrompt = CreateRandomString();
+        string secondPrompt = CreateRandomString();
+        List<AgentContext> recalledContexts = [];
+
+        this.dataOrchestrationServiceMock.Setup(service =>
+            service.RecallAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) =>
+                {
+                    recalledContexts.Add(context);
+
+                    return context with
+                    {
+                        Observations = [.. context.Observations, "some observation"]
+                    };
+                });
+
+        this.decisionOrchestrationServiceMock.Setup(service =>
+            service.ThinkAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) => context);
+
+        SetupDirectionTerminates("done");
+
+        // when
+        await this.agentCoordinationService.ProcessPromptAsync(firstPrompt);
+        await this.agentCoordinationService.ProcessPromptAsync(secondPrompt);
+
+        // then
+        recalledContexts.Should().HaveCount(2);
+        recalledContexts[0].Prompt.Should().Be(firstPrompt);
+        recalledContexts[1].Prompt.Should().Be(secondPrompt);
+
+        // The second prompt starts clean — no observations carried from the first.
+        recalledContexts[1].Observations.Should().BeEmpty();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.cs
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Coordinations;
+using Standard.Agents.Services.Orchestrations.Data;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Standard.Agents.Services.Orchestrations.Direction;
+using Tynamix.ObjectFiller;
+using Xeptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Coordinations;
+
+public partial class AgentCoordinationServiceTests
+{
+    private readonly Mock<IDataOrchestrationService> dataOrchestrationServiceMock;
+    private readonly Mock<IDecisionOrchestrationService> decisionOrchestrationServiceMock;
+    private readonly Mock<IDirectionOrchestrationService> directionOrchestrationServiceMock;
+    private readonly Mock<ILogBroker> logBrokerMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly IAgentCoordinationService agentCoordinationService;
+
+    public AgentCoordinationServiceTests()
+    {
+        this.dataOrchestrationServiceMock = new Mock<IDataOrchestrationService>();
+        this.decisionOrchestrationServiceMock = new Mock<IDecisionOrchestrationService>();
+        this.directionOrchestrationServiceMock = new Mock<IDirectionOrchestrationService>();
+        this.logBrokerMock = new Mock<ILogBroker>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.agentCoordinationService = new AgentCoordinationService(
+            dataOrchestrationService: this.dataOrchestrationServiceMock.Object,
+            decisionOrchestrationService: this.decisionOrchestrationServiceMock.Object,
+            directionOrchestrationService: this.directionOrchestrationServiceMock.Object,
+            logBroker: this.logBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    // Pass-through Recall and Think; Direction decides how the turn ends.
+    private void SetupOrchestrationsPassThrough()
+    {
+        this.dataOrchestrationServiceMock.Setup(service =>
+            service.RecallAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) => context);
+
+        this.decisionOrchestrationServiceMock.Setup(service =>
+            service.ThinkAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) => context);
+    }
+
+    private void SetupDirectionTerminates(string result) =>
+        this.directionOrchestrationServiceMock.Setup(service =>
+            service.ActAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) =>
+                    context with { Result = result, Status = AgentStatus.Responded });
+
+    // Never terminates — every turn stays Working, as vector 06's scripted Brain does.
+    private void SetupDirectionNeverTerminates(string result) =>
+        this.directionOrchestrationServiceMock.Setup(service =>
+            service.ActAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) =>
+                    context with { Result = result, Status = AgentStatus.Working });
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+
+    public static TheoryData<Xeption> DependencyExceptions() =>
+        new()
+        {
+            new Models.Orchestrations.Agents.Exceptions.AgentOrchestrationDependencyException(
+                "orchestration dependency", new Xeption("inner")),
+
+            new Models.Orchestrations.Agents.Exceptions.AgentOrchestrationServiceException(
+                "orchestration service", new Xeption("inner"))
+        };
+}

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationDependencyException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
+
+public class AgentCoordinationDependencyException : Xeption
+{
+    public AgentCoordinationDependencyException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationDependencyValidationException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationDependencyValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
+
+public class AgentCoordinationDependencyValidationException : Xeption
+{
+    public AgentCoordinationDependencyValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationServiceException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
+
+public class AgentCoordinationServiceException : Xeption
+{
+    public AgentCoordinationServiceException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationValidationException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
+
+public class AgentCoordinationValidationException : Xeption
+{
+    public AgentCoordinationValidationException(string message, Xeption innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/FailedAgentCoordinationServiceException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/FailedAgentCoordinationServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
+
+public class FailedAgentCoordinationServiceException : Xeption
+{
+    public FailedAgentCoordinationServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/InvalidAgentException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/InvalidAgentException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
+
+public class InvalidAgentException : Xeption
+{
+    public InvalidAgentException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Exceptions.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Exceptions.cs
@@ -1,0 +1,113 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Coordinations.Agents.Exceptions;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Coordinations;
+
+public partial class AgentCoordinationService
+{
+    private delegate ValueTask<string> ReturningStringFunction();
+
+    // The last tier. Per the decision on #34, this is where a failed turn surfaces:
+    // nothing sets AgentStatus.Failed, so an unrecoverable failure arrives here as a
+    // categorical exception and leaves as AgentCoordinationServiceException — the
+    // caller's single, typed contract for "the agent could not answer".
+    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    {
+        try
+        {
+            return await returningStringFunction();
+        }
+        catch (InvalidAgentException invalidAgentException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidAgentException);
+        }
+        catch (AgentOrchestrationValidationException agentOrchestrationValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                agentOrchestrationValidationException.InnerException as Xeption);
+        }
+        catch (AgentOrchestrationDependencyValidationException agentOrchestrationDependencyValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                agentOrchestrationDependencyValidationException.InnerException as Xeption);
+        }
+        catch (AgentOrchestrationDependencyException agentOrchestrationDependencyException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                agentOrchestrationDependencyException.InnerException as Xeption);
+        }
+        catch (AgentOrchestrationServiceException agentOrchestrationServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                agentOrchestrationServiceException.InnerException as Xeption);
+        }
+        catch (Exception exception)
+        {
+            var failedAgentCoordinationServiceException =
+                new FailedAgentCoordinationServiceException(
+                    message: "Failed agent coordination service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(
+                failedAgentCoordinationServiceException);
+        }
+    }
+
+    private async ValueTask<AgentCoordinationValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var agentCoordinationValidationException =
+            new AgentCoordinationValidationException(
+                message: "Agent coordination validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentCoordinationValidationException);
+
+        return agentCoordinationValidationException;
+    }
+
+    private async ValueTask<AgentCoordinationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+        Xeption exception)
+    {
+        var agentCoordinationDependencyValidationException =
+            new AgentCoordinationDependencyValidationException(
+                message: "Agent coordination dependency validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentCoordinationDependencyValidationException);
+
+        return agentCoordinationDependencyValidationException;
+    }
+
+    private async ValueTask<AgentCoordinationDependencyException> CreateAndLogDependencyExceptionAsync(
+        Xeption exception)
+    {
+        var agentCoordinationDependencyException =
+            new AgentCoordinationDependencyException(
+                message: "Agent coordination dependency error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentCoordinationDependencyException);
+
+        return agentCoordinationDependencyException;
+    }
+
+    private async ValueTask<AgentCoordinationServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var agentCoordinationServiceException =
+            new AgentCoordinationServiceException(
+                message: "Agent coordination service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(agentCoordinationServiceException);
+
+        return agentCoordinationServiceException;
+    }
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Validations.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Validations.cs
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Coordinations.Agents.Exceptions;
+
+namespace Standard.Agents.Services.Coordinations;
+
+public partial class AgentCoordinationService
+{
+    private static void ValidatePrompt(string prompt)
+    {
+        if (string.IsNullOrWhiteSpace(prompt))
+        {
+            throw new InvalidAgentException(
+                message: "Invalid prompt. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Orchestrations.Data;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Standard.Agents.Services.Orchestrations.Direction;
+
+namespace Standard.Agents.Services.Coordinations;
+
+public partial class AgentCoordinationService : IAgentCoordinationService
+{
+    private readonly IDataOrchestrationService dataOrchestrationService;
+    private readonly IDecisionOrchestrationService decisionOrchestrationService;
+    private readonly IDirectionOrchestrationService directionOrchestrationService;
+    private readonly ILogBroker logBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public AgentCoordinationService(
+        IDataOrchestrationService dataOrchestrationService,
+        IDecisionOrchestrationService decisionOrchestrationService,
+        IDirectionOrchestrationService directionOrchestrationService,
+        ILogBroker logBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.dataOrchestrationService = dataOrchestrationService;
+        this.decisionOrchestrationService = decisionOrchestrationService;
+        this.directionOrchestrationService = directionOrchestrationService;
+        this.logBroker = logBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<string> ProcessPromptAsync(string prompt) =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -4,14 +4,27 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Orchestrations.Data;
 using Standard.Agents.Services.Orchestrations.Decision;
 using Standard.Agents.Services.Orchestrations.Direction;
 
 namespace Standard.Agents.Services.Coordinations;
 
+// The Agent — and the only loop in the system.
+//
+// SPEC.md 4.4: Coordination MUST hold no nature logic beyond sequencing and
+// observing. Everything below is one of those two things; the moment a decision
+// appears here, it belongs in a nature instead.
 public partial class AgentCoordinationService : IAgentCoordinationService
 {
+    // SPEC.md 5: MUST be finite, SHOULD be small. The number is ours.
+    //
+    // Finite is the load-bearing half. A Brain that never emits a terminal reply is
+    // not hypothetical — it is vector 06 — and without a bound the agent does not
+    // fail, it hangs, burning an inference call per turn forever.
+    private const int MaxTurns = 7;
+
     private readonly IDataOrchestrationService dataOrchestrationService;
     private readonly IDecisionOrchestrationService decisionOrchestrationService;
     private readonly IDirectionOrchestrationService directionOrchestrationService;
@@ -33,5 +46,39 @@ public partial class AgentCoordinationService : IAgentCoordinationService
     }
 
     public ValueTask<string> ProcessPromptAsync(string prompt) =>
-        throw new NotImplementedException();
+    TryCatch(async () =>
+    {
+        ValidatePrompt(prompt);
+
+        await this.logBroker.ResetAsync();
+
+        // The context is a local, born here and dying here. Invariant 7.4 — the
+        // instance is ephemeral and stateless across prompts; holding this in a field
+        // would leak one prompt's observations into the next.
+        AgentContext context = new() { Prompt = prompt };
+
+        for (int turn = 1; turn <= MaxTurns; turn++)
+        {
+            context = await this.dataOrchestrationService.RecallAsync(context);
+            context = await this.decisionOrchestrationService.ThinkAsync(context);
+            context = await this.directionOrchestrationService.ActAsync(context);
+
+            await LogTurnAsync(turn, context);
+
+            // Stops on ANY non-Working status rather than on a list of known ones, so
+            // a new terminal state needs no change here. SPEC.md 3 forbids a boolean
+            // for exactly this reason.
+            if (context.Status != AgentStatus.Working)
+            {
+                break;
+            }
+        }
+
+        return context.Result;
+    });
+
+    private async ValueTask LogTurnAsync(int turn, AgentContext context) =>
+        await this.logBroker.WriteAsync(
+            $"turn {turn} | intent: {context.Intent} | direction: {context.DirectionType} " +
+            $"| status: {context.Status}");
 }

--- a/Standard.Agents/Services/Coordinations/IAgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/IAgentCoordinationService.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Coordinations;
+
+public interface IAgentCoordinationService
+{
+    ValueTask<string> ProcessPromptAsync(string prompt);
+}


### PR DESCRIPTION
The Agent — **and the only loop in the system**. SPEC.md §4.4, §5.

```csharp
ValueTask<string> ProcessPromptAsync(string prompt);
```

Exactly the normative algorithm: reset the log → fresh context → **Recall → Think → Act** → break on any non-`Working` status → return the result.

## Three tests that earn their place

**`ShouldCallRecallThinkActInOrderOnProcessPromptAsync` — enforced order.**
All three orchestrations take *and* return `AgentContext`, so **the sequence is not encoded in their signatures**. Nothing would stop Act running before Think and the types would still line up. The Standard asks for an explicit order test in exactly this case; `MockSequence` makes the order assertable rather than assumed.

**`ShouldNotLeakStateBetweenPromptsOnProcessPromptAsync` — invariant §7.4.**
Runs two prompts on the **same instance** and asserts the second starts clean. If the context lived in a field — the natural place to put it — the second prompt would inherit the first's observations, answer a question nobody asked, and **the leak would grow with every prompt**. This is the only thing that would notice.

**`ShouldCapTurnsOnProcessPromptIfBrainNeverTerminatesAsync` — vector 06.**
Note: without the cap this test doesn't fail, it **hangs**. That's why §5 makes the bound a MUST and why the loop is the one place a bound isn't optional.

## `MaxTurns = 7`

§5 says *finite, SHOULD be small*. **The number is ours** and the comment says so. Finite is the load-bearing half — a Brain that never emits a terminal reply isn't hypothetical, it's vector 06, and without a bound the agent doesn't fail, it hangs, burning an inference call per turn forever.

## `!= Working`, not a list

The status Theory covers all four non-Working values **including `AwaitingInput`, which nothing sets today**. The loop stops by construction rather than by enumerating states it knows — so a future terminal state works without the loop changing. That's precisely why §3 forbids a boolean.

## Where failure surfaces

The other half of the #34 decision. Nothing sets `AgentStatus.Failed`, so an unrecoverable failure arrives here as a categorical exception and leaves as `AgentCoordinationServiceException` — **one typed contract for "the agent could not answer"**, with the full ladder intact underneath.

## Discipline note

The 5 exception tests had **no observed FAIL** (same as #33, #34). Mutation-checked: removing the rewrap fails 3 of them and no others; restoring returns 187/187. The 9 logic tests **did** have genuine FAILs.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 187, Total: 187** (19 new cases)

---

## The 1·3·9 is complete

| Tier | | |
|---|---|---|
| **Coordination · 1** | `AgentCoordinationService` | Done |
| **Orchestration · 3** | Data · Decision · Direction | Done |
| **Foundation · 9** | Skills/Memory/Knowledge · Gate/Brain/Judge · Internal/External/Return | Done |
| **Broker · 8+2** | every one a real liaison | Done |

**`Agent = Orchestration(Data, Decision, Direction)`** — and it runs end to end.

Next: #36/#37 (the facade and the fractal bridge), then #39 — where the six vectors finally certify.

Closes #35
