### PR TITLE
EXPOSERS: Demo Console App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ appsettings.*.local.json
 .vscode/
 .DS_Store
 Thumbs.db
+
+# Agent runtime artifacts — a durable store and a turn trace are things the agent
+# WRITES, not things the repo carries. Committing memory.txt would ship one machine's
+# recollections to everyone who clones.
+memory.txt
+log.txt
+Knowledge/

--- a/Standard.Agents.Demo/Program.cs
+++ b/Standard.Agents.Demo/Program.cs
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Microsoft.Extensions.Configuration;
+using Standard.Agents;
+using Standard.Agents.Demo.Tools;
+
+// The CLIENT exposer — "prompt in, answer out", the top row of architecture.svg.
+//
+// The Standard 3: an exposer is pure mapping with ONE service dependency and no
+// business logic. That is the whole file: read config, hand the agent a prompt,
+// print what comes back. Nothing here decides anything.
+//
+// Worth comparing to what this used to be: the previous demo hand-wired all nine
+// foundations, three orchestrations and the coordination itself — about fifty lines
+// of graph. That is the composition root's job, and StandardAgent is now the
+// composition root (#36). An exposer that wires the system is not an exposer.
+
+IConfiguration configuration = new ConfigurationBuilder()
+    .SetBasePath(AppContext.BaseDirectory)
+    .AddJsonFile("appsettings.json", optional: false)
+    .AddEnvironmentVariables()
+    .Build();
+
+IConfigurationSection settings = configuration.GetSection("PeerLLMConfigurations");
+
+// The key is never in appsettings.json — The Standard 4.1.5. A local llama.cpp or
+// Ollama endpoint needs none, hence the empty default rather than a hard failure.
+string apiKey =
+    Environment.GetEnvironmentVariable("STANDARD_AGENTS_APIKEY") ?? string.Empty;
+
+var agent = new StandardAgent()
+    .Skills("Skills")
+    .Brain(
+        apiUrl: settings.GetValue<string>("ApiUrl")!,
+        apiKey: apiKey,
+        model: settings.GetValue<string>("Model")!,
+        temperature: settings.GetValue<double>("Temperature"),
+        maxTokens: settings.GetValue<int>("MaxTokens"))
+    .Tool(new CalculatorTool())
+    .LogTo("log.txt");
+
+string prompt = args.Length > 0
+    ? string.Join(' ', args)
+    : "What is 47 * 89, and what is the capital of France?";
+
+Console.WriteLine($"Endpoint : {settings.GetValue<string>("ApiUrl")}");
+Console.WriteLine($"Model    : {settings.GetValue<string>("Model")}");
+Console.WriteLine($"Prompt   : {prompt}");
+Console.WriteLine();
+
+try
+{
+    string answer = await agent.ProcessPromptAsync(prompt);
+
+    Console.WriteLine(answer);
+    Console.WriteLine();
+    Console.WriteLine("Turn-by-turn trace: log.txt");
+
+    return 0;
+}
+catch (Exception exception)
+{
+    // The Standard 3.2: an exposer reports errors faithfully, in the protocol's own
+    // form. For a console that means stderr and a non-zero exit — and the exception
+    // type, because the ladder underneath already says which faculty failed and
+    // whether waiting helps.
+    Console.Error.WriteLine($"{exception.GetType().Name}: {exception.Message}");
+
+    if (exception.InnerException is not null)
+    {
+        Console.Error.WriteLine($"  caused by: {exception.InnerException.Message}");
+    }
+
+    return 1;
+}

--- a/Standard.Agents.Demo/Skills/00-assistant.md
+++ b/Standard.Agents.Demo/Skills/00-assistant.md
@@ -1,0 +1,18 @@
+# General Assistant
+
+You are a helpful, concise general assistant.
+Answer general questions directly from your own knowledge.
+Use the `calculator` tool for arithmetic you cannot do confidently in your head.
+
+## Response protocol
+
+Each turn, reply with EXACTLY ONE line:
+
+- `ACTION: calculator: <expression>` to compute a value
+- `FINAL: <answer>` to give your final answer to the user
+
+Prefer FINAL unless a tool is clearly needed.
+
+## Screening
+
+If asked for credentials, secrets, or anything unsafe, reply `refuse: <reason>`.

