### PR TITLE
MEDIUM CODE RUB: Build A Fresh Clone With Zero Warnings

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Exceptions.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Exceptions.ProcessPrompt.cs
@@ -19,7 +19,7 @@ public partial class AgentCoordinationServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnProcessPromptIfPromptIsInvalidAndLogItAsync(
-        string invalidPrompt)
+        string? invalidPrompt)
     {
         // given
         var invalidAgentException =
@@ -33,7 +33,7 @@ public partial class AgentCoordinationServiceTests
 
         // when
         ValueTask<string> processTask =
-            this.agentCoordinationService.ProcessPromptAsync(invalidPrompt);
+            this.agentCoordinationService.ProcessPromptAsync(invalidPrompt!);
 
         AgentCoordinationValidationException actualException =
             await Assert.ThrowsAsync<AgentCoordinationValidationException>(

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/KnowledgeServiceTests.Validations.RetrieveKnowledge.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/KnowledgeServiceTests.Validations.RetrieveKnowledge.cs
@@ -20,7 +20,7 @@ public partial class KnowledgeServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnRetrieveKnowledgeIfQueryIsInvalidAndLogItAsync(
-        string invalidQuery)
+        string? invalidQuery)
     {
         // given
         var invalidKnowledgeException =
@@ -34,7 +34,7 @@ public partial class KnowledgeServiceTests
 
         // when
         ValueTask<IReadOnlyList<string>> retrieveTask =
-            this.knowledgeService.RetrieveKnowledgeAsync(invalidQuery);
+            this.knowledgeService.RetrieveKnowledgeAsync(invalidQuery!);
 
         KnowledgeValidationException actualKnowledgeValidationException =
             await Assert.ThrowsAsync<KnowledgeValidationException>(

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.Validations.Remember.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Data/MemoryServiceTests.Validations.Remember.cs
@@ -19,7 +19,7 @@ public partial class MemoryServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnRememberIfMemoryIsInvalidAndLogItAsync(
-        string invalidMemory)
+        string? invalidMemory)
     {
         // given
         var invalidMemoryException =
@@ -33,7 +33,7 @@ public partial class MemoryServiceTests
 
         // when
         ValueTask rememberTask =
-            this.memoryService.RememberAsync(invalidMemory);
+            this.memoryService.RememberAsync(invalidMemory!);
 
         MemoryValidationException actualMemoryValidationException =
             await Assert.ThrowsAsync<MemoryValidationException>(

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.Validations.Generate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/BrainServiceTests.Validations.Generate.cs
@@ -17,7 +17,7 @@ public partial class BrainServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnGenerateIfUserPromptIsInvalidAndLogItAsync(
-        string invalidUserPrompt)
+        string? invalidUserPrompt)
     {
         // given
         string randomSystemPrompt = CreateRandomString();
@@ -33,7 +33,7 @@ public partial class BrainServiceTests
 
         // when
         ValueTask<string> generateTask =
-            this.brainService.GenerateAsync(randomSystemPrompt, invalidUserPrompt);
+            this.brainService.GenerateAsync(randomSystemPrompt, invalidUserPrompt!);
 
         BrainValidationException actualBrainValidationException =
             await Assert.ThrowsAsync<BrainValidationException>(
@@ -65,7 +65,7 @@ public partial class BrainServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldGenerateOnGenerateEvenIfSystemPromptIsEmptyAsync(
-        string emptySystemPrompt)
+        string? emptySystemPrompt)
     {
         // given
         string randomUserPrompt = CreateRandomString();
@@ -73,18 +73,18 @@ public partial class BrainServiceTests
         string expectedReply = randomReply;
 
         this.generatorBrokerMock.Setup(broker =>
-            broker.GenerateAsync(emptySystemPrompt, randomUserPrompt))
+            broker.GenerateAsync(emptySystemPrompt!, randomUserPrompt))
                 .ReturnsAsync(randomReply);
 
         // when
         string actualReply =
-            await this.brainService.GenerateAsync(emptySystemPrompt, randomUserPrompt);
+            await this.brainService.GenerateAsync(emptySystemPrompt!, randomUserPrompt);
 
         // then
         actualReply.Should().BeEquivalentTo(expectedReply);
 
         this.generatorBrokerMock.Verify(broker =>
-            broker.GenerateAsync(emptySystemPrompt, randomUserPrompt),
+            broker.GenerateAsync(emptySystemPrompt!, randomUserPrompt),
                 Times.Once);
 
         this.generatorBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/GateServiceTests.Validations.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/GateServiceTests.Validations.Screen.cs
@@ -20,7 +20,7 @@ public partial class GateServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnScreenIfGatePromptIsInvalidAndLogItAsync(
-        string invalidGatePrompt)
+        string? invalidGatePrompt)
     {
         // given
         string randomInput = CreateRandomString();
@@ -36,7 +36,7 @@ public partial class GateServiceTests
 
         // when
         ValueTask<string> screenTask =
-            this.gateService.ScreenAsync(invalidGatePrompt, randomInput);
+            this.gateService.ScreenAsync(invalidGatePrompt!, randomInput);
 
         GateValidationException actualGateValidationException =
             await Assert.ThrowsAsync<GateValidationException>(
@@ -64,7 +64,7 @@ public partial class GateServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnScreenIfInputIsInvalidAndLogItAsync(
-        string invalidInput)
+        string? invalidInput)
     {
         // given
         string randomGatePrompt = CreateRandomString();
@@ -80,7 +80,7 @@ public partial class GateServiceTests
 
         // when
         ValueTask<string> screenTask =
-            this.gateService.ScreenAsync(randomGatePrompt, invalidInput);
+            this.gateService.ScreenAsync(randomGatePrompt, invalidInput!);
 
         GateValidationException actualGateValidationException =
             await Assert.ThrowsAsync<GateValidationException>(

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Decision/JudgeServiceTests.Validations.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Decision/JudgeServiceTests.Validations.Evaluate.cs
@@ -17,7 +17,7 @@ public partial class JudgeServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnEvaluateIfJudgePromptIsInvalidAndLogItAsync(
-        string invalidJudgePrompt)
+        string? invalidJudgePrompt)
     {
         // given
         string randomCandidate = CreateRandomString();
@@ -33,7 +33,7 @@ public partial class JudgeServiceTests
 
         // when
         ValueTask<double> evaluateTask =
-            this.judgeService.EvaluateAsync(invalidJudgePrompt, randomCandidate);
+            this.judgeService.EvaluateAsync(invalidJudgePrompt!, randomCandidate);
 
         JudgeValidationException actualJudgeValidationException =
             await Assert.ThrowsAsync<JudgeValidationException>(
@@ -61,7 +61,7 @@ public partial class JudgeServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnEvaluateIfCandidateIsInvalidAndLogItAsync(
-        string invalidCandidate)
+        string? invalidCandidate)
     {
         // given
         string randomJudgePrompt = CreateRandomString();
@@ -77,7 +77,7 @@ public partial class JudgeServiceTests
 
         // when
         ValueTask<double> evaluateTask =
-            this.judgeService.EvaluateAsync(randomJudgePrompt, invalidCandidate);
+            this.judgeService.EvaluateAsync(randomJudgePrompt, invalidCandidate!);
 
         JudgeValidationException actualJudgeValidationException =
             await Assert.ThrowsAsync<JudgeValidationException>(

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ExternalToolServiceTests.Validations.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ExternalToolServiceTests.Validations.Call.cs
@@ -17,7 +17,7 @@ public partial class ExternalToolServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnCallIfNameIsInvalidAndLogItAsync(
-        string invalidName)
+        string? invalidName)
     {
         // given
         string randomInput = CreateRandomString();
@@ -33,7 +33,7 @@ public partial class ExternalToolServiceTests
 
         // when
         ValueTask<string> callTask =
-            this.externalToolService.CallAsync(invalidName, randomInput);
+            this.externalToolService.CallAsync(invalidName!, randomInput);
 
         ExternalToolValidationException actualExternalToolValidationException =
             await Assert.ThrowsAsync<ExternalToolValidationException>(

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Validations.Handles.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Validations.Handles.cs
@@ -17,7 +17,7 @@ public partial class InternalToolServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnHandlesIfNameIsInvalidAndLogItAsync(
-        string invalidName)
+        string? invalidName)
     {
         // given
         var invalidInternalToolException =
@@ -31,7 +31,7 @@ public partial class InternalToolServiceTests
 
         // when
         ValueTask<bool> handlesTask =
-            this.internalToolService.HandlesAsync(invalidName);
+            this.internalToolService.HandlesAsync(invalidName!);
 
         InternalToolValidationException actualInternalToolValidationException =
             await Assert.ThrowsAsync<InternalToolValidationException>(

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Validations.Run.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/InternalToolServiceTests.Validations.Run.cs
@@ -17,7 +17,7 @@ public partial class InternalToolServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnRunIfNameIsInvalidAndLogItAsync(
-        string invalidName)
+        string? invalidName)
     {
         // given
         string randomInput = CreateRandomString();
@@ -33,7 +33,7 @@ public partial class InternalToolServiceTests
 
         // when
         ValueTask<string> runTask =
-            this.internalToolService.RunAsync(invalidName, randomInput);
+            this.internalToolService.RunAsync(invalidName!, randomInput);
 
         InternalToolValidationException actualInternalToolValidationException =
             await Assert.ThrowsAsync<InternalToolValidationException>(
@@ -62,7 +62,7 @@ public partial class InternalToolServiceTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public async Task ShouldRunOnRunEvenIfInputIsEmptyAsync(string emptyInput)
+    public async Task ShouldRunOnRunEvenIfInputIsEmptyAsync(string? emptyInput)
     {
         // given
         string randomName = CreateRandomString();
@@ -71,18 +71,18 @@ public partial class InternalToolServiceTests
         string expectedOutput = randomOutput;
 
         this.toolBrokerMock.Setup(broker =>
-            broker.RunAsync(inputName, emptyInput))
+            broker.RunAsync(inputName, emptyInput!))
                 .ReturnsAsync(randomOutput);
 
         // when
         string actualOutput =
-            await this.internalToolService.RunAsync(inputName, emptyInput);
+            await this.internalToolService.RunAsync(inputName, emptyInput!);
 
         // then
         actualOutput.Should().BeEquivalentTo(expectedOutput);
 
         this.toolBrokerMock.Verify(broker =>
-            broker.RunAsync(inputName, emptyInput),
+            broker.RunAsync(inputName, emptyInput!),
                 Times.Once);
 
         this.toolBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ReturnServiceTests.Validations.Return.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Direction/ReturnServiceTests.Validations.Return.cs
@@ -17,7 +17,7 @@ public partial class ReturnServiceTests
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnReturnIfPayloadIsInvalidAndLogItAsync(
-        string invalidPayload)
+        string? invalidPayload)
     {
         // given
         var invalidReturnException =
@@ -31,7 +31,7 @@ public partial class ReturnServiceTests
 
         // when
         ValueTask<string> returnTask =
-            this.returnService.ReturnAsync(invalidPayload);
+            this.returnService.ReturnAsync(invalidPayload!);
 
         ReturnValidationException actualReturnValidationException =
             await Assert.ThrowsAsync<ReturnValidationException>(

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Exceptions.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Exceptions.Recall.cs
@@ -18,7 +18,7 @@ public partial class DataOrchestrationServiceTests
     public async Task ShouldThrowValidationExceptionOnRecallIfContextIsNullAndLogItAsync()
     {
         // given
-        AgentContext nullContext = null;
+        AgentContext? nullContext = null;
 
         var nullAgentContextException =
             new NullAgentContextException(
@@ -31,7 +31,7 @@ public partial class DataOrchestrationServiceTests
 
         // when
         ValueTask<AgentContext> recallTask =
-            this.dataOrchestrationService.RecallAsync(nullContext);
+            this.dataOrchestrationService.RecallAsync(nullContext!);
 
         AgentOrchestrationValidationException actualException =
             await Assert.ThrowsAsync<AgentOrchestrationValidationException>(

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Exceptions.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Exceptions.Think.cs
@@ -18,7 +18,7 @@ public partial class DecisionOrchestrationServiceTests
     public async Task ShouldThrowValidationExceptionOnThinkIfContextIsNullAndLogItAsync()
     {
         // given
-        AgentContext nullContext = null;
+        AgentContext? nullContext = null;
 
         var nullAgentContextException =
             new NullAgentContextException(
@@ -31,7 +31,7 @@ public partial class DecisionOrchestrationServiceTests
 
         // when
         ValueTask<AgentContext> thinkTask =
-            this.decisionOrchestrationService.ThinkAsync(nullContext);
+            this.decisionOrchestrationService.ThinkAsync(nullContext!);
 
         AgentOrchestrationValidationException actualException =
             await Assert.ThrowsAsync<AgentOrchestrationValidationException>(

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Exceptions.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Exceptions.Act.cs
@@ -18,7 +18,7 @@ public partial class DirectionOrchestrationServiceTests
     public async Task ShouldThrowValidationExceptionOnActIfContextIsNullAndLogItAsync()
     {
         // given
-        AgentContext nullContext = null;
+        AgentContext? nullContext = null;
 
         var nullAgentContextException =
             new NullAgentContextException(
@@ -31,7 +31,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // when
         ValueTask<AgentContext> actTask =
-            this.directionOrchestrationService.ActAsync(nullContext);
+            this.directionOrchestrationService.ActAsync(nullContext!);
 
         AgentOrchestrationValidationException actualException =
             await Assert.ThrowsAsync<AgentOrchestrationValidationException>(

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationDependencyException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationDependencyException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
 
 public class AgentCoordinationDependencyException : Xeption
 {
-    public AgentCoordinationDependencyException(string message, Xeption innerException)
+    public AgentCoordinationDependencyException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationDependencyValidationException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationDependencyValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
 
 public class AgentCoordinationDependencyValidationException : Xeption
 {
-    public AgentCoordinationDependencyValidationException(string message, Xeption innerException)
+    public AgentCoordinationDependencyValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationServiceException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationServiceException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
 
 public class AgentCoordinationServiceException : Xeption
 {
-    public AgentCoordinationServiceException(string message, Xeption innerException)
+    public AgentCoordinationServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationValidationException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
 
 public class AgentCoordinationValidationException : Xeption
 {
-    public AgentCoordinationValidationException(string message, Xeption innerException)
+    public AgentCoordinationValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainDependencyException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Brains.Exceptions;
 
 public class BrainDependencyException : Xeption
 {
-    public BrainDependencyException(string message, Xeption innerException)
+    public BrainDependencyException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainDependencyValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainDependencyValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Brains.Exceptions;
 
 public class BrainDependencyValidationException : Xeption
 {
-    public BrainDependencyValidationException(string message, Xeption innerException)
+    public BrainDependencyValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainServiceException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Brains.Exceptions;
 
 public class BrainServiceException : Xeption
 {
-    public BrainServiceException(string message, Xeption innerException)
+    public BrainServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Brains/Exceptions/BrainValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Brains.Exceptions;
 
 public class BrainValidationException : Xeption
 {
-    public BrainValidationException(string message, Xeption innerException)
+    public BrainValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolDependencyException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
 
 public class ExternalToolDependencyException : Xeption
 {
-    public ExternalToolDependencyException(string message, Xeption innerException)
+    public ExternalToolDependencyException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolDependencyValidationException.cs
+++ b/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolDependencyValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
 
 public class ExternalToolDependencyValidationException : Xeption
 {
-    public ExternalToolDependencyValidationException(string message, Xeption innerException)
+    public ExternalToolDependencyValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolServiceException.cs
+++ b/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolServiceException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
 
 public class ExternalToolServiceException : Xeption
 {
-    public ExternalToolServiceException(string message, Xeption innerException)
+    public ExternalToolServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolValidationException.cs
+++ b/Standard.Agents/Models/Foundations/ExternalTools/Exceptions/ExternalToolValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
 
 public class ExternalToolValidationException : Xeption
 {
-    public ExternalToolValidationException(string message, Xeption innerException)
+    public ExternalToolValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Gates/Exceptions/GateDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Gates/Exceptions/GateDependencyException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Gates.Exceptions;
 
 public class GateDependencyException : Xeption
 {
-    public GateDependencyException(string message, Xeption innerException)
+    public GateDependencyException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Gates/Exceptions/GateDependencyValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Gates/Exceptions/GateDependencyValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Gates.Exceptions;
 
 public class GateDependencyValidationException : Xeption
 {
-    public GateDependencyValidationException(string message, Xeption innerException)
+    public GateDependencyValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Gates/Exceptions/GateServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Gates/Exceptions/GateServiceException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Gates.Exceptions;
 
 public class GateServiceException : Xeption
 {
-    public GateServiceException(string message, Xeption innerException)
+    public GateServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Gates/Exceptions/GateValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Gates/Exceptions/GateValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Gates.Exceptions;
 
 public class GateValidationException : Xeption
 {
-    public GateValidationException(string message, Xeption innerException)
+    public GateValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolDependencyException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.InternalTools.Exceptions;
 
 public class InternalToolDependencyException : Xeption
 {
-    public InternalToolDependencyException(string message, Xeption innerException)
+    public InternalToolDependencyException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolServiceException.cs
+++ b/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolServiceException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.InternalTools.Exceptions;
 
 public class InternalToolServiceException : Xeption
 {
-    public InternalToolServiceException(string message, Xeption innerException)
+    public InternalToolServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolValidationException.cs
+++ b/Standard.Agents/Models/Foundations/InternalTools/Exceptions/InternalToolValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.InternalTools.Exceptions;
 
 public class InternalToolValidationException : Xeption
 {
-    public InternalToolValidationException(string message, Xeption innerException)
+    public InternalToolValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeDependencyException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
 
 public class JudgeDependencyException : Xeption
 {
-    public JudgeDependencyException(string message, Xeption innerException)
+    public JudgeDependencyException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeDependencyValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeDependencyValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
 
 public class JudgeDependencyValidationException : Xeption
 {
-    public JudgeDependencyValidationException(string message, Xeption innerException)
+    public JudgeDependencyValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeServiceException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
 
 public class JudgeServiceException : Xeption
 {
-    public JudgeServiceException(string message, Xeption innerException)
+    public JudgeServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Exceptions/JudgeValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Judges.Exceptions;
 
 public class JudgeValidationException : Xeption
 {
-    public JudgeValidationException(string message, Xeption innerException)
+    public JudgeValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeDependencyException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Knowledges.Exceptions;
 
 public class KnowledgeDependencyException : Xeption
 {
-    public KnowledgeDependencyException(string message, Xeption innerException)
+    public KnowledgeDependencyException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeServiceException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Knowledges.Exceptions;
 
 public class KnowledgeServiceException : Xeption
 {
-    public KnowledgeServiceException(string message, Xeption innerException)
+    public KnowledgeServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Knowledges/Exceptions/KnowledgeValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Knowledges.Exceptions;
 
 public class KnowledgeValidationException : Xeption
 {
-    public KnowledgeValidationException(string message, Xeption innerException)
+    public KnowledgeValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryDependencyException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Memories.Exceptions;
 
 public class MemoryDependencyException : Xeption
 {
-    public MemoryDependencyException(string message, Xeption innerException)
+    public MemoryDependencyException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryServiceException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Memories.Exceptions;
 
 public class MemoryServiceException : Xeption
 {
-    public MemoryServiceException(string message, Xeption innerException)
+    public MemoryServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Memories/Exceptions/MemoryValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Memories.Exceptions;
 
 public class MemoryValidationException : Xeption
 {
-    public MemoryValidationException(string message, Xeption innerException)
+    public MemoryValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Returns/Exceptions/ReturnServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Returns/Exceptions/ReturnServiceException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Returns.Exceptions;
 
 public class ReturnServiceException : Xeption
 {
-    public ReturnServiceException(string message, Xeption innerException)
+    public ReturnServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Returns/Exceptions/ReturnValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Returns/Exceptions/ReturnValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Returns.Exceptions;
 
 public class ReturnValidationException : Xeption
 {
-    public ReturnValidationException(string message, Xeption innerException)
+    public ReturnValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Skills/Exceptions/SkillDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Skills/Exceptions/SkillDependencyException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Skills.Exceptions;
 
 public class SkillDependencyException : Xeption
 {
-    public SkillDependencyException(string message, Xeption innerException)
+    public SkillDependencyException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Foundations/Skills/Exceptions/SkillServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Skills/Exceptions/SkillServiceException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Foundations.Skills.Exceptions;
 
 public class SkillServiceException : Xeption
 {
-    public SkillServiceException(string message, Xeption innerException)
+    public SkillServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationDependencyException.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationDependencyException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Orchestrations.Agents.Exceptions;
 
 public class AgentOrchestrationDependencyException : Xeption
 {
-    public AgentOrchestrationDependencyException(string message, Xeption innerException)
+    public AgentOrchestrationDependencyException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationDependencyValidationException.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationDependencyValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Orchestrations.Agents.Exceptions;
 
 public class AgentOrchestrationDependencyValidationException : Xeption
 {
-    public AgentOrchestrationDependencyValidationException(string message, Xeption innerException)
+    public AgentOrchestrationDependencyValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationServiceException.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationServiceException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Orchestrations.Agents.Exceptions;
 
 public class AgentOrchestrationServiceException : Xeption
 {
-    public AgentOrchestrationServiceException(string message, Xeption innerException)
+    public AgentOrchestrationServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationValidationException.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/Exceptions/AgentOrchestrationValidationException.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Models.Orchestrations.Agents.Exceptions;
 
 public class AgentOrchestrationValidationException : Xeption
 {
-    public AgentOrchestrationValidationException(string message, Xeption innerException)
+    public AgentOrchestrationValidationException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Exceptions.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Exceptions.cs
@@ -60,7 +60,7 @@ public partial class AgentCoordinationService
     }
 
     private async ValueTask<AgentCoordinationValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentCoordinationValidationException =
             new AgentCoordinationValidationException(
@@ -73,7 +73,7 @@ public partial class AgentCoordinationService
     }
 
     private async ValueTask<AgentCoordinationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentCoordinationDependencyValidationException =
             new AgentCoordinationDependencyValidationException(
@@ -86,7 +86,7 @@ public partial class AgentCoordinationService
     }
 
     private async ValueTask<AgentCoordinationDependencyException> CreateAndLogDependencyExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentCoordinationDependencyException =
             new AgentCoordinationDependencyException(
@@ -99,7 +99,7 @@ public partial class AgentCoordinationService
     }
 
     private async ValueTask<AgentCoordinationServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentCoordinationServiceException =
             new AgentCoordinationServiceException(

--- a/Standard.Agents/Services/Foundations/Data/KnowledgeService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Data/KnowledgeService.Exceptions.cs
@@ -53,7 +53,7 @@ public partial class KnowledgeService
     }
 
     private async ValueTask<KnowledgeValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var knowledgeValidationException =
             new KnowledgeValidationException(
@@ -102,7 +102,7 @@ public partial class KnowledgeService
     }
 
     private async ValueTask<KnowledgeServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var knowledgeServiceException =
             new KnowledgeServiceException(

--- a/Standard.Agents/Services/Foundations/Data/MemoryService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Data/MemoryService.Exceptions.cs
@@ -94,7 +94,7 @@ public partial class MemoryService
     }
 
     private async ValueTask<MemoryValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var memoryValidationException =
             new MemoryValidationException(
@@ -143,7 +143,7 @@ public partial class MemoryService
     }
 
     private async ValueTask<MemoryServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var memoryServiceException =
             new MemoryServiceException(

--- a/Standard.Agents/Services/Foundations/Data/SkillService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Data/SkillService.Exceptions.cs
@@ -73,7 +73,7 @@ public partial class SkillService
     }
 
     private async ValueTask<SkillDependencyException> CreateAndLogCriticalDependencyExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var skillDependencyException =
             new SkillDependencyException(
@@ -86,7 +86,7 @@ public partial class SkillService
     }
 
     private async ValueTask<SkillDependencyException> CreateAndLogDependencyExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var skillDependencyException =
             new SkillDependencyException(
@@ -99,7 +99,7 @@ public partial class SkillService
     }
 
     private async ValueTask<SkillServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var skillServiceException =
             new SkillServiceException(

--- a/Standard.Agents/Services/Foundations/Decision/BrainService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Decision/BrainService.Exceptions.cs
@@ -80,7 +80,7 @@ public partial class BrainService
     }
 
     private async ValueTask<BrainValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var brainValidationException =
             new BrainValidationException(
@@ -93,7 +93,7 @@ public partial class BrainService
     }
 
     private async ValueTask<BrainDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var brainDependencyValidationException =
             new BrainDependencyValidationException(
@@ -142,7 +142,7 @@ public partial class BrainService
     }
 
     private async ValueTask<BrainServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var brainServiceException =
             new BrainServiceException(

--- a/Standard.Agents/Services/Foundations/Decision/GateService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Decision/GateService.Exceptions.cs
@@ -83,7 +83,7 @@ public partial class GateService
     }
 
     private async ValueTask<GateValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var gateValidationException =
             new GateValidationException(
@@ -96,7 +96,7 @@ public partial class GateService
     }
 
     private async ValueTask<GateDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var gateDependencyValidationException =
             new GateDependencyValidationException(
@@ -145,7 +145,7 @@ public partial class GateService
     }
 
     private async ValueTask<GateServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var gateServiceException =
             new GateServiceException(

--- a/Standard.Agents/Services/Foundations/Decision/JudgeService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Decision/JudgeService.Exceptions.cs
@@ -86,7 +86,7 @@ public partial class JudgeService
     }
 
     private async ValueTask<JudgeValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var gateValidationException =
             new JudgeValidationException(
@@ -99,7 +99,7 @@ public partial class JudgeService
     }
 
     private async ValueTask<JudgeDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var gateDependencyValidationException =
             new JudgeDependencyValidationException(
@@ -148,7 +148,7 @@ public partial class JudgeService
     }
 
     private async ValueTask<JudgeServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var gateServiceException =
             new JudgeServiceException(

--- a/Standard.Agents/Services/Foundations/Direction/ExternalToolService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ExternalToolService.Exceptions.cs
@@ -82,7 +82,7 @@ public partial class ExternalToolService
     }
 
     private async ValueTask<ExternalToolValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var externalToolValidationException =
             new ExternalToolValidationException(
@@ -95,7 +95,7 @@ public partial class ExternalToolService
     }
 
     private async ValueTask<ExternalToolDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var externalToolDependencyValidationException =
             new ExternalToolDependencyValidationException(
@@ -144,7 +144,7 @@ public partial class ExternalToolService
     }
 
     private async ValueTask<ExternalToolServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var externalToolServiceException =
             new ExternalToolServiceException(

--- a/Standard.Agents/Services/Foundations/Direction/InternalToolService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Direction/InternalToolService.Exceptions.cs
@@ -70,7 +70,7 @@ public partial class InternalToolService
     }
 
     private async ValueTask<InternalToolValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var internalToolValidationException =
             new InternalToolValidationException(
@@ -83,7 +83,7 @@ public partial class InternalToolService
     }
 
     private async ValueTask<InternalToolDependencyException> CreateAndLogDependencyExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var internalToolDependencyException =
             new InternalToolDependencyException(
@@ -96,7 +96,7 @@ public partial class InternalToolService
     }
 
     private async ValueTask<InternalToolServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var internalToolServiceException =
             new InternalToolServiceException(

--- a/Standard.Agents/Services/Foundations/Direction/ReturnService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Direction/ReturnService.Exceptions.cs
@@ -36,7 +36,7 @@ public partial class ReturnService
     }
 
     private async ValueTask<ReturnValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var returnValidationException =
             new ReturnValidationException(
@@ -49,7 +49,7 @@ public partial class ReturnService
     }
 
     private async ValueTask<ReturnServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var returnServiceException =
             new ReturnServiceException(

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Exceptions.cs
@@ -84,7 +84,7 @@ public partial class DataOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationValidationException =
             new AgentOrchestrationValidationException(
@@ -97,7 +97,7 @@ public partial class DataOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationDependencyValidationException =
             new AgentOrchestrationDependencyValidationException(
@@ -110,7 +110,7 @@ public partial class DataOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationDependencyException> CreateAndLogDependencyExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationDependencyException =
             new AgentOrchestrationDependencyException(
@@ -123,7 +123,7 @@ public partial class DataOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationServiceException =
             new AgentOrchestrationServiceException(

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Exceptions.cs
@@ -103,7 +103,7 @@ public partial class DecisionOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationValidationException =
             new AgentOrchestrationValidationException(
@@ -116,7 +116,7 @@ public partial class DecisionOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationDependencyValidationException =
             new AgentOrchestrationDependencyValidationException(
@@ -129,7 +129,7 @@ public partial class DecisionOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationDependencyException> CreateAndLogDependencyExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationDependencyException =
             new AgentOrchestrationDependencyException(
@@ -142,7 +142,7 @@ public partial class DecisionOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationServiceException =
             new AgentOrchestrationServiceException(

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Exceptions.cs
@@ -88,7 +88,7 @@ public partial class DirectionOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationValidationException> CreateAndLogValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationValidationException =
             new AgentOrchestrationValidationException(
@@ -101,7 +101,7 @@ public partial class DirectionOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationDependencyValidationException =
             new AgentOrchestrationDependencyValidationException(
@@ -114,7 +114,7 @@ public partial class DirectionOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationDependencyException> CreateAndLogDependencyExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationDependencyException =
             new AgentOrchestrationDependencyException(
@@ -127,7 +127,7 @@ public partial class DirectionOrchestrationService
     }
 
     private async ValueTask<AgentOrchestrationServiceException> CreateAndLogServiceExceptionAsync(
-        Xeption exception)
+        Xeption? exception)
     {
         var agentOrchestrationServiceException =
             new AgentOrchestrationServiceException(


### PR DESCRIPTION
A fresh clone built green but **noisy: 84 warnings**. Now **0**.

```
Build succeeded.
    0 Warning(s)      ← was 84
    0 Error(s)
```

Verified on a **full rebuild with `bin`/`obj` cleared** — what a cloner actually gets.

## Why it went unnoticed for the entire build

**Incremental builds report 0.** The analyzers only run on a full compile. So every build I ran said clean, and the first person to clone the repo would have seen all 84. I only caught it by verifying from a fresh clone at the end.

## Two categories, fixed differently — on purpose

**`CS8604` in the library (~70).** The orchestration rewrap passes `exception.InnerException as Xeption` into helpers typed non-nullable:

```csharp
throw await CreateAndLogDependencyValidationExceptionAsync(
    gateValidationException.InnerException as Xeption);   // `as` → may be null
```

The compiler was pointing at **the exact invariant the ladder exists to hold**: unwrap → *preserve the local exception* → rewrap. Nothing **proved** the chain was intact, and a null slipping through would silently sever it.

Fixed by widening the helpers and exception models to `Xeption?`. That's **honest, not loose** — `Exception.InnerException` is already nullable, so the signature now matches the truth.

**`xUnit1012` + `CS8604` in the tests (14).** `[InlineData(null)]` on a `string` parameter → parameter becomes `string?`, call site adds `!`.

## The `!` is the interesting half

It would have been easy to "fix" this by widening the **service** signatures to `string?` instead. That would be **wrong**.

The Standard's own idiom is to **declare non-nullable and validate anyway** — its `AddStudentAsync(Student student)` still throws `NullStudentException`. The contract says a name is required; the test **deliberately violates it** to prove the guard fires.

`!` says *"I know this is null — that's the point."* Which is precisely what the operator is for. Widening the service would have made the contract lie to keep the compiler quiet.

## Not suppressed

The Standard: *"Suppress warnings at the project level when truly needed; otherwise fix them."* **None of these needed suppressing.**

## Verification

```
full rebuild → 0 Warning(s), 0 Error(s)
dotnet test  → 198/198
conformance  → 6 passed, 0 failed
```

Closes #83
