### PR TITLE
ACCEPTANCE: Conformance Vectors

### DIFF
--- a/Standard.Agents.Conformance/Harness.cs
+++ b/Standard.Agents.Conformance/Harness.cs
@@ -1,0 +1,132 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Data;
+using Standard.Agents.Brokers.Decision;
+using Standard.Agents.Brokers.Direction;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Tools;
+
+namespace Standard.Agents.Conformance;
+
+// The doubles the runner contract calls for (conformance/CONFORMANCE.md step 3).
+//
+// Every one of these replaces a broker, never a service. That is what makes the
+// vectors meaningful: the whole 1-3-9 above the broker line — the loop, the
+// interpretation, the routing, the guardians — is the REAL library. Only the
+// resources are scripted, so what conformance proves is the agent, not the harness.
+
+// The scripted Brain. Agent behavior involves an LLM and is non-deterministic, so it
+// cannot be asserted directly; scripting the Brain makes the deterministic contracts
+// assertable.
+//
+// Repeats the last reply when exhausted — CONFORMANCE.md requires this, and vector 06
+// depends on it: one non-terminal reply then becomes an infinite one, which is how a
+// never-terminating Brain is simulated.
+public sealed class ScriptedGeneratorBroker : IGeneratorBroker
+{
+    private readonly IReadOnlyList<string> replies;
+    private int index;
+
+    public ScriptedGeneratorBroker(IReadOnlyList<string> replies) =>
+        this.replies = replies;
+
+    public ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt)
+    {
+        string reply = this.replies[Math.Min(this.index, this.replies.Count - 1)];
+        this.index++;
+
+        return ValueTask.FromResult(reply);
+    }
+}
+
+// A tool that returns a fixed output regardless of input.
+public sealed class StubTool : ITool
+{
+    private readonly string output;
+
+    public string Name { get; }
+
+    public StubTool(string name, string output)
+    {
+        this.Name = name;
+        this.output = output;
+    }
+
+    public ValueTask<string> ExecuteAsync(string input) =>
+        ValueTask.FromResult(this.output);
+}
+
+// "Skill returns any text" — the scripted Brain ignores it.
+public sealed class StubSkillBroker : ISkillBroker
+{
+    public ValueTask<string> SelectSkillsAsync() =>
+        ValueTask.FromResult("You are a test agent.");
+}
+
+// "Memory and Knowledge empty."
+public sealed class StubMemoryBroker : IMemoryBroker
+{
+    public ValueTask<IReadOnlyList<string>> SelectMemoriesAsync() =>
+        ValueTask.FromResult<IReadOnlyList<string>>([]);
+
+    public ValueTask InsertMemoryAsync(string memory) =>
+        ValueTask.CompletedTask;
+}
+
+public sealed class StubKnowledgeBroker : IKnowledgeBroker
+{
+    public ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query) =>
+        ValueTask.FromResult<IReadOnlyList<string>>([]);
+}
+
+// "Gate allows." A pass-through Gate is Core-profile behaviour (SPEC.md 8.1) and is
+// stated explicitly here rather than shipped as a library default — #50.
+public sealed class AllowingClassifierBroker : IClassifierBroker
+{
+    public ValueTask<string> ClassifyAsync(string systemPrompt, string input) =>
+        ValueTask.FromResult("allow");
+}
+
+// "Judge returns 1.0."
+public sealed class ApprovingVerifierBroker : IVerifierBroker
+{
+    public ValueTask<double> VerifyAsync(string systemPrompt, string candidate) =>
+        ValueTask.FromResult(1.0);
+}
+
+// "External reports 'not configured'." It REPORTS rather than throws — vector 05
+// routes an unknown tool here and expects the agent to recover, which it can only do
+// if the report arrives as data.
+public sealed class NotConfiguredMcpBroker : IMcpBroker
+{
+    public ValueTask<string> CallAsync(string name, string input) =>
+        ValueTask.FromResult($"[external '{name}' not configured]");
+}
+
+// "Log is a no-op" — conformance runs touch no files.
+public sealed class NullLogBroker : ILogBroker
+{
+    public string LogPath => string.Empty;
+
+    public ValueTask ResetAsync() =>
+        ValueTask.CompletedTask;
+
+    public ValueTask WriteAsync(string content) =>
+        ValueTask.CompletedTask;
+}
+
+// The vector schema — matches conformance/vectors/*.json.
+public sealed record Vector(
+    string Name,
+    string? Description,
+    List<string> GeneratorReplies,
+    Dictionary<string, string>? Tools,
+    string Prompt,
+    Expectation Expect);
+
+public sealed record Expectation(
+    string? Result,
+    string? ResultContains);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.Json;
+using Standard.Agents;
+using Standard.Agents.Conformance;
+using Standard.Agents.Tools;
+
+// The reference conformance runner. It loads the language-neutral vectors, builds an
+// agent whose BROKERS are scripted but whose 1-3-9 is the real library, runs each
+// prompt, and compares the returned result.
+//
+// Exit code 0 = every vector passes = Standard-Agents Conformant at the Core profile.
+// An implementation in any other language mirrors this harness against the same
+// vectors (CONFORMANCE.md, "Adding a language").
+
+string vectorsPath = args.Length > 0
+    ? args[0]
+    : Path.Combine(FindRepositoryRoot(), "conformance", "vectors");
+
+JsonSerializerOptions jsonOptions = new()
+{
+    PropertyNameCaseInsensitive = true
+};
+
+Console.WriteLine($"Conformance vectors: {vectorsPath}");
+Console.WriteLine();
+
+int passed = 0;
+int failed = 0;
+
+foreach (string vectorFile in
+    Directory.EnumerateFiles(vectorsPath, "*.json").OrderBy(path => path, StringComparer.Ordinal))
+{
+    Vector vector =
+        JsonSerializer.Deserialize<Vector>(await File.ReadAllTextAsync(vectorFile), jsonOptions)!;
+
+    string actualResult = await RunVectorAsync(vector);
+
+    bool isConformant = vector.Expect.Result is not null
+        ? actualResult == vector.Expect.Result
+        : vector.Expect.ResultContains is not null
+            && actualResult.Contains(vector.Expect.ResultContains, StringComparison.Ordinal);
+
+    if (isConformant)
+    {
+        passed++;
+        Console.WriteLine($"PASS  {vector.Name}");
+    }
+    else
+    {
+        failed++;
+
+        string expectation = vector.Expect.Result is not null
+            ? vector.Expect.Result
+            : $"contains: {vector.Expect.ResultContains}";
+
+        Console.WriteLine($"FAIL  {vector.Name}");
+        Console.WriteLine($"        expected: {Show(expectation)}");
+        Console.WriteLine($"        actual:   {Show(actualResult)}");
+    }
+}
+
+Console.WriteLine();
+Console.WriteLine($"{passed} passed, {failed} failed");
+
+return failed == 0 ? 0 : 1;
+
+// Every broker is a double; everything above the broker line is the real library,
+// composed through StandardAgent — the same composition a real consumer uses.
+async Task<string> RunVectorAsync(Vector vector)
+{
+    IEnumerable<ITool> tools =
+        (vector.Tools ?? []).Select(pair => (ITool)new StubTool(pair.Key, pair.Value));
+
+    IAgent agent = new StandardAgent()
+        .UseSkills(new StubSkillBroker())
+        .UseGenerator(new ScriptedGeneratorBroker(vector.GeneratorReplies))
+        .UseMemory(new StubMemoryBroker())
+        .UseKnowledge(new StubKnowledgeBroker())
+        .UseGate(new AllowingClassifierBroker())
+        .UseJudge(new ApprovingVerifierBroker())
+        .UseMcp(new NotConfiguredMcpBroker())
+        .UseLog(new NullLogBroker())
+        .Tools(tools);
+
+    return await agent.ProcessPromptAsync(vector.Prompt);
+}
+
+// Newlines shown escaped, so a multi-line mismatch (vector 04) is legible on one line.
+static string Show(string value) =>
+    value.Replace("\n", "\\n").Replace("\r", "\\r");
+
+static string FindRepositoryRoot()
+{
+    DirectoryInfo? directory = new(AppContext.BaseDirectory);
+
+    while (directory is not null
+        && Directory.Exists(Path.Combine(directory.FullName, "conformance")) is false)
+    {
+        directory = directory.Parent;
+    }
+
+    return directory?.FullName
+        ?? throw new DirectoryNotFoundException(
+            "Could not find the repository root — no 'conformance' directory found "
+                + "walking up from the executable.");
+}

