### PR TITLE
CONFIG: Add CI Workflow Running Dotnet Test

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,35 @@
+name: Standard.Agents Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Pulling Code
+      uses: actions/checkout@v4
+
+    - name: Installing .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Restoring Packages
+      run: dotnet restore
+
+    - name: Building Solution
+      run: dotnet build --no-restore --configuration Release
+
+    - name: Running Tests
+      run: dotnet test --no-build --configuration Release --verbosity normal
+
+    # Spec certification, not just unit tests. The vectors are the contract SPEC.md
+    # defines; a green suite that no longer conforms is worth catching on the PR that
+    # breaks it rather than on the next release.
+    - name: Certifying Conformance
+      run: dotnet run --project Standard.Agents.Conformance --no-build --configuration Release


### PR DESCRIPTION
There was **no CI in this repo at all**.

```yaml
restore → build (Release) → test → certify conformance
```

## Every step verified locally in Release first

Exactly as the workflow runs them — not assumed:

```
dotnet restore                                    → up-to-date
dotnet build --no-restore -c Release              → Build succeeded
dotnet test --no-build -c Release                 → Passed! 196/196
dotnet run --project Standard.Agents.Conformance  → 6 passed, exit 0
```

## It certifies conformance, not just tests

The vectors are the contract SPEC.md defines, and the runner already exits non-zero on failure — so it gates for free.

**The two suites don't overlap**, and #78 is the proof:

| Break | Unit tests | Vectors |
|---|---|---|
| revert #73 (`Result` on non-terminal) | pass | **FAIL** |
| remove first-line-only parsing | **FAIL** | pass |

Either one alone would let a real regression through. A green unit suite that no longer conforms is worth catching on the PR that breaks it, not at the next release.

## `ubuntu-latest`, not `windows-latest`

The library targets `net10.0` with no platform dependency — and **building on Linux is what proves that**. `SkillBroker`, `MemoryBroker` and `KnowledgeBroker` all touch paths, and path handling is exactly the kind of thing that only misbehaves on the platform nobody tested. Everything so far has only ever run on Windows.

## Runs on `pull_request`, not just `push`

The gate has to exist **before** merge. Without it the FAIL/PASS discipline is unenforced at the one moment it matters — a PASS commit that silently regressed another test would land unnoticed.

Closes #40