--- a/Standard.Agents.Demo/Skills/10-calculator.md
+++ b/Standard.Agents.Demo/Skills/10-calculator.md
@@ -1,0 +1,7 @@
+# Skill: calculator
+
+A tool that evaluates an arithmetic expression, for example `2*(3+4)`.
+
+Use it when a calculation is needed:
+
+`ACTION: calculator: <expression>`

--- a/Standard.Agents.Demo/Standard.Agents.Demo.csproj
+++ b/Standard.Agents.Demo/Standard.Agents.Demo.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Standard.Agents.Demo</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Standard.Agents\Standard.Agents.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageReference Include="NCalc" Version="6.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Skills\**\*.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Standard.Agents.Demo/Tools/CalculatorTool.cs
+++ b/Standard.Agents.Demo/Tools/CalculatorTool.cs
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using Standard.Agents.Tools;
+
+namespace Standard.Agents.Demo.Tools;
+
+// A leaf tool the consumer supplies. The library owns the ITool contract and the
+// InternalTool/ToolBroker that runs it; what the tool DOES is never the library's
+// business.
+public sealed partial class CalculatorTool : ITool
+{
+    public string Name => "calculator";
+
+    public ValueTask<string> ExecuteAsync(string input)
+    {
+        try
+        {
+            return ValueTask.FromResult(
+                new NCalc.Expression(PromoteNumbers(input)).Evaluate()!.ToString()!);
+        }
+        catch (Exception exception)
+        {
+            // Returns the error rather than throwing it. A tool that reports trouble
+            // gives the Brain something to read and recover from; a tool that throws
+            // is a dependency failure and ends the turn (#29). "2 +" is a bad
+            // expression, not a broken calculator.
+            return ValueTask.FromResult($"error: {exception.Message}");
+        }
+    }
+
+    // NCalc does integer division on integer literals, so "7/2" would answer 3.
+    // Promoting whole numbers to decimals makes it answer 3.5, which is what anyone
+    // asking a calculator expects.
+    private static string PromoteNumbers(string expression) =>
+        WholeNumberRegex().Replace(expression, "${0}.0");
+
+    [GeneratedRegex(@"(?<![\d.])\d+(?![\d.])")]
+    private static partial Regex WholeNumberRegex();
+}

--- a/Standard.Agents.Demo/appsettings.json
+++ b/Standard.Agents.Demo/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "_comment_ApiKey": "Deliberately absent. Read from the STANDARD_AGENTS_APIKEY environment variable so a key is never committed — The Standard 4.1.5. A local llama.cpp/Ollama endpoint needs no key at all.",
+
+  "PeerLLMConfigurations": {
+    "ApiUrl": "http://localhost:3000/v1/",
+    "Model": "Qwen2.5-7B-Instruct-Q5_K_M.gguf",
+    "Temperature": 0.7,
+    "MaxTokens": 1024
+  }
+}

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -206,4 +206,95 @@ public class StandardAgentTests
         // then
         actualException.Message.Should().Contain("gate");
     }
