### PR TITLE
CLIENTS: Agent Tool — The Fractal Bridge

### DIFF
--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
@@ -1,0 +1,141 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Tools;
+using Tynamix.ObjectFiller;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Tools;
+
+public class AgentToolTests
+{
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    [Fact]
+    public async Task ShouldRunNestedAgentAsToolAsync()
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomInput = CreateRandomString();
+        string randomAnswer = CreateRandomString();
+        string expectedOutput = randomAnswer;
+
+        var nestedAgentMock = new Mock<IAgent>();
+
+        nestedAgentMock.Setup(agent =>
+            agent.ProcessPromptAsync(randomInput))
+                .ReturnsAsync(randomAnswer);
+
+        var agentTool = new AgentTool(randomName, nestedAgentMock.Object);
+
+        // when
+        string actualOutput = await agentTool.ExecuteAsync(randomInput);
+
+        // then
+        actualOutput.Should().Be(expectedOutput);
+        agentTool.Name.Should().Be(randomName);
+
+        // The tool's input becomes the nested agent's PROMPT — that is the bridge.
+        nestedAgentMock.Verify(agent =>
+            agent.ProcessPromptAsync(randomInput),
+                Times.Once);
+
+        nestedAgentMock.VerifyNoOtherCalls();
+    }
+
+    // ⭐ The fractal, actually exercised: an agent registered as a tool of another
+    // agent. The outer agent asks for "researcher" and cannot tell whether a function
+    // or a whole mind answered — which is the point of Theory Ch.4.
+    [Fact]
+    public async Task ShouldNestAgentInsideAgentAsync()
+    {
+        // given — the inner agent answers anything with a fixed finding
+        var innerAgent = new Mock<IAgent>();
+
+        innerAgent.Setup(agent =>
+            agent.ProcessPromptAsync(It.IsAny<string>()))
+                .ReturnsAsync("the capital is Paris");
+
+        var researcher = new AgentTool("researcher", innerAgent.Object);
+
+        // the outer agent uses it once, then answers
+        var outerBrain = new Mock<Brokers.Decision.IGeneratorBroker>();
+        var replies = new Queue<string>(
+        [
+            "ACTION: researcher: capital of France",
+            "FINAL: Paris"
+        ]);
+
+        outerBrain.Setup(broker =>
+            broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(() => replies.Dequeue());
+
+        var skills = new Mock<Brokers.Data.ISkillBroker>();
+        skills.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("you are an agent");
+
+        var memory = new Mock<Brokers.Data.IMemoryBroker>();
+        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var gate = new Mock<Brokers.Decision.IClassifierBroker>();
+        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("allow");
+
+        var judge = new Mock<Brokers.Decision.IVerifierBroker>();
+        judge.Setup(b => b.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(1.0);
+
+        var outerAgent = new StandardAgent()
+            .UseSkills(skills.Object)
+            .UseGenerator(outerBrain.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(new Mock<Brokers.Data.IKnowledgeBroker>().Object)
+            .UseGate(gate.Object)
+            .UseJudge(judge.Object)
+            .UseMcp(new Mock<Brokers.Direction.IMcpBroker>().Object)
+            .UseLog(new Mock<Brokers.Loggings.ILogBroker>().Object)
+            .Tool(researcher);
+
+        // when
+        string actualResult = await outerAgent.ProcessPromptAsync("what is the capital of France?");
+
+        // then
+        actualResult.Should().Be("Paris");
+
+        // The nested agent ran its own loop, driven by the outer agent's tool call.
+        innerAgent.Verify(agent =>
+            agent.ProcessPromptAsync("capital of France"),
+                Times.Once);
+    }
+
+    // A nested agent that fails is a tool that fails. The exception is not swallowed
+    // into a plausible-looking answer — the outer agent's Direction categorises it
+    // like any other dependency failure.
+    [Fact]
+    public async Task ShouldPropagateOnExecuteIfNestedAgentThrowsAsync()
+    {
+        // given
+        var nestedAgentMock = new Mock<IAgent>();
+        var nestedFailure = new InvalidOperationException("inner agent failed");
+
+        nestedAgentMock.Setup(agent =>
+            agent.ProcessPromptAsync(It.IsAny<string>()))
+                .ThrowsAsync(nestedFailure);
+
+        var agentTool = new AgentTool("nested", nestedAgentMock.Object);
+
+        // when
+        ValueTask<string> executeTask = agentTool.ExecuteAsync("anything");
+
+        InvalidOperationException actualException =
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                executeTask.AsTask);
+
+        // then
+        actualException.Message.Should().Be("inner agent failed");
+    }
+}

--- a/Standard.Agents/Tools/AgentTool.cs
+++ b/Standard.Agents/Tools/AgentTool.cs
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Tools;
+
+// The fractal bridge. Theory Ch.4: "a Direction can be another whole Agent (an agent
+// wrapped as a tool). Agents nest inside agents. Turtles up."
+//
+// This is the whole mechanism, and it is deliberately this small. An agent already
+// satisfies "text in, text out"; ITool already asks for exactly that. Nesting needs
+// no new machinery because the shapes already agree — which is the fractal being a
+// property of the design rather than a feature bolted onto it.
+//
+// It is also how Theory Ch.8 resolves guardianship at scale: a compliance sub-agent
+// is a distinct conscience — "the fractal" — rather than the same brain grading
+// itself. And Ch.5: "An agent has one brain. Multiplicity of brains is not an
+// intra-agent feature — it is the fractal." Want a second brain? Nest an agent. Do
+// not add one to Decision.
+public sealed class AgentTool : ITool
+{
+    private readonly IAgent agent;
+
+    public string Name { get; }
+
+    public AgentTool(string name, IAgent agent)
+    {
+        this.Name = name;
+        this.agent = agent;
+    }
+
+    // The nested agent runs its own full loop — its own Recall, Think, Act, its own
+    // turn cap, its own guardians. The outer agent sees one tool call and a string
+    // back, and cannot tell whether a function or a mind answered it.
+    public async ValueTask<string> ExecuteAsync(string input) =>
+        await this.agent.ProcessPromptAsync(input);
+}


### PR DESCRIPTION
An agent as a tool of another agent. Theory Ch.4 — **turtles up**.

> *"Upward — a Direction can be another whole Agent (an agent wrapped as a tool). Agents nest inside agents."*

## The class is ten lines, and that's the point

```csharp
public async ValueTask<string> ExecuteAsync(string input) =>
    await this.agent.ProcessPromptAsync(input);
```

An agent already satisfies *text in, text out*. `ITool` already asks for exactly that. **Nesting needs no new machinery because the shapes already agree** — the fractal is a property of the design, not a feature bolted onto it.

SPEC.md §4.4 anticipates this: *"An `AgentCoordination` **SHOULD** also satisfy the tool contract (§6) so an agent can be nested as a tool of another agent (the fractal)."*

## `ShouldNestAgentInsideAgentAsync` exercises it, rather than describing it

An agent registered as a tool of another agent. The outer Brain says `ACTION: researcher: capital of France` → the inner agent **runs its own full loop** — its own Recall, Think, Act, its own turn cap, its own guardians — and the outer agent sees one tool call and a string back. It cannot tell whether a function or a whole mind answered.

This is also **the first test in the suite to drive the entire 1·3·9 through `StandardAgent` end to end**, two turns deep, with only the brokers stubbed.

## Why this matters beyond novelty

Theory Ch.8 resolves guardianship at scale with it: a compliance **sub-agent** is a distinct conscience — *"the fractal"* — rather than the same brain grading itself.

Theory Ch.5: *"An agent has **one brain**. Multiplicity of brains is not an intra-agent feature — it is the fractal."* Want a second brain? **Nest an agent. Don't add one to Decision.**

## A nested agent that throws is a tool that throws

The exception isn't swallowed into a plausible-looking answer — the outer agent's Direction categorises it like any other dependency failure (#34).

## Discipline note

**No observed FAIL** — a ten-line delegation written before its tests. Mutation-checked: stubbing out the delegation fails **all 3**; restoring returns 196/196.

## Verification

`dotnet test` → **Passed! Failed: 0, Passed: 196, Total: 196** (3 new cases)

Closes #37