--- a/Standard.Agents.Conformance/Standard.Agents.Conformance.csproj
+++ b/Standard.Agents.Conformance/Standard.Agents.Conformance.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Standard.Agents\Standard.Agents.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Standard.Agents.slnx
+++ b/Standard.Agents.slnx
@@ -1,4 +1,5 @@
 <Solution>
   <Project Path="Standard.Agents/Standard.Agents.csproj" />
+  <Project Path="Standard.Agents.Conformance/Standard.Agents.Conformance.csproj" />
   <Project Path="Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj" />
 </Solution>


### PR DESCRIPTION
The conformance runner. **`dotnet run --project Standard.Agents.Conformance` → 6 passed, 0 failed, exit code 0.**

```
PASS  direct-answer
PASS  tool-then-final
PASS  first-line-action-only
PASS  multiline-final
PASS  unknown-tool-recovers
PASS  max-turns-cap
```

**The implementation is Standard-Agents Conformant at the Core profile.**

## Every double replaces a BROKER, never a service

That's what makes the vectors mean anything. The whole 1·3·9 above the broker line — the loop, the interpretation, the routing, the guardians — is **the real library**, composed through `StandardAgent` exactly as a consumer composes it. Only the resources are scripted.

**What conformance proves is the agent, not the harness.**

## The runner contract, honored literally

