### PR TITLE
CLIENTS: Standard Agent Facade

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -1,0 +1,209 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents;
+using Standard.Agents.Brokers.Data;
+using Standard.Agents.Brokers.Decision;
+using Standard.Agents.Brokers.Direction;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Clients.Agents.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+public class StandardAgentTests
+{
+    // Every broker swapped, so nothing reaches a network. This is also exactly what
+    // the conformance harness does (#39) — if the facade cannot be fully stubbed, the
+    // vectors cannot run.
+    private static StandardAgent CreateFullyStubbedAgent(string brainReply)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("you are an agent");
+
+        var generatorBroker = new Mock<IGeneratorBroker>();
+        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(brainReply);
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+        knowledgeBroker.Setup(b => b.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+
+        var classifierBroker = new Mock<IClassifierBroker>();
+        classifierBroker.Setup(b => b.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("allow");
+
+        var verifierBroker = new Mock<IVerifierBroker>();
+        verifierBroker.Setup(b => b.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(1.0);
+
+        var mcpBroker = new Mock<IMcpBroker>();
+        var logBroker = new Mock<ILogBroker>();
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseGenerator(generatorBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .UseGate(classifierBroker.Object)
+            .UseJudge(verifierBroker.Object)
+            .UseMcp(mcpBroker.Object)
+            .UseLog(logBroker.Object);
+    }
+
+    [Fact]
+    public async Task ShouldComposeAndProcessPromptAsync()
+    {
+        // given
+        StandardAgent agent = CreateFullyStubbedAgent("FINAL: 42");
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync("what is the answer?");
+
+        // then
+        actualResult.Should().Be("42");
+    }
+
+    // The builder is fluent — every method returns the same instance, so a chain
+    // configures one agent rather than silently building several.
+    [Fact]
+    public void ShouldReturnSameInstanceOnEachBuilderMethod()
+    {
+        // given
+        var agent = new StandardAgent();
+
+        // when
+        StandardAgent chained = agent
+            .Skills("Skills")
+            .Brain("https://x/", "key", "model")
+            .Memory("memory.txt")
+            .Knowledge("Knowledge")
+            .Mcp("https://mcp/")
+            .LogTo("log.txt");
+
+        // then
+        chained.Should().BeSameAs(agent);
+    }
+
+    // ⭐ Configuration set AFTER a prompt must take effect. The composition is cached,
+    // so a builder method that did not drop it would return `this` and silently ignore
+    // the change — the caller would see the old agent and no error explaining why.
+    [Fact]
+    public async Task ShouldRecomposeAfterConfigurationChangesAsync()
+    {
+        // given
+        StandardAgent agent = CreateFullyStubbedAgent("FINAL: first");
+
+        string firstResult = await agent.ProcessPromptAsync("prompt");
+
+        var newGenerator = new Mock<IGeneratorBroker>();
+        newGenerator.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("FINAL: second");
+
+        // when
+        agent.UseGenerator(newGenerator.Object);
+        string secondResult = await agent.ProcessPromptAsync("prompt");
+
+        // then
+        firstResult.Should().Be("first");
+        secondResult.Should().Be("second");
+    }
+
+    // An agent with no brain is not an agent. Theory Ch.5: "An agent has one brain."
+    // Zero is not a valid count, and failing at composition names the mistake where it
+    // was made rather than as a null-reference on the first prompt.
+    [Fact]
+    public async Task ShouldThrowCompositionExceptionOnProcessPromptIfBrainIsNotConfiguredAsync()
+    {
+        // given
+        var agent = new StandardAgent();
+
+        // when
+        ValueTask<string> processTask = agent.ProcessPromptAsync("prompt");
+
+        InvalidAgentCompositionException actualException =
+            await Assert.ThrowsAsync<InvalidAgentCompositionException>(
+                processTask.AsTask);
+
+        // then
+        actualException.Message.Should().Contain("no brain");
+    }
+
+    // ⚠️ A swapped generator with no Brain() settings must still compose.
+    //
+    // Gate and Judge fall back to the Brain's endpoint settings, so a caller who
+    // supplies a generator broker but never calls Brain() leaves those settings null.
+    // Building the default Classifier/Verifier from them would dereference null — and
+    // the conformance harness (#39) is exactly this caller.
+    [Fact]
+    public async Task ShouldComposeOnProcessPromptIfGeneratorIsSwappedWithoutBrainSettingsAsync()
+    {
+        // given
+        var generatorBroker = new Mock<IGeneratorBroker>();
+        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("FINAL: ok");
+
+        var classifierBroker = new Mock<IClassifierBroker>();
+        classifierBroker.Setup(b => b.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("allow");
+
+        var verifierBroker = new Mock<IVerifierBroker>();
+        verifierBroker.Setup(b => b.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(1.0);
+
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("skills");
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+        var logBroker = new Mock<ILogBroker>();
+
+        // No Brain(...) call anywhere.
+        var agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseGenerator(generatorBroker.Object)
+            .UseGate(classifierBroker.Object)
+            .UseJudge(verifierBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .UseMcp(new Mock<IMcpBroker>().Object)
+            .UseLog(logBroker.Object);
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync("prompt");
+
+        // then
+        actualResult.Should().Be("ok");
+    }
+
+    // A swapped generator with an UNSWAPPED gate has nowhere to get the gate's
+    // endpoint from. That must be a named composition error, not a null-reference from
+    // inside a broker constructor.
+    [Fact]
+    public async Task ShouldThrowCompositionExceptionOnProcessPromptIfGateHasNoSettingsAsync()
+    {
+        // given
+        var generatorBroker = new Mock<IGeneratorBroker>();
+
+        var agent = new StandardAgent()
+            .UseGenerator(generatorBroker.Object);
+
+        // when
+        ValueTask<string> processTask = agent.ProcessPromptAsync("prompt");
+
+        InvalidAgentCompositionException actualException =
+            await Assert.ThrowsAsync<InvalidAgentCompositionException>(
+                processTask.AsTask);
+
+        // then
+        actualException.Message.Should().Contain("gate");
+    }
+}

--- a/Standard.Agents/IAgent.cs
+++ b/Standard.Agents/IAgent.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents;
+
+public interface IAgent
+{
+    ValueTask<string> ProcessPromptAsync(string prompt);
+}

--- a/Standard.Agents/Models/Clients/Agents/Exceptions/InvalidAgentCompositionException.cs
+++ b/Standard.Agents/Models/Clients/Agents/Exceptions/InvalidAgentCompositionException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Clients.Agents.Exceptions;
+
+public class InvalidAgentCompositionException : Xeption
+{
+    public InvalidAgentCompositionException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/StandardAgent.Validations.cs
+++ b/Standard.Agents/StandardAgent.Validations.cs
@@ -9,19 +9,41 @@ namespace Standard.Agents;
 
 public sealed partial class StandardAgent
 {
-    // An agent with no Brain is not an agent. Theory Ch.5: "An agent has one brain."
-    // Zero is not a valid count, and failing at composition says so at the moment the
-    // mistake was made rather than as a null-reference on the first prompt.
+    // Validates what each DEFAULT broker needs, not what the agent "should" have. A
+    // swapped-in broker needs no settings at all — that is the whole point of Use*,
+    // and it is how the conformance harness composes an agent with no endpoint.
     //
-    // A swapped-in generator counts — UseGenerator(broker) is a Brain.
+    // Each check names the missing piece, so a composition mistake reads as itself
+    // rather than as a null-reference from inside a broker constructor.
     private void ValidateComposition()
     {
+        // Theory Ch.5: "An agent has one brain." Zero is not a valid count.
         if (this.generatorBroker is null && this.brainSettings is null)
         {
             throw new InvalidAgentCompositionException(
                 message:
                     "Agent has no brain. Call Brain(apiUrl, apiKey, model) "
                         + "or UseGenerator(broker) before processing a prompt.");
+        }
+
+        // Gate and Judge fall back to the Brain's settings, so they are only
+        // unsatisfiable when the Brain was swapped in rather than configured.
+        if (this.classifierBroker is null && this.gateSettings is null && this.brainSettings is null)
+        {
+            throw new InvalidAgentCompositionException(
+                message:
+                    "Agent has no gate. Call Gate(apiUrl, apiKey, model) or "
+                        + "UseGate(broker) — a swapped-in brain leaves the gate "
+                        + "nothing to fall back to.");
+        }
+
+        if (this.verifierBroker is null && this.judgeSettings is null && this.brainSettings is null)
+        {
+            throw new InvalidAgentCompositionException(
+                message:
+                    "Agent has no judge. Call Judge(apiUrl, apiKey, model) or "
+                        + "UseJudge(broker) — a swapped-in brain leaves the judge "
+                        + "nothing to fall back to.");
         }
     }
 }

--- a/Standard.Agents/StandardAgent.Validations.cs
+++ b/Standard.Agents/StandardAgent.Validations.cs
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Clients.Agents.Exceptions;
+
+namespace Standard.Agents;
+
+public sealed partial class StandardAgent
+{
+    // An agent with no Brain is not an agent. Theory Ch.5: "An agent has one brain."
+    // Zero is not a valid count, and failing at composition says so at the moment the
+    // mistake was made rather than as a null-reference on the first prompt.
+    //
+    // A swapped-in generator counts — UseGenerator(broker) is a Brain.
+    private void ValidateComposition()
+    {
+        if (this.generatorBroker is null && this.brainSettings is null)
+        {
+            throw new InvalidAgentCompositionException(
+                message:
+                    "Agent has no brain. Call Brain(apiUrl, apiKey, model) "
+                        + "or UseGenerator(broker) before processing a prompt.");
+        }
+    }
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -1,0 +1,250 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Standard.Agents.Brokers.Data;
+using Standard.Agents.Brokers.Decision;
+using Standard.Agents.Brokers.Direction;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Coordinations;
+using Standard.Agents.Services.Foundations.Data;
+using Standard.Agents.Services.Foundations.Decision;
+using Standard.Agents.Services.Foundations.Direction;
+using Standard.Agents.Services.Orchestrations.Data;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Standard.Agents.Services.Orchestrations.Direction;
+using Standard.Agents.Tools;
+
+namespace Standard.Agents;
+
+// The composition root. SPEC.md 9: "DI is OPTIONAL. A hand-wired composition root is
+// fully conformant." Compose() IS that root — the whole 1-3-9 graph in one readable
+// method, no container, nothing to chase. That is No Magic taken literally.
+//
+// Two ways to configure each nature:
+//   Brain/Gate/Judge/Memory/... — build the default broker from primitives
+//   Use*(broker)                — swap the broker entirely
+//
+// The second is what makes invariant 7.6 reachable: point Gate and Judge at a
+// different model, or a deterministic rule, without touching the library.
+public sealed partial class StandardAgent : IAgent
+{
+    private readonly List<ITool> tools = [];
+
+    private string skillsPath = "Skills";
+    private string logPath = "log.txt";
+    private string memoryPath = "memory.txt";
+    private string knowledgePath = "Knowledge";
+    private string knowledgePattern = "*.md";
+    private int knowledgeMaxResults = 3;
+
+    private InferenceSettings? brainSettings;
+    private InferenceSettings? gateSettings;
+    private InferenceSettings? judgeSettings;
+
+    private string mcpEndpointUrl = string.Empty;
+    private string mcpRelativeUrl = string.Empty;
+    private int mcpTimeoutSeconds = 30;
+
+    private ISkillBroker? skillBroker;
+    private IGeneratorBroker? generatorBroker;
+    private IMemoryBroker? memoryBroker;
+    private IKnowledgeBroker? knowledgeBroker;
+    private IClassifierBroker? classifierBroker;
+    private IVerifierBroker? verifierBroker;
+    private IMcpBroker? mcpBroker;
+    private ILogBroker? logBroker;
+    private ILoggingBroker? loggingBroker;
+
+    private IAgentCoordinationService? agent;
+
+    public StandardAgent Skills(string path) =>
+        Set(() => this.skillsPath = path);
+
+    public StandardAgent Brain(
+        string apiUrl,
+        string apiKey,
+        string model,
+        double temperature = 0.7,
+        int maxTokens = 1024,
+        int timeoutSeconds = 120) =>
+        Set(() => this.brainSettings =
+            new InferenceSettings(apiUrl, apiKey, model, temperature, maxTokens, timeoutSeconds));
+
+    // Optional, and pointing it at a different model is the whole point. Left unset,
+    // the Gate falls back to the Brain's endpoint — SPEC.md 9 permits collapsing the
+    // three Decision brokers onto one endpoint, and Theory Ch.5 calls it "three
+    // interfaces, collapsible substrate: at small scale one model wears all three
+    // hats". For anything safety-critical, set this — invariant 7.6 says the guardian
+    // must not be the brain.
+    public StandardAgent Gate(
+        string apiUrl,
+        string apiKey,
+        string model,
+        double temperature = 0.0,
+        int maxTokens = 16,
+        int timeoutSeconds = 30) =>
+        Set(() => this.gateSettings =
+            new InferenceSettings(apiUrl, apiKey, model, temperature, maxTokens, timeoutSeconds));
+
+    public StandardAgent Judge(
+        string apiUrl,
+        string apiKey,
+        string model,
+        double temperature = 0.0,
+        int maxTokens = 16,
+        int timeoutSeconds = 30) =>
+        Set(() => this.judgeSettings =
+            new InferenceSettings(apiUrl, apiKey, model, temperature, maxTokens, timeoutSeconds));
+
+    public StandardAgent Memory(string path) =>
+        Set(() => this.memoryPath = path);
+
+    public StandardAgent Knowledge(string path, string pattern = "*.md", int maxResults = 3) =>
+        Set(() =>
+        {
+            this.knowledgePath = path;
+            this.knowledgePattern = pattern;
+            this.knowledgeMaxResults = maxResults;
+        });
+
+    public StandardAgent Mcp(string endpointUrl, string relativeUrl = "", int timeoutSeconds = 30) =>
+        Set(() =>
+        {
+            this.mcpEndpointUrl = endpointUrl;
+            this.mcpRelativeUrl = relativeUrl;
+            this.mcpTimeoutSeconds = timeoutSeconds;
+        });
+
+    public StandardAgent Tool(ITool tool) =>
+        Set(() => this.tools.Add(tool));
+
+    public StandardAgent Tools(IEnumerable<ITool> tools) =>
+        Set(() => this.tools.AddRange(tools));
+
+    public StandardAgent LogTo(string path) =>
+        Set(() => this.logPath = path);
+
+    public StandardAgent UseSkills(ISkillBroker broker) =>
+        Set(() => this.skillBroker = broker);
+
+    public StandardAgent UseGenerator(IGeneratorBroker broker) =>
+        Set(() => this.generatorBroker = broker);
+
+    public StandardAgent UseMemory(IMemoryBroker broker) =>
+        Set(() => this.memoryBroker = broker);
+
+    public StandardAgent UseKnowledge(IKnowledgeBroker broker) =>
+        Set(() => this.knowledgeBroker = broker);
+
+    public StandardAgent UseGate(IClassifierBroker broker) =>
+        Set(() => this.classifierBroker = broker);
+
+    public StandardAgent UseJudge(IVerifierBroker broker) =>
+        Set(() => this.verifierBroker = broker);
+
+    public StandardAgent UseMcp(IMcpBroker broker) =>
+        Set(() => this.mcpBroker = broker);
+
+    public StandardAgent UseLog(ILogBroker broker) =>
+        Set(() => this.logBroker = broker);
+
+    public StandardAgent UseLogging(ILoggingBroker broker) =>
+        Set(() => this.loggingBroker = broker);
+
+    public ValueTask<string> ProcessPromptAsync(string prompt)
+    {
+        this.agent ??= Compose();
+
+        return this.agent.ProcessPromptAsync(prompt);
+    }
+
+    // Every builder method drops the cached composition, so configuration set after a
+    // prompt still takes effect. Returning `this` without doing that would silently
+    // ignore the change.
+    private StandardAgent Set(Action configure)
+    {
+        configure();
+        this.agent = null;
+
+        return this;
+    }
+
+    private IAgentCoordinationService Compose()
+    {
+        ValidateComposition();
+
+        // Gate and Judge fall back to the Brain's endpoint — collapsible substrate.
+        InferenceSettings brain = this.brainSettings!;
+        InferenceSettings gate = this.gateSettings ?? brain;
+        InferenceSettings judge = this.judgeSettings ?? brain;
+
+        ISkillBroker skill =
+            this.skillBroker ?? new SkillBroker(this.skillsPath);
+
+        IGeneratorBroker generator =
+            this.generatorBroker ?? new GeneratorBroker(
+                brain.ApiUrl, brain.ApiKey, brain.Model,
+                brain.Temperature, brain.MaxTokens, brain.TimeoutSeconds);
+
+        IMemoryBroker memory =
+            this.memoryBroker ?? new MemoryBroker(this.memoryPath);
+
+        IKnowledgeBroker knowledge =
+            this.knowledgeBroker ?? new KnowledgeBroker(
+                this.knowledgePath, this.knowledgePattern, this.knowledgeMaxResults);
+
+        IClassifierBroker classifier =
+            this.classifierBroker ?? new ClassifierBroker(
+                gate.ApiUrl, gate.ApiKey, gate.Model,
+                gate.Temperature, gate.MaxTokens, gate.TimeoutSeconds);
+
+        IVerifierBroker verifier =
+            this.verifierBroker ?? new VerifierBroker(
+                judge.ApiUrl, judge.ApiKey, judge.Model,
+                judge.Temperature, judge.MaxTokens, judge.TimeoutSeconds);
+
+        IToolBroker toolBroker = new ToolBroker(this.tools);
+
+        IMcpBroker mcp =
+            this.mcpBroker ?? new McpBroker(
+                this.mcpEndpointUrl, this.mcpRelativeUrl, this.mcpTimeoutSeconds);
+
+        ILogBroker log = this.logBroker ?? new LogBroker(this.logPath);
+
+        // Null by default: diagnostics are the host's to wire, and the exception
+        // ladder still throws whether or not anyone is listening.
+        ILoggingBroker logging =
+            this.loggingBroker ?? new LoggingBroker(new NullLogger<LoggingBroker>());
+
+        DataOrchestrationService data = new(
+            new SkillService(skill, logging),
+            new MemoryService(memory, logging),
+            new KnowledgeService(knowledge, logging),
+            logging);
+
+        DecisionOrchestrationService decision = new(
+            new GateService(classifier, logging),
+            new BrainService(generator, logging),
+            new JudgeService(verifier, logging),
+            logging);
+
+        DirectionOrchestrationService direction = new(
+            new InternalToolService(toolBroker, logging),
+            new ExternalToolService(mcp, logging),
+            new ReturnService(logging),
+            logging);
+
+        return new AgentCoordinationService(data, decision, direction, log, logging);
+    }
+
+    private sealed record InferenceSettings(
+        string ApiUrl,
+        string ApiKey,
+        string Model,
+        double Temperature,
+        int MaxTokens,
+        int TimeoutSeconds);
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -154,11 +154,15 @@ public sealed partial class StandardAgent : IAgent
     public StandardAgent UseLogging(ILoggingBroker broker) =>
         Set(() => this.loggingBroker = broker);
 
-    public ValueTask<string> ProcessPromptAsync(string prompt)
+    // async, so a composition failure surfaces on await rather than being thrown
+    // synchronously out of a method whose signature promises a ValueTask. A caller
+    // doing `var task = agent.ProcessPromptAsync(p); ... await task;` would otherwise
+    // be hit at the assignment, nowhere near the await they were guarding.
+    public async ValueTask<string> ProcessPromptAsync(string prompt)
     {
         this.agent ??= Compose();
 
-        return this.agent.ProcessPromptAsync(prompt);
+        return await this.agent.ProcessPromptAsync(prompt);
     }
 
     // Every builder method drops the cached composition, so configuration set after a
@@ -177,16 +181,18 @@ public sealed partial class StandardAgent : IAgent
         ValidateComposition();
 
         // Gate and Judge fall back to the Brain's endpoint — collapsible substrate.
-        InferenceSettings brain = this.brainSettings!;
-        InferenceSettings gate = this.gateSettings ?? brain;
-        InferenceSettings judge = this.judgeSettings ?? brain;
+        // These stay nullable: ValidateComposition has already proved that any of the
+        // three that is still null has a swapped-in broker and will never be read.
+        InferenceSettings? brain = this.brainSettings;
+        InferenceSettings? gate = this.gateSettings ?? brain;
+        InferenceSettings? judge = this.judgeSettings ?? brain;
 
         ISkillBroker skill =
             this.skillBroker ?? new SkillBroker(this.skillsPath);
 
         IGeneratorBroker generator =
             this.generatorBroker ?? new GeneratorBroker(
-                brain.ApiUrl, brain.ApiKey, brain.Model,
+                brain!.ApiUrl, brain.ApiKey, brain.Model,
                 brain.Temperature, brain.MaxTokens, brain.TimeoutSeconds);
 
         IMemoryBroker memory =
@@ -198,12 +204,12 @@ public sealed partial class StandardAgent : IAgent
 
         IClassifierBroker classifier =
             this.classifierBroker ?? new ClassifierBroker(
-                gate.ApiUrl, gate.ApiKey, gate.Model,
+                gate!.ApiUrl, gate.ApiKey, gate.Model,
                 gate.Temperature, gate.MaxTokens, gate.TimeoutSeconds);
 
         IVerifierBroker verifier =
             this.verifierBroker ?? new VerifierBroker(
-                judge.ApiUrl, judge.ApiKey, judge.Model,
+                judge!.ApiUrl, judge.ApiKey, judge.Model,
                 judge.Temperature, judge.MaxTokens, judge.TimeoutSeconds);
 
         IToolBroker toolBroker = new ToolBroker(this.tools);


### PR DESCRIPTION
The composition root and public surface. SPEC.md §9: *"DI is OPTIONAL. A hand-wired composition root is fully conformant."*

`Compose()` **is** that root — the whole 1·3·9 graph in one readable method. No container, nothing to chase. **No Magic taken literally.**

```csharp
var agent = new StandardAgent()
    .Skills("Skills")
    .Brain(apiUrl, apiKey, "gpt-4o-mini")
    .Tool(new CalculatorTool())
    .LogTo("log.txt");

string answer = await agent.ProcessPromptAsync("what is 1+1?");
```

## Two ways to configure each nature

| | |
|---|---|
| `Brain(...)` / `Gate(...)` / `Judge(...)` / `Memory(...)` … | build the default broker from primitives |
| `UseGenerator(broker)` / `UseGate(broker)` … | swap the broker entirely |

The second is what makes **invariant §7.6 reachable**: point Gate and Judge at a different model — or a deterministic rule — without touching the library.

Left unset, Gate and Judge **fall back to the Brain's endpoint**. SPEC.md §9 permits collapsing the three Decision brokers onto one endpoint, and Theory Ch.5 calls it *"three interfaces, collapsible substrate — at small scale one model wears all three hats."* For anything safety-critical, set them. The comment says so at the call site.

## Two defects the tests caught

**1. A swapped generator with no `Brain()` NRE'd.**

Gate and Judge fall back to the Brain's *settings*, so a caller who supplies a generator broker and never calls `Brain()` left those null — and building the default Classifier from them dereferenced null.

**That caller isn't hypothetical — it's the conformance harness (#39).** It scripts the Brain, stubs everything else, and has no endpoint to name. The facade would have NRE'd the moment the vectors ran, from inside a broker constructor, with nothing pointing back at the missing configuration.

`ValidateComposition` now checks **what each default broker actually needs**, and names the missing piece.

**2. `ProcessPromptAsync` threw synchronously.**

`Compose()` threw out of a method whose signature promises a `ValueTask`, so the exception escaped **at the assignment** rather than on `await`. A caller writing `var task = agent.ProcessPromptAsync(p); ... await task;` would be hit nowhere near the await they were guarding.

The test found this by *failing to catch an exception that was being thrown correctly*. Now `async`.

## Other decisions

- **Every builder method drops the cached composition** — `ShouldRecomposeAfterConfigurationChangesAsync` pins it. Returning `this` without dropping it would silently ignore config set after the first prompt.
- **Logging defaults to `NullLogger`** — diagnostics are the host's to wire, and the exception ladder throws whether or not anyone is listening.
- **`brain!` / `gate!` / `judge!` are load-bearing**, not laziness: `ValidateComposition` has already proved any still-null one has a swapped-in broker and will never be read.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 193, Total: 193** (6 new cases)

Closes #36