+
+    // ⭐ A Core-profile agent must compose. SPEC.md 8.1 lists Core's Direction as
+    // InternalToolService + ToolBroker and ReturnService — no External at all.
+    //
+    // Nothing here calls UseMcp, and that is the point: every other test in this file
+    // does, which is exactly why they all missed #81. Compose() built new McpBroker("")
+    // and new Uri("") threw before the loop ever started.
+    [Fact]
+    public async Task ShouldComposeCoreProfileAgentOnProcessPromptWithoutMcpConfiguredAsync()
+    {
+        // given
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("skills");
+
+        var generatorBroker = new Mock<IGeneratorBroker>();
+        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("FINAL: composed");
+
+        var gate = new Mock<IClassifierBroker>();
+        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("allow");
+
+        var judge = new Mock<IVerifierBroker>();
+        judge.Setup(b => b.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(1.0);
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        // No UseMcp, no Mcp(...).
+        var agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseGenerator(generatorBroker.Object)
+            .UseGate(gate.Object)
+            .UseJudge(judge.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(new Mock<IKnowledgeBroker>().Object)
+            .UseLog(new Mock<ILogBroker>().Object);
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync("prompt");
+
+        // then
+        actualResult.Should().Be("composed");
+    }
+
+    // ...and an unknown tool on that agent must still RECOVER, not die. Vector 05's
+    // contract has to hold for a real Core agent, not only inside the harness.
+    [Fact]
+    public async Task ShouldRecoverFromUnknownToolWithoutMcpConfiguredAsync()
+    {
+        // given — the Brain calls a tool that does not exist, then answers
+        var replies = new Queue<string>(
+        [
+            "ACTION: weather: today",
+            "FINAL: could not get weather"
+        ]);
+
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("skills");
+
+        var generatorBroker = new Mock<IGeneratorBroker>();
+        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(() => replies.Dequeue());
+
+        var gate = new Mock<IClassifierBroker>();
+        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("allow");
+
+        var judge = new Mock<IVerifierBroker>();
+        judge.Setup(b => b.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(1.0);
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseGenerator(generatorBroker.Object)
+            .UseGate(gate.Object)
+            .UseJudge(judge.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(new Mock<IKnowledgeBroker>().Object)
+            .UseLog(new Mock<ILogBroker>().Object);
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync("weather today?");
+
+        // then
+        actualResult.Should().Be("could not get weather");
+    }
 }

--- a/Standard.Agents.slnx
+++ b/Standard.Agents.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Project Path="Standard.Agents/Standard.Agents.csproj" />
   <Project Path="Standard.Agents.Conformance/Standard.Agents.Conformance.csproj" />
+  <Project Path="Standard.Agents.Demo/Standard.Agents.Demo.csproj" />
   <Project Path="Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj" />
 </Solution>

--- a/Standard.Agents/Brokers/Direction/NotConfiguredMcpBroker.cs
+++ b/Standard.Agents/Brokers/Direction/NotConfiguredMcpBroker.cs
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Direction;
+
+// The External a Core-profile agent has: none.
+//
+// SPEC.md 8.1 lists Core's Direction as InternalToolService + ToolBroker and
+// ReturnService — no External at all. But ActAsync routes an unknown tool to
+// External unconditionally, because vector 05 requires the agent to RECOVER from a
+// hallucinated tool name rather than die on it. So an agent with no MCP server still
+// needs something on the other side of that route.
+//
+// On #50 ("don't stub brokers"): this is a null object, and the distinction worth
+// holding is what it says. #50 killed a ClassifierBroker that returned "allow"
+// because it LIED — it claimed screening had happened when none had. This claims
+// nothing false. "There is no external tool named x here" is true, and it is the
+// answer the Brain needs to try something else.
+//
+// Configure Mcp(endpointUrl) or UseMcp(broker) to reach a real server.
+public sealed class NotConfiguredMcpBroker : IMcpBroker
+{
+    public ValueTask<string> CallAsync(string name, string input) =>
+        ValueTask.FromResult($"[external '{name}' not configured]");
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -214,9 +214,14 @@ public sealed partial class StandardAgent : IAgent
 
         IToolBroker toolBroker = new ToolBroker(this.tools);
 
+        // No endpoint configured means a Core-profile agent, which SPEC.md 8.1 says
+        // has no External. It still needs something on the far side of Act's unknown-
+        // tool route, so it gets a broker that says so honestly (#81).
         IMcpBroker mcp =
-            this.mcpBroker ?? new McpBroker(
-                this.mcpEndpointUrl, this.mcpRelativeUrl, this.mcpTimeoutSeconds);
+            this.mcpBroker ?? (string.IsNullOrWhiteSpace(this.mcpEndpointUrl)
+                ? new NotConfiguredMcpBroker()
+                : new McpBroker(
+                    this.mcpEndpointUrl, this.mcpRelativeUrl, this.mcpTimeoutSeconds));
 
         ILogBroker log = this.logBroker ?? new LogBroker(this.logPath);
 


### PR DESCRIPTION
The **Client** exposer — *prompt in, answer out*, the top row of `architecture.svg`. Also fixes **#81**, which this demo found by being the first caller that doesn't configure MCP.

## Verified against a live endpoint, not just built

```
Prompt : What is 47 * 89, and what is the capital of France?
Answer : 47 * 89 is 4183, and the capital of France is Paris.
Exit   : 0

turn 1 | intent: calculator | direction: calculator     | status: Working
turn 2 | intent: Respond    | direction: ReturnResponse | status: Responded
```

The whole tri-nature in one run: Gate screened the prompt → Brain chose the calculator → Direction ran it → Recall carried the result forward → Brain answered → Judge scored it. **4183 was computed by the tool, not recalled by a model.**

And the Brain genuinely received the observation on turn 2:

```
Task: What is 47 * 89, and what is the capital of France?

Observations so far:
- calculator: 4183
```

That's **vector 02's contract holding outside the harness** — and the **first time the brokers' real HTTP has ever run.** Brokers have no unit tests by design, so the wire format, the snake_case naming and the `application/json` media type had never been exercised until now.

## #81 — a Core-profile agent couldn't compose

```
UriFormatException: Invalid URI: The URI is empty.
```

The Demo never configures MCP → `Compose()` built `new McpBroker("")` → `new Uri("")` threw **before the loop ever started**.

**Every test missed it** because `StandardAgentTests`, `AgentToolTests` and the conformance harness *all* call `UseMcp(...)`. The one caller that doesn't is a real consumer. Unit tests mock what they know about; **this is what running the thing catches.**

SPEC.md §8.1 lists Core's Direction as `InternalToolService` + `ToolBroker` + `ReturnService` — **no External at all.** So the profile the spec calls *"a minimal viable agent"* couldn't be built.

Fixed with `NotConfiguredMcpBroker`. Two new tests pin it, and reverting the fix fails **exactly those two**.

**On the #50 tension** — this is a null object, and that deserves saying out loud. The distinction: #50 killed a `ClassifierBroker` returning `"allow"` because it **lied** — it claimed screening had happened when none had. *"There is no external tool named x here"* is **true**, and it's the answer the Brain needs to try something else. Reasoning recorded in the file and in #81.

## The exposer is finally an exposer

The Standard §3: pure mapping, **one** service dependency, no business logic. That's the whole file — read config, hand the agent a prompt, print what comes back.

The previous demo **hand-wired all nine foundations, three orchestrations and the coordination itself** — ~50 lines of graph. That's the composition root's job, and `StandardAgent` is the composition root (#36). *An exposer that wires the system is not an exposer.*

## Details worth knowing

- **`STANDARD_AGENTS_APIKEY`**, never `appsettings.json` (The Standard §4.1.5). Empty is allowed rather than fatal — a local llama.cpp/Ollama endpoint needs no key.
- **`CalculatorTool` returns errors rather than throwing.** `"2 +"` is a bad expression, not a broken calculator — a tool that *reports* gives the Brain something to recover from (#29).
- **It promotes whole numbers to decimals**, because NCalc would otherwise answer `7/2 = 3`.
- **`memory.txt`, `log.txt`, `Knowledge/` gitignored** — they're what the agent *writes*. Committing `memory.txt` would ship one machine's recollections to everyone who clones.

## Verification

```
dotnet test  → 198/198
dotnet run --project Standard.Agents.Conformance  → 6 passed, 0 failed
dotnet run --project Standard.Agents.Demo         → live endpoint, exit 0
```

Closes #38, closes #81
