### PR TITLE
RELEASES: Set Package Version To 0.1.0.0

### DIFF
--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -11,8 +11,10 @@
 
     <!-- The Standard's release format is v1.2.3.4 — model . service/routine . fix/config
          . automated build. Deliberately NOT semver; the segments say what KIND of change
-         happened. First release: the initial model. -->
-    <Version>1.0.0.0</Version>
+         happened, so a model change can never hide in the service segment.
+         0.1.0.0 tracks SPEC.md v0.1 (draft): the spec is not settled, so neither is the
+         model. Segment 1 goes to 1 when the spec does. -->
+    <Version>0.1.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>


### PR DESCRIPTION
Sets the package version to **`0.1.0.0`** ahead of the first publish.

## Why 0.1 and not 1.0

It tracks **SPEC.md v0.1 (draft)**. The spec isn't settled, so the model isn't settled either — segment 1 goes to `1` when the spec does.

Shipping `1.0.0.0` against a draft spec would promise a stability **the contract itself doesn't claim yet**.

Still The Standard's release format, not semver: `model . service/routine . fix/config . automated build`. NuGet displays `0.1.0` because it normalises a zero build segment; a real build increment (`0.1.0.5`) survives intact.

## Package id is free

```
flat-container /standard.agents/index.json  → HTTP 404   (free)
exact-id search hits                        → 0
```

## Verified

```
dotnet pack  → Standard.Agents.0.1.0.nupkg
               LICENSE.txt · README.md · the-standard-agent-icon.png · lib/net10.0/Standard.Agents.dll
               deps: Microsoft.Extensions.Logging.Abstractions 10.0.10 · RESTFulSense 3.2.0 · Xeption 2.9.0
build        → 0 Warning(s), 0 Error(s)
test         → 198/198
conformance  → 6 passed, 0 failed
```

**Not published by this PR.** The push is a separate, irreversible step — see the PR discussion.