Per CONFORMANCE.md step 3: scripted Brain (repeating its last reply when exhausted) · stub internal tools · Skill returns any text · Memory and Knowledge empty · Gate allows · Judge returns 1.0 · External reports *"not configured"* · Log is a no-op.

Two of those carry weight:

- **External *reports* rather than throws.** Vector 05 routes an unknown tool there and expects recovery — which only works if the report arrives as **data**.
- **The allowing Gate is stated by the harness, not shipped as a library default.** Core-profile pass-through is a choice the caller makes (SPEC.md §8.1). That distinction is the whole of #50.

## Mutation-tested rather than trusted

Six green on the first run is exactly when you should be suspicious. So I broke things on purpose:

| Mutation | Unit tests | Vectors |
|---|---|---|
| Revert #73 (`Result` on non-terminal turns) | — | **FAIL `max-turns-cap`** (caught) |
| Remove first-line-only parsing | **1 failed** | **6 passed** (missed) |

The first is the suite doing its job. **The second is a finding: vector 03 cannot see a parsing bug**, because the stub tool returns `"2"` regardless of input — so a corrupted tool input is never observable in the result. It verifies less than it claims.

Raised as **#78**. It's a *suite* issue, not an implementation one — this repo parses first-line-only and has a unit test proving it — but **another language could ship that bug and certify green**, which is precisely what the suite exists to prevent.

## Also

`conformance/CONFORMANCE.md` links to `../SPEC.md`, which doesn't exist in this repo (SPEC.md lives in `The-Standard-Agent-Specs`). Left alone here — it's a docs fix, not an acceptance one.

## Verification

```
dotnet test  → 196/196
dotnet run --project Standard.Agents.Conformance  → 6 passed, 0 failed, exit 0
```

Closes #39
