### PR TITLE
MINOR FIX: Put System Usings First Again

### DIFF
--- a/Standard.Agents.Conformance/Harness.cs
+++ b/Standard.Agents.Conformance/Harness.cs
@@ -6,7 +6,6 @@
 using Standard.Agents.Brokers.Classifiers;
 using Standard.Agents.Brokers.Generators;
 using Standard.Agents.Brokers.Knowledges;
-using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Logs;
 using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Brokers.Memorys;

--- a/Standard.Agents.Demo/Program.cs
+++ b/Standard.Agents.Demo/Program.cs
@@ -50,7 +50,7 @@ try
 }
 catch (Exception exception)
 {
-                    Console.Error.WriteLine($"{exception.GetType().Name}: {exception.Message}");
+    Console.Error.WriteLine($"{exception.GetType().Name}: {exception.Message}");
 
     if (exception.InnerException is not null)
     {

--- a/Standard.Agents.Demo/Tools/CalculatorTool.cs
+++ b/Standard.Agents.Demo/Tools/CalculatorTool.cs
@@ -21,12 +21,12 @@ public sealed partial class CalculatorTool : ITool
         }
         catch (Exception exception)
         {
-                                                            return ValueTask.FromResult($"error: {exception.Message}");
+            return ValueTask.FromResult($"error: {exception.Message}");
         }
     }
 
-                private static string PromoteNumbers(string expression) =>
-        WholeNumberRegex().Replace(expression, "${0}.0");
+    private static string PromoteNumbers(string expression) =>
+WholeNumberRegex().Replace(expression, "${0}.0");
 
     [GeneratedRegex(@"(?<![\d.])\d+(?![\d.])")]
     private static partial Regex WholeNumberRegex();

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -8,21 +8,19 @@ using Moq;
 using Standard.Agents.Brokers.Classifiers;
 using Standard.Agents.Brokers.Generators;
 using Standard.Agents.Brokers.Knowledges;
-using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Logs;
 using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Models.Clients.Agents.Exceptions;
-using Standard.Agents;
 using Xunit;
 
 namespace Standard.Agents.Tests.Unit.Clients;
 
 public class StandardAgentTests
 {
-                private static StandardAgent CreateFullyStubbedAgent(string brainReply)
+    private static StandardAgent CreateFullyStubbedAgent(string brainReply)
     {
         var skillBroker = new Mock<ISkillBroker>();
         skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("you are an agent");
@@ -72,7 +70,7 @@ public class StandardAgentTests
         actualResult.Should().Be("42");
     }
 
-            [Fact]
+    [Fact]
     public void ShouldReturnSameInstanceOnEachBuilderMethod()
     {
         // given
@@ -91,7 +89,7 @@ public class StandardAgentTests
         chained.Should().BeSameAs(agent);
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldRecomposeAfterConfigurationChangesAsync()
     {
         // given
@@ -112,7 +110,7 @@ public class StandardAgentTests
         secondResult.Should().Be("second");
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldThrowCompositionExceptionOnProcessPromptIfBrainIsNotConfiguredAsync()
     {
         // given
@@ -129,7 +127,7 @@ public class StandardAgentTests
         actualException.Message.Should().Contain("no brain");
     }
 
-                            [Fact]
+    [Fact]
     public async Task ShouldComposeOnProcessPromptIfGeneratorIsSwappedWithoutBrainSettingsAsync()
     {
         // given
@@ -154,15 +152,15 @@ public class StandardAgentTests
         var knowledgeBroker = new Mock<IKnowledgeBroker>();
         var logBroker = new Mock<ILogBroker>();
 
-                var agent = new StandardAgent()
-            .UseSkills(skillBroker.Object)
-            .UseGenerator(generatorBroker.Object)
-            .UseGate(classifierBroker.Object)
-            .UseJudge(verifierBroker.Object)
-            .UseMemory(memoryBroker.Object)
-            .UseKnowledge(knowledgeBroker.Object)
-            .UseMcp(new Mock<IMcpBroker>().Object)
-            .UseLog(logBroker.Object);
+        var agent = new StandardAgent()
+    .UseSkills(skillBroker.Object)
+    .UseGenerator(generatorBroker.Object)
+    .UseGate(classifierBroker.Object)
+    .UseJudge(verifierBroker.Object)
+    .UseMemory(memoryBroker.Object)
+    .UseKnowledge(knowledgeBroker.Object)
+    .UseMcp(new Mock<IMcpBroker>().Object)
+    .UseLog(logBroker.Object);
 
         // when
         string actualResult = await agent.ProcessPromptAsync("prompt");
@@ -171,7 +169,7 @@ public class StandardAgentTests
         actualResult.Should().Be("ok");
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldThrowCompositionExceptionOnProcessPromptIfGateHasNoSettingsAsync()
     {
         // given
@@ -191,7 +189,7 @@ public class StandardAgentTests
         actualException.Message.Should().Contain("gate");
     }
 
-                            [Fact]
+    [Fact]
     public async Task ShouldComposeCoreProfileAgentOnProcessPromptWithoutMcpConfiguredAsync()
     {
         // given
@@ -213,14 +211,14 @@ public class StandardAgentTests
         var memory = new Mock<IMemoryBroker>();
         memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
 
-                var agent = new StandardAgent()
-            .UseSkills(skillBroker.Object)
-            .UseGenerator(generatorBroker.Object)
-            .UseGate(gate.Object)
-            .UseJudge(judge.Object)
-            .UseMemory(memory.Object)
-            .UseKnowledge(new Mock<IKnowledgeBroker>().Object)
-            .UseLog(new Mock<ILogBroker>().Object);
+        var agent = new StandardAgent()
+    .UseSkills(skillBroker.Object)
+    .UseGenerator(generatorBroker.Object)
+    .UseGate(gate.Object)
+    .UseJudge(judge.Object)
+    .UseMemory(memory.Object)
+    .UseKnowledge(new Mock<IKnowledgeBroker>().Object)
+    .UseLog(new Mock<ILogBroker>().Object);
 
         // when
         string actualResult = await agent.ProcessPromptAsync("prompt");
@@ -229,7 +227,7 @@ public class StandardAgentTests
         actualResult.Should().Be("composed");
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldRecoverFromUnknownToolWithoutMcpConfiguredAsync()
     {
         // given — the Brain calls a tool that does not exist, then answers

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Exceptions.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Exceptions.ProcessPrompt.cs
@@ -46,14 +46,14 @@ public partial class AgentCoordinationServiceTests
             broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
                 Times.Once);
 
-                        this.logBrokerMock.VerifyNoOtherCalls();
+        this.logBrokerMock.VerifyNoOtherCalls();
         this.dataOrchestrationServiceMock.VerifyNoOtherCalls();
     }
 
-                [Theory]
+    [Theory]
     [MemberData(nameof(DependencyExceptions))]
     public async Task ShouldThrowDependencyExceptionOnProcessPromptIfDependencyErrorOccursAndLogItAsync(
-        Xeption orchestrationException)
+Xeption orchestrationException)
     {
         // given
         string randomPrompt = CreateRandomString();

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
@@ -12,7 +12,7 @@ namespace Standard.Agents.Tests.Unit.Services.Coordinations;
 
 public partial class AgentCoordinationServiceTests
 {
-        [Fact]
+    [Fact]
     public async Task ShouldProcessPromptAsync()
     {
         // given
@@ -30,7 +30,7 @@ public partial class AgentCoordinationServiceTests
         actualResult.Should().Be(expectedResult);
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldSeedContextWithPromptOnProcessPromptAsync()
     {
         // given
@@ -50,7 +50,7 @@ public partial class AgentCoordinationServiceTests
                         Times.Once);
     }
 
-                    [Fact]
+    [Fact]
     public async Task ShouldCallRecallThinkActInOrderOnProcessPromptAsync()
     {
         // given
@@ -78,13 +78,13 @@ public partial class AgentCoordinationServiceTests
         actualResult.Should().Be("done");
     }
 
-                [Theory]
+    [Theory]
     [InlineData(AgentStatus.Responded)]
     [InlineData(AgentStatus.Refused)]
     [InlineData(AgentStatus.Failed)]
     [InlineData(AgentStatus.AwaitingInput)]
     public async Task ShouldBreakLoopOnProcessPromptIfStatusIsNotWorkingAsync(
-        AgentStatus terminalStatus)
+AgentStatus terminalStatus)
     {
         // given
         string randomPrompt = CreateRandomString();
@@ -107,7 +107,7 @@ public partial class AgentCoordinationServiceTests
                 Times.Once);
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldCapTurnsOnProcessPromptIfBrainNeverTerminatesAsync()
     {
         // given
@@ -122,16 +122,16 @@ public partial class AgentCoordinationServiceTests
         // then
         actualResult.Should().Be("again");
 
-                        this.dataOrchestrationServiceMock.Verify(service =>
-            service.RecallAsync(It.IsAny<AgentContext>()),
-                Times.Exactly(7));
+        this.dataOrchestrationServiceMock.Verify(service =>
+service.RecallAsync(It.IsAny<AgentContext>()),
+Times.Exactly(7));
 
         this.decisionOrchestrationServiceMock.Verify(service =>
             service.ThinkAsync(It.IsAny<AgentContext>()),
                 Times.Exactly(7));
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldRecallEveryTurnOnProcessPromptAsync()
     {
         // given
@@ -146,16 +146,16 @@ public partial class AgentCoordinationServiceTests
             service.ThinkAsync(It.IsAny<AgentContext>()))
                 .ReturnsAsync((AgentContext context) => context);
 
-                this.directionOrchestrationServiceMock.Setup(service =>
-            service.ActAsync(It.IsAny<AgentContext>()))
-                .ReturnsAsync((AgentContext context) =>
-                {
-                    turn++;
+        this.directionOrchestrationServiceMock.Setup(service =>
+    service.ActAsync(It.IsAny<AgentContext>()))
+        .ReturnsAsync((AgentContext context) =>
+        {
+            turn++;
 
-                    return turn < 3
-                        ? context with { Result = "working", Status = AgentStatus.Working }
-                        : context with { Result = "done", Status = AgentStatus.Responded };
-                });
+            return turn < 3
+                ? context with { Result = "working", Status = AgentStatus.Working }
+                : context with { Result = "done", Status = AgentStatus.Responded };
+        });
 
         // when
         string actualResult =
@@ -169,7 +169,7 @@ public partial class AgentCoordinationServiceTests
                 Times.Exactly(3));
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldResetLogOnProcessPromptAsync()
     {
         // given
@@ -186,7 +186,7 @@ public partial class AgentCoordinationServiceTests
                 Times.Once);
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldWriteTurnToLogOnProcessPromptAsync()
     {
         // given
@@ -203,7 +203,7 @@ public partial class AgentCoordinationServiceTests
                 Times.AtLeastOnce);
     }
 
-                    [Fact]
+    [Fact]
     public async Task ShouldNotLeakStateBetweenPromptsOnProcessPromptAsync()
     {
         // given
@@ -238,6 +238,6 @@ public partial class AgentCoordinationServiceTests
         recalledContexts[0].Prompt.Should().Be(firstPrompt);
         recalledContexts[1].Prompt.Should().Be(secondPrompt);
 
-                recalledContexts[1].Observations.Should().BeEmpty();
+        recalledContexts[1].Observations.Should().BeEmpty();
     }
 }

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Logs;
@@ -11,7 +12,6 @@ using Standard.Agents.Services.Coordinations;
 using Standard.Agents.Services.Orchestrations.Data;
 using Standard.Agents.Services.Orchestrations.Decision;
 using Standard.Agents.Services.Orchestrations.Direction;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 using Xunit;
@@ -46,7 +46,7 @@ public partial class AgentCoordinationServiceTests
     private static string CreateRandomString() =>
         new MnemonicString().GetValue();
 
-        private void SetupOrchestrationsPassThrough()
+    private void SetupOrchestrationsPassThrough()
     {
         this.dataOrchestrationServiceMock.Setup(service =>
             service.RecallAsync(It.IsAny<AgentContext>()))
@@ -63,11 +63,11 @@ public partial class AgentCoordinationServiceTests
                 .ReturnsAsync((AgentContext context) =>
                     context with { Result = result, Status = AgentStatus.Responded });
 
-        private void SetupDirectionNeverTerminates(string result) =>
-        this.directionOrchestrationServiceMock.Setup(service =>
-            service.ActAsync(It.IsAny<AgentContext>()))
-                .ReturnsAsync((AgentContext context) =>
-                    context with { Result = result, Status = AgentStatus.Working });
+    private void SetupDirectionNeverTerminates(string result) =>
+    this.directionOrchestrationServiceMock.Setup(service =>
+        service.ActAsync(It.IsAny<AgentContext>()))
+            .ReturnsAsync((AgentContext context) =>
+                context with { Result = result, Status = AgentStatus.Working });
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Exceptions.Generate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Exceptions.Generate.cs
@@ -13,22 +13,22 @@ namespace Standard.Agents.Tests.Unit.Services.Foundations.Brains;
 
 public partial class BrainServiceTests
 {
-            public static TheoryData<Exception> CriticalDependencyExceptions() =>
-        new()
-        {
+    public static TheoryData<Exception> CriticalDependencyExceptions() =>
+new()
+{
             new HttpResponseUnauthorizedException(),
             new HttpResponseForbiddenException(),
             new HttpResponseNotFoundException(),
             new HttpResponseUrlNotFoundException(),
             new HttpRequestException()
-        };
+};
 
-            public static TheoryData<Exception> DependencyExceptions() =>
-        new()
-        {
+    public static TheoryData<Exception> DependencyExceptions() =>
+new()
+{
             new HttpResponseInternalServerErrorException(),
             new HttpResponseServiceUnavailableException()
-        };
+};
 
     [Theory]
     [MemberData(nameof(CriticalDependencyExceptions))]
@@ -126,7 +126,7 @@ public partial class BrainServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldThrowDependencyValidationExceptionOnGenerateIfBadRequestErrorOccursAndLogItAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.Generate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.Generate.cs
@@ -41,7 +41,7 @@ public partial class BrainServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldPassPromptsThroughUnalteredOnGenerateAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Validations.Generate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Validations.Generate.cs
@@ -48,20 +48,20 @@ public partial class BrainServiceTests
                 expectedBrainValidationException))),
                     Times.Once);
 
-                this.generatorBrokerMock.Verify(broker =>
-            broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()),
-                Times.Never);
+        this.generatorBrokerMock.Verify(broker =>
+    broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()),
+        Times.Never);
 
         this.generatorBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                [Theory]
+    [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldGenerateOnGenerateEvenIfSystemPromptIsEmptyAsync(
-        string? emptySystemPrompt)
+string? emptySystemPrompt)
     {
         // given
         string randomUserPrompt = CreateRandomString();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.cs
@@ -3,11 +3,11 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Generators;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Services.Foundations.Brains;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 

--- a/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Exceptions.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Exceptions.Call.cs
@@ -30,10 +30,10 @@ public partial class ExternalToolServiceTests
             new HttpResponseServiceUnavailableException()
         };
 
-                [Theory]
+    [Theory]
     [MemberData(nameof(CriticalDependencyExceptions))]
     public async Task ShouldThrowCriticalDependencyExceptionOnCallIfCriticalErrorOccursAndLogItAsync(
-        Exception criticalDependencyException)
+Exception criticalDependencyException)
     {
         // given
         string randomName = CreateRandomString();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Logic.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Logic.Call.cs
@@ -41,7 +41,7 @@ public partial class ExternalToolServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldReturnToolOutputOnCallEvenIfToolReportsAnErrorAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Validations.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Validations.Call.cs
@@ -48,9 +48,9 @@ public partial class ExternalToolServiceTests
                 expectedExternalToolValidationException))),
                     Times.Once);
 
-                        this.mcpBrokerMock.Verify(broker =>
-            broker.CallAsync(It.IsAny<string>(), It.IsAny<string>()),
-                Times.Never);
+        this.mcpBrokerMock.Verify(broker =>
+broker.CallAsync(It.IsAny<string>(), It.IsAny<string>()),
+Times.Never);
 
         this.mcpBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.cs
@@ -3,11 +3,11 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Services.Foundations.ExternalTools;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Exceptions.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Exceptions.Screen.cs
@@ -30,10 +30,10 @@ public partial class GateServiceTests
             new HttpResponseServiceUnavailableException()
         };
 
-                [Theory]
+    [Theory]
     [MemberData(nameof(CriticalDependencyExceptions))]
     public async Task ShouldThrowCriticalDependencyExceptionOnScreenIfCriticalErrorOccursAndLogItAsync(
-        Exception criticalDependencyException)
+Exception criticalDependencyException)
     {
         // given
         string randomGatePrompt = CreateRandomString();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Logic.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Logic.Screen.cs
@@ -41,7 +41,7 @@ public partial class GateServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                [Theory]
+    [Theory]
     [InlineData("allow")]
     [InlineData("refuse")]
     [InlineData("refuse: asks for credentials")]
@@ -71,7 +71,7 @@ public partial class GateServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldPassGatePromptThroughUnalteredOnScreenAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Validations.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Validations.Screen.cs
@@ -12,12 +12,12 @@ namespace Standard.Agents.Tests.Unit.Services.Foundations.Gates;
 
 public partial class GateServiceTests
 {
-                [Theory]
+    [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnScreenIfGatePromptIsInvalidAndLogItAsync(
-        string? invalidGatePrompt)
+string? invalidGatePrompt)
     {
         // given
         string randomInput = CreateRandomString();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.cs
@@ -3,11 +3,11 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Classifiers;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Services.Foundations.Gates;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Exceptions.Run.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Exceptions.Run.cs
@@ -12,7 +12,7 @@ namespace Standard.Agents.Tests.Unit.Services.Foundations.InternalTools;
 
 public partial class InternalToolServiceTests
 {
-                [Fact]
+    [Fact]
     public async Task ShouldThrowDependencyExceptionOnRunIfToolErrorOccursAndLogItAsync()
     {
         // given
@@ -61,7 +61,7 @@ public partial class InternalToolServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                    [Fact]
+    [Fact]
     public async Task ShouldThrowDependencyExceptionOnRunIfToolIsNotFoundAndLogItAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Logic.Handles.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Logic.Handles.cs
@@ -11,7 +11,7 @@ namespace Standard.Agents.Tests.Unit.Services.Foundations.InternalTools;
 
 public partial class InternalToolServiceTests
 {
-            [Theory]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task ShouldHandlesAsync(bool brokerHasTool)

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Logic.Run.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Logic.Run.cs
@@ -41,7 +41,7 @@ public partial class InternalToolServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldReturnToolOutputOnRunEvenIfToolReportsAnErrorAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Validations.Handles.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Validations.Handles.cs
@@ -46,9 +46,9 @@ public partial class InternalToolServiceTests
                 expectedInternalToolValidationException))),
                     Times.Once);
 
-                this.toolBrokerMock.Verify(broker =>
-            broker.HasAsync(It.IsAny<string>()),
-                Times.Never);
+        this.toolBrokerMock.Verify(broker =>
+    broker.HasAsync(It.IsAny<string>()),
+        Times.Never);
 
         this.toolBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Validations.Run.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Validations.Run.cs
@@ -56,7 +56,7 @@ public partial class InternalToolServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-            [Theory]
+    [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.cs
@@ -3,11 +3,11 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Tools;
 using Standard.Agents.Services.Foundations.InternalTools;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Logic.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Logic.Evaluate.cs
@@ -11,7 +11,7 @@ namespace Standard.Agents.Tests.Unit.Services.Foundations.Judges;
 
 public partial class JudgeServiceTests
 {
-        [Theory]
+    [Theory]
     [InlineData(0.0)]
     [InlineData(0.3)]
     [InlineData(1.0)]
@@ -41,7 +41,7 @@ public partial class JudgeServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldPassJudgePromptThroughUnalteredOnEvaluateAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Validations.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Validations.Evaluate.cs
@@ -100,13 +100,13 @@ public partial class JudgeServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                                [Theory]
+    [Theory]
     [InlineData(-0.1)]
     [InlineData(1.1)]
     [InlineData(87)]
     [InlineData(double.NaN)]
     public async Task ShouldThrowValidationExceptionOnEvaluateIfScoreIsOutOfRangeAndLogItAsync(
-        double outOfRangeScore)
+double outOfRangeScore)
     {
         // given
         string randomJudgePrompt = CreateRandomString();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.cs
@@ -3,11 +3,11 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Services.Foundations.Judges;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Exceptions.RetrieveKnowledge.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Exceptions.RetrieveKnowledge.cs
@@ -12,13 +12,13 @@ namespace Standard.Agents.Tests.Unit.Services.Foundations.Knowledges;
 
 public partial class KnowledgeServiceTests
 {
-        public static TheoryData<Exception> CriticalDependencyExceptions() =>
-        new()
-        {
+    public static TheoryData<Exception> CriticalDependencyExceptions() =>
+    new()
+    {
             new FileNotFoundException(),
             new DirectoryNotFoundException(),
             new UnauthorizedAccessException()
-        };
+    };
 
     [Theory]
     [MemberData(nameof(CriticalDependencyExceptions))]
@@ -159,4 +159,4 @@ public partial class KnowledgeServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-            }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Logic.RetrieveKnowledge.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Logic.RetrieveKnowledge.cs
@@ -40,7 +40,7 @@ public partial class KnowledgeServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldRetrieveNoKnowledgeOnRetrieveKnowledgeIfNothingMatchesAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Validations.RetrieveKnowledge.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Validations.RetrieveKnowledge.cs
@@ -12,12 +12,12 @@ namespace Standard.Agents.Tests.Unit.Services.Foundations.Knowledges;
 
 public partial class KnowledgeServiceTests
 {
-                [Theory]
+    [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnRetrieveKnowledgeIfQueryIsInvalidAndLogItAsync(
-        string? invalidQuery)
+string? invalidQuery)
     {
         // given
         var invalidKnowledgeException =

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.cs
@@ -3,11 +3,11 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Knowledges;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Services.Foundations.Knowledges;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Exceptions.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Exceptions.cs
@@ -12,13 +12,13 @@ namespace Standard.Agents.Tests.Unit.Services.Foundations.Memorys;
 
 public partial class MemoryServiceTests
 {
-        public static TheoryData<Exception> CriticalDependencyExceptions() =>
-        new()
-        {
+    public static TheoryData<Exception> CriticalDependencyExceptions() =>
+    new()
+    {
             new FileNotFoundException(),
             new DirectoryNotFoundException(),
             new UnauthorizedAccessException()
-        };
+    };
 
     [Theory]
     [MemberData(nameof(CriticalDependencyExceptions))]
@@ -155,7 +155,7 @@ public partial class MemoryServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldThrowDependencyExceptionOnRememberIfDependencyErrorOccursAndLogItAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Logic.RecallMemories.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Logic.RecallMemories.cs
@@ -38,7 +38,7 @@ public partial class MemoryServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldRecallNoMemoriesOnRecallMemoriesIfStoreIsEmptyAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Validations.Remember.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Validations.Remember.cs
@@ -12,12 +12,12 @@ namespace Standard.Agents.Tests.Unit.Services.Foundations.Memorys;
 
 public partial class MemoryServiceTests
 {
-            [Theory]
+    [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnRememberIfMemoryIsInvalidAndLogItAsync(
-        string? invalidMemory)
+string? invalidMemory)
     {
         // given
         var invalidMemoryException =

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.cs
@@ -3,11 +3,11 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Services.Foundations.Memorys;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Returns/ReturnServiceTests.Logic.Return.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Returns/ReturnServiceTests.Logic.Return.cs
@@ -4,7 +4,6 @@
 // ---------------------------------------------------------------
 
 using FluentAssertions;
-using Moq;
 using Xunit;
 
 namespace Standard.Agents.Tests.Unit.Services.Foundations.Returns;

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Returns/ReturnServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Returns/ReturnServiceTests.cs
@@ -3,10 +3,10 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Services.Foundations.Returns;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.Exceptions.RetrieveSkills.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.Exceptions.RetrieveSkills.cs
@@ -101,10 +101,10 @@ public partial class SkillServiceTests
             broker.SelectSkillsAsync(),
                 Times.Once);
 
-                this.loggingBrokerMock.Verify(broker =>
-            broker.LogErrorAsync(It.Is(SameExceptionAs(
-                expectedSkillDependencyException))),
-                    Times.Once);
+        this.loggingBrokerMock.Verify(broker =>
+    broker.LogErrorAsync(It.Is(SameExceptionAs(
+        expectedSkillDependencyException))),
+            Times.Once);
 
         this.skillBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.cs
@@ -3,11 +3,11 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Services.Foundations.Skills;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Exceptions.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Exceptions.Recall.cs
@@ -56,10 +56,10 @@ public partial class DataOrchestrationServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                [Theory]
+    [Theory]
     [MemberData(nameof(DependencyValidationExceptions))]
     public async Task ShouldThrowDependencyValidationExceptionOnRecallIfDependencyValidationErrorOccursAndLogItAsync(
-        Xeption foundationException)
+Xeption foundationException)
     {
         // given
         AgentContext inputContext = CreateRandomAgentContext();

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Recall.cs
@@ -12,7 +12,7 @@ namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Data;
 
 public partial class DataOrchestrationServiceTests
 {
-        [Fact]
+    [Fact]
     public async Task ShouldSetSystemPromptFromSkillServiceOnRecallAsync()
     {
         // given
@@ -40,7 +40,7 @@ public partial class DataOrchestrationServiceTests
                 Times.Once);
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldNotMutateInputContextOnRecallAsync()
     {
         // given
@@ -67,7 +67,7 @@ public partial class DataOrchestrationServiceTests
         actualContext.Prompt.Should().BeEquivalentTo(originalPrompt);
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldSeedObservationsFromMemoriesOnRecallAsync()
     {
         // given
@@ -95,7 +95,7 @@ public partial class DataOrchestrationServiceTests
                 Times.Once);
     }
 
-                    [Fact]
+    [Fact]
     public async Task ShouldPreserveExistingObservationsOnRecallAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
@@ -10,7 +11,6 @@ using Standard.Agents.Services.Foundations.Knowledges;
 using Standard.Agents.Services.Foundations.Memorys;
 using Standard.Agents.Services.Foundations.Skills;
 using Standard.Agents.Services.Orchestrations.Data;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 using Xunit;
@@ -48,15 +48,15 @@ public partial class DataOrchestrationServiceTests
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
 
-                                public static TheoryData<Xeption> DependencyValidationExceptions() =>
-        new()
-        {
+    public static TheoryData<Xeption> DependencyValidationExceptions() =>
+new()
+{
             new Models.Foundations.Memorys.Exceptions.MemoryValidationException(
                 "memory validation", new Xeption("inner")),
 
             new Models.Foundations.Knowledges.Exceptions.KnowledgeValidationException(
                 "knowledge validation", new Xeption("inner"))
-        };
+};
 
     public static TheoryData<Xeption> DependencyExceptions() =>
         new()

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Exceptions.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Exceptions.Think.cs
@@ -56,10 +56,10 @@ public partial class DecisionOrchestrationServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                [Theory]
+    [Theory]
     [MemberData(nameof(DependencyValidationExceptions))]
     public async Task ShouldThrowDependencyValidationExceptionOnThinkIfDependencyValidationErrorOccursAndLogItAsync(
-        Xeption foundationException)
+Xeption foundationException)
     {
         // given
         AgentContext inputContext = CreateRandomAgentContext();

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
@@ -31,7 +31,7 @@ public partial class DecisionOrchestrationServiceTests
         actualContext.Intent.Should().Be("Refuse");
     }
 
-                            [Theory]
+    [Theory]
     [InlineData("refuse")]
     [InlineData("REFUSE")]
     [InlineData("refuse: asks for credentials")]
@@ -54,7 +54,7 @@ public partial class DecisionOrchestrationServiceTests
         actualContext.RawReply.Should().Be(verdict);
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldNotCallBrainOnThinkIfGateRefusesAsync()
     {
         // given
@@ -80,7 +80,7 @@ public partial class DecisionOrchestrationServiceTests
         this.judgeServiceMock.VerifyNoOtherCalls();
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldLoopOnThinkIfJudgeScoresBelowThresholdAsync()
     {
         // given
@@ -104,7 +104,7 @@ public partial class DecisionOrchestrationServiceTests
         actualContext.DirectionType.Should().NotBe("ReturnResponse");
     }
 
-                    [Fact]
+    [Fact]
     public async Task ShouldFeedRejectedDraftBackAsObservationOnThinkAsync()
     {
         // given
@@ -128,7 +128,7 @@ public partial class DecisionOrchestrationServiceTests
             .ContainSingle(observation => observation.Contains("a poor answer"));
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldNotJudgeOnThinkIfDirectionIsToolAsync()
     {
         // given
@@ -150,7 +150,7 @@ public partial class DecisionOrchestrationServiceTests
         this.judgeServiceMock.VerifyNoOtherCalls();
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldScreenPromptAndJudgeDraftOnThinkAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
@@ -34,7 +34,7 @@ public partial class DecisionOrchestrationServiceTests
         actualContext.RawReply.Should().Be("FINAL: 42");
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldParseActionFromFirstLineOnlyOnThinkAsync()
     {
         // given
@@ -53,10 +53,10 @@ public partial class DecisionOrchestrationServiceTests
         actualContext.DirectionType.Should().Be("calculator");
         actualContext.Payload.Should().Be("1+1");
 
-                actualContext.Payload.Should().NotContain("wrong");
+        actualContext.Payload.Should().NotContain("wrong");
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldPreserveMultilineFinalOnThinkAsync()
     {
         // given
@@ -77,7 +77,7 @@ public partial class DecisionOrchestrationServiceTests
         actualContext.Payload.Should().Be("line one\nline two");
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldPreserveColonsInToolInputOnThinkAsync()
     {
         // given
@@ -97,7 +97,7 @@ public partial class DecisionOrchestrationServiceTests
         actualContext.Payload.Should().Be("https://example.com:8080/a?b=1");
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldSetIntentToToolNameOnThinkIfActionAsync()
     {
         // given
@@ -136,7 +136,7 @@ public partial class DecisionOrchestrationServiceTests
         actualContext.Intent.Should().Be("Respond");
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldTreatNonProtocolReplyAsAnswerOnThinkAsync()
     {
         // given
@@ -157,7 +157,7 @@ public partial class DecisionOrchestrationServiceTests
         actualContext.Payload.Should().Be("just an answer, no prefix");
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldPassObservationsToBrainOnThinkAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
@@ -10,7 +11,6 @@ using Standard.Agents.Services.Foundations.Brains;
 using Standard.Agents.Services.Foundations.Gates;
 using Standard.Agents.Services.Foundations.Judges;
 using Standard.Agents.Services.Orchestrations.Decision;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 using Xunit;
@@ -49,10 +49,10 @@ public partial class DecisionOrchestrationServiceTests
             SystemPrompt = CreateRandomString()
         };
 
-            private void SetupGateAllows() =>
-        this.gateServiceMock.Setup(service =>
-            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync("allow");
+    private void SetupGateAllows() =>
+this.gateServiceMock.Setup(service =>
+    service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+        .ReturnsAsync("allow");
 
     private void SetupJudgeApproves() =>
         this.judgeServiceMock.Setup(service =>
@@ -62,9 +62,9 @@ public partial class DecisionOrchestrationServiceTests
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
 
-            public static TheoryData<Xeption> DependencyValidationExceptions() =>
-        new()
-        {
+    public static TheoryData<Xeption> DependencyValidationExceptions() =>
+new()
+{
             new Models.Foundations.Gates.Exceptions.GateValidationException(
                 "gate validation", new Xeption("inner")),
 
@@ -76,7 +76,7 @@ public partial class DecisionOrchestrationServiceTests
 
             new Models.Foundations.Brains.Exceptions.BrainDependencyValidationException(
                 "brain dependency validation", new Xeption("inner"))
-        };
+};
 
     public static TheoryData<Xeption> DependencyExceptions() =>
         new()

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Exceptions.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Exceptions.Act.cs
@@ -56,10 +56,10 @@ public partial class DirectionOrchestrationServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-                [Theory]
+    [Theory]
     [MemberData(nameof(DependencyValidationExceptions))]
     public async Task ShouldThrowDependencyValidationExceptionOnActIfDependencyValidationErrorOccursAndLogItAsync(
-        Xeption foundationException)
+Xeption foundationException)
     {
         // given
         AgentContext inputContext = CreateContextWithDirection("calculator", "1+1");

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
@@ -12,7 +12,7 @@ namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
 
 public partial class DirectionOrchestrationServiceTests
 {
-        [Fact]
+    [Fact]
     public async Task ShouldReturnAndTerminateOnActIfDirectionTypeIsReturnResponseAsync()
     {
         // given
@@ -41,7 +41,7 @@ public partial class DirectionOrchestrationServiceTests
         this.externalToolServiceMock.VerifyNoOtherCalls();
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldRefuseAndTerminateOnActIfDirectionTypeIsRefuseAsync()
     {
         // given
@@ -66,7 +66,7 @@ public partial class DirectionOrchestrationServiceTests
         this.externalToolServiceMock.VerifyNoOtherCalls();
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldRunInternalToolAndAppendObservationOnActAsync()
     {
         // given
@@ -94,7 +94,7 @@ public partial class DirectionOrchestrationServiceTests
                 Times.Never);
     }
 
-                    [Fact]
+    [Fact]
     public async Task ShouldRouteToExternalAndRecoverOnActIfToolIsUnknownAsync()
     {
         // given
@@ -126,7 +126,7 @@ public partial class DirectionOrchestrationServiceTests
                 Times.Never);
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldPreserveExistingObservationsOnActAsync()
     {
         // given
@@ -157,7 +157,7 @@ public partial class DirectionOrchestrationServiceTests
         actualContext.Observations.Should().Contain(priorObservation);
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldKeepWorkingOnActIfToolReportsAnErrorAsync()
     {
         // given
@@ -182,7 +182,7 @@ public partial class DirectionOrchestrationServiceTests
             .ContainSingle(o => o.Contains("could not parse expression"));
     }
 
-                                [Fact]
+    [Fact]
     public async Task ShouldSetResultToToolOutputOnActEvenIfNonTerminalAsync()
     {
         // given
@@ -206,7 +206,7 @@ public partial class DirectionOrchestrationServiceTests
         actualContext.Status.Should().Be(AgentStatus.Working);
     }
 
-            [Fact]
+    [Fact]
     public async Task ShouldNameToolInObservationOnActAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
@@ -10,7 +11,6 @@ using Standard.Agents.Services.Foundations.ExternalTools;
 using Standard.Agents.Services.Foundations.InternalTools;
 using Standard.Agents.Services.Foundations.Returns;
 using Standard.Agents.Services.Orchestrations.Direction;
-using System.Linq.Expressions;
 using Tynamix.ObjectFiller;
 using Xeptions;
 using Xunit;

--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
@@ -5,7 +5,6 @@
 
 using FluentAssertions;
 using Moq;
-using Standard.Agents.Brokers.Logs;
 using Standard.Agents.Tools;
 using Tynamix.ObjectFiller;
 using Xunit;
@@ -41,14 +40,14 @@ public class AgentToolTests
         actualOutput.Should().Be(expectedOutput);
         agentTool.Name.Should().Be(randomName);
 
-                nestedAgentMock.Verify(agent =>
-            agent.ProcessPromptAsync(randomInput),
-                Times.Once);
+        nestedAgentMock.Verify(agent =>
+    agent.ProcessPromptAsync(randomInput),
+        Times.Once);
 
         nestedAgentMock.VerifyNoOtherCalls();
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldNestAgentInsideAgentAsync()
     {
         // given — the inner agent answers anything with a fixed finding
@@ -60,7 +59,7 @@ public class AgentToolTests
 
         var researcher = new AgentTool("researcher", innerAgent.Object);
 
-                var outerBrain = new Mock<Brokers.Generators.IGeneratorBroker>();
+        var outerBrain = new Mock<Brokers.Generators.IGeneratorBroker>();
         var replies = new Queue<string>(
         [
             "ACTION: researcher: capital of France",
@@ -102,12 +101,12 @@ public class AgentToolTests
         // then
         actualResult.Should().Be("Paris");
 
-                innerAgent.Verify(agent =>
-            agent.ProcessPromptAsync("capital of France"),
-                Times.Once);
+        innerAgent.Verify(agent =>
+    agent.ProcessPromptAsync("capital of France"),
+        Times.Once);
     }
 
-                [Fact]
+    [Fact]
     public async Task ShouldPropagateOnExecuteIfNestedAgentThrowsAsync()
     {
         // given

--- a/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
@@ -66,7 +66,7 @@ public sealed class ClassifierBroker : IClassifierBroker
                 ChatCompletionsRelativeUrl,
                 chatCompletionRequest);
 
-                        return chatCompletionResponse.Choices[0].Message.Content;
+        return chatCompletionResponse.Choices[0].Message.Content;
     }
 
     private async ValueTask<TResult> PostAsync<TContent, TResult>(

--- a/Standard.Agents/Brokers/Generators/GeneratorBroker.cs
+++ b/Standard.Agents/Brokers/Generators/GeneratorBroker.cs
@@ -13,7 +13,7 @@ public sealed class GeneratorBroker : IGeneratorBroker
 {
     private const string ChatCompletionsRelativeUrl = "chat/completions";
 
-        private const string JsonMediaType = "application/json";
+    private const string JsonMediaType = "application/json";
 
     private static readonly JsonSerializerOptions jsonOptions = new()
     {
@@ -82,12 +82,12 @@ public sealed class GeneratorBroker : IGeneratorBroker
             deserializationFunction: json =>
                 ValueTask.FromResult(JsonSerializer.Deserialize<TResult>(json, jsonOptions)!));
 
-        private sealed record ChatCompletionRequest(
-        string Model,
-        IReadOnlyList<ChatMessage> Messages,
-        bool Stream,
-        double Temperature,
-        int MaxTokens);
+    private sealed record ChatCompletionRequest(
+    string Model,
+    IReadOnlyList<ChatMessage> Messages,
+    bool Stream,
+    double Temperature,
+    int MaxTokens);
 
     private sealed record ChatMessage(
         string Role,

--- a/Standard.Agents/Brokers/Knowledges/KnowledgeBroker.cs
+++ b/Standard.Agents/Brokers/Knowledges/KnowledgeBroker.cs
@@ -20,7 +20,7 @@ public sealed class KnowledgeBroker : IKnowledgeBroker
         this.searchPattern = searchPattern;
         this.maxResults = maxResults;
 
-                                Directory.CreateDirectory(this.knowledgePath);
+        Directory.CreateDirectory(this.knowledgePath);
     }
 
     public async ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query)
@@ -38,7 +38,7 @@ public sealed class KnowledgeBroker : IKnowledgeBroker
         {
             string document = await File.ReadAllTextAsync(documentPath);
 
-                                                if (document.Contains(query, StringComparison.OrdinalIgnoreCase))
+            if (document.Contains(query, StringComparison.OrdinalIgnoreCase))
             {
                 matches.Add(document);
             }

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -14,8 +14,8 @@ public sealed class LoggingBroker : ILoggingBroker
     public LoggingBroker(ILogger<LoggingBroker> logger) =>
         this.logger = logger;
 
-            public async ValueTask LogInformationAsync(string message) =>
-        this.logger.LogInformation(message);
+    public async ValueTask LogInformationAsync(string message) =>
+this.logger.LogInformation(message);
 
     public async ValueTask LogTraceAsync(string message) =>
         this.logger.LogTrace(message);

--- a/Standard.Agents/Brokers/Mcps/McpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/McpBroker.cs
@@ -63,7 +63,7 @@ public sealed class McpBroker : IMcpBroker
         return ToText(jsonRpcResponse);
     }
 
-                        private static string ToText(JsonRpcResponse jsonRpcResponse)
+    private static string ToText(JsonRpcResponse jsonRpcResponse)
     {
         if (jsonRpcResponse.Error is not null)
         {

--- a/Standard.Agents/Brokers/Memorys/MemoryBroker.cs
+++ b/Standard.Agents/Brokers/Memorys/MemoryBroker.cs
@@ -13,14 +13,14 @@ public sealed class MemoryBroker : IMemoryBroker
     {
         this.memoryPath = Path.GetFullPath(memoryPath);
 
-                                        EnsureStoreExists(this.memoryPath);
+        EnsureStoreExists(this.memoryPath);
     }
 
     public async ValueTask<IReadOnlyList<string>> SelectMemoriesAsync() =>
         await File.ReadAllLinesAsync(this.memoryPath);
 
-                public async ValueTask InsertMemoryAsync(string memory) =>
-        await File.AppendAllLinesAsync(this.memoryPath, [memory]);
+    public async ValueTask InsertMemoryAsync(string memory) =>
+await File.AppendAllLinesAsync(this.memoryPath, [memory]);
 
     private static void EnsureStoreExists(string memoryPath)
     {
@@ -28,6 +28,6 @@ public sealed class MemoryBroker : IMemoryBroker
 
         Directory.CreateDirectory(directoryPath);
 
-                                File.AppendAllText(memoryPath, string.Empty);
+        File.AppendAllText(memoryPath, string.Empty);
     }
 }

--- a/Standard.Agents/Brokers/Skills/SkillBroker.cs
+++ b/Standard.Agents/Brokers/Skills/SkillBroker.cs
@@ -19,9 +19,9 @@ public sealed class SkillBroker : ISkillBroker
     {
         List<string> skills = [];
 
-                IOrderedEnumerable<string> skillFilePaths =
-            Directory.EnumerateFiles(this.skillsPath, SkillFilePattern)
-                .OrderBy(skillFilePath => skillFilePath, StringComparer.Ordinal);
+        IOrderedEnumerable<string> skillFilePaths =
+    Directory.EnumerateFiles(this.skillsPath, SkillFilePattern)
+        .OrderBy(skillFilePath => skillFilePath, StringComparer.Ordinal);
 
         foreach (string skillFilePath in skillFilePaths)
         {

--- a/Standard.Agents/Brokers/Tools/ToolBroker.cs
+++ b/Standard.Agents/Brokers/Tools/ToolBroker.cs
@@ -11,10 +11,10 @@ public sealed class ToolBroker : IToolBroker
 {
     private readonly IReadOnlyDictionary<string, ITool> tools;
 
-        public ToolBroker(IEnumerable<ITool> tools) =>
-        this.tools = tools.ToDictionary(
-            tool => tool.Name,
-            StringComparer.OrdinalIgnoreCase);
+    public ToolBroker(IEnumerable<ITool> tools) =>
+    this.tools = tools.ToDictionary(
+        tool => tool.Name,
+        StringComparer.OrdinalIgnoreCase);
 
     public ValueTask<bool> HasAsync(string name) =>
         ValueTask.FromResult(this.tools.ContainsKey(name));

--- a/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
@@ -70,11 +70,11 @@ public sealed class VerifierBroker : IVerifierBroker
         return ToScore(chatCompletionResponse.Choices[0].Message.Content);
     }
 
-                        private static double ToScore(string content) =>
-        double.Parse(
-            content.Trim(),
-            NumberStyles.Float,
-            CultureInfo.InvariantCulture);
+    private static double ToScore(string content) =>
+double.Parse(
+content.Trim(),
+NumberStyles.Float,
+CultureInfo.InvariantCulture);
 
     private async ValueTask<TResult> PostAsync<TContent, TResult>(
         string relativeUrl,

--- a/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
@@ -9,14 +9,14 @@ public sealed record AgentContext
 {
     public string Prompt { get; init; } = "";
 
-        public string SystemPrompt { get; init; } = "";
+    public string SystemPrompt { get; init; } = "";
     public IReadOnlyList<string> Observations { get; init; } = [];
 
-        public string Intent { get; init; } = "";
+    public string Intent { get; init; } = "";
     public string DirectionType { get; init; } = "";
     public string Payload { get; init; } = "";
     public string RawReply { get; init; } = "";
 
-        public string Result { get; init; } = "";
+    public string Result { get; init; } = "";
     public AgentStatus Status { get; init; }
 }

--- a/Standard.Agents/Models/Orchestrations/Agents/AgentStatus.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentStatus.cs
@@ -7,7 +7,7 @@ namespace Standard.Agents.Models.Orchestrations.Agents;
 
 public enum AgentStatus
 {
-        Working = 0,
+    Working = 0,
     Responded = 1,
     AwaitingInput = 2,
     Refused = 3,

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Exceptions.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Exceptions.cs
@@ -13,7 +13,7 @@ public partial class AgentCoordinationService
 {
     private delegate ValueTask<string> ReturningStringFunction();
 
-                    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
     {
         try
         {

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -14,7 +14,7 @@ namespace Standard.Agents.Services.Coordinations;
 
 public partial class AgentCoordinationService : IAgentCoordinationService
 {
-                        private const int MaxTurns = 7;
+    private const int MaxTurns = 7;
 
     private readonly IDataOrchestrationService dataOrchestrationService;
     private readonly IDecisionOrchestrationService decisionOrchestrationService;
@@ -43,7 +43,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
         await this.logBroker.ResetAsync();
 
-                                AgentContext context = new() { Prompt = prompt };
+        AgentContext context = new() { Prompt = prompt };
 
         for (int turn = 1; turn <= MaxTurns; turn++)
         {
@@ -53,7 +53,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
             await LogTurnAsync(turn, context);
 
-                                                if (context.Status != AgentStatus.Working)
+            if (context.Status != AgentStatus.Working)
             {
                 break;
             }

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.Exceptions.cs
@@ -25,9 +25,9 @@ public partial class BrainService
         }
         catch (HttpResponseBadRequestException httpResponseBadRequestException)
         {
-                        var invalidBrainException =
-                new InvalidBrainException(
-                    message: "Invalid brain request. Please correct the error and try again.");
+            var invalidBrainException =
+    new InvalidBrainException(
+        message: "Invalid brain request. Please correct the error and try again.");
 
             invalidBrainException.AddData(httpResponseBadRequestException.Data);
 

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.Validations.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Services.Foundations.Brains;
 
 public partial class BrainService
 {
-            private static void ValidateUserPrompt(string userPrompt)
+    private static void ValidateUserPrompt(string userPrompt)
     {
         if (string.IsNullOrWhiteSpace(userPrompt))
         {

--- a/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.Exceptions.cs
@@ -13,7 +13,7 @@ public partial class ExternalToolService
 {
     private delegate ValueTask<string> ReturningStringFunction();
 
-                private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
     {
         try
         {

--- a/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.Validations.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Services.Foundations.ExternalTools;
 
 public partial class ExternalToolService
 {
-                private static void ValidateName(string name)
+    private static void ValidateName(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
         {

--- a/Standard.Agents/Services/Foundations/Gates/GateService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Gates/GateService.Validations.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Services.Foundations.Gates;
 
 public partial class GateService
 {
-                private static void ValidateScreen(string gatePrompt, string input)
+    private static void ValidateScreen(string gatePrompt, string input)
     {
         if (string.IsNullOrWhiteSpace(gatePrompt) || string.IsNullOrWhiteSpace(input))
         {

--- a/Standard.Agents/Services/Foundations/InternalTools/InternalToolService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/InternalTools/InternalToolService.Exceptions.cs
@@ -13,7 +13,7 @@ public partial class InternalToolService
     private delegate ValueTask<bool> ReturningBooleanFunction();
     private delegate ValueTask<string> ReturningStringFunction();
 
-            private async ValueTask<bool> TryCatch(ReturningBooleanFunction returningBooleanFunction)
+    private async ValueTask<bool> TryCatch(ReturningBooleanFunction returningBooleanFunction)
     {
         try
         {
@@ -34,7 +34,7 @@ public partial class InternalToolService
         }
     }
 
-        private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
     {
         try
         {

--- a/Standard.Agents/Services/Foundations/InternalTools/InternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/InternalTools/InternalToolService.cs
@@ -29,11 +29,11 @@ public partial class InternalToolService : IInternalToolService
         return await this.toolBroker.HasAsync(name);
     });
 
-                public ValueTask<string> RunAsync(string name, string input) =>
-    TryCatch(async () =>
-    {
-        ValidateName(name);
+    public ValueTask<string> RunAsync(string name, string input) =>
+TryCatch(async () =>
+{
+    ValidateName(name);
 
-        return await this.toolBroker.RunAsync(name, input);
-    });
+    return await this.toolBroker.RunAsync(name, input);
+});
 }

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.Exceptions.cs
@@ -13,7 +13,7 @@ public partial class JudgeService
 {
     private delegate ValueTask<double> ReturningScoreFunction();
 
-                private async ValueTask<double> TryCatch(ReturningScoreFunction returningScoreFunction)
+    private async ValueTask<double> TryCatch(ReturningScoreFunction returningScoreFunction)
     {
         try
         {

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.Validations.cs
@@ -21,7 +21,7 @@ public partial class JudgeService
         }
     }
 
-                                private static void ValidateScore(double score)
+    private static void ValidateScore(double score)
     {
         bool isWithinRange = score >= MinimumScore && score <= MaximumScore;
 

--- a/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.Exceptions.cs
@@ -11,7 +11,7 @@ namespace Standard.Agents.Services.Foundations.Knowledges;
 public partial class KnowledgeService
 {
     private delegate ValueTask<IReadOnlyList<string>> ReturningDocumentsFunction();
-    
+
     private async ValueTask<IReadOnlyList<string>> TryCatch(
         ReturningDocumentsFunction returningDocumentsFunction)
     {
@@ -35,7 +35,7 @@ public partial class KnowledgeService
         {
             throw await CreateAndLogCriticalDependencyExceptionAsync(unauthorizedAccessException);
         }
-                        catch (IOException ioException)
+        catch (IOException ioException)
         {
             throw await CreateAndLogDependencyExceptionAsync(ioException);
         }

--- a/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.Validations.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Services.Foundations.Knowledges;
 
 public partial class KnowledgeService
 {
-                private static void ValidateQuery(string query)
+    private static void ValidateQuery(string query)
     {
         if (string.IsNullOrWhiteSpace(query))
         {

--- a/Standard.Agents/Services/Foundations/Memorys/MemoryService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Memorys/MemoryService.Exceptions.cs
@@ -36,7 +36,7 @@ public partial class MemoryService
         {
             throw await CreateAndLogCriticalDependencyExceptionAsync(unauthorizedAccessException);
         }
-                        catch (IOException ioException)
+        catch (IOException ioException)
         {
             throw await CreateAndLogDependencyExceptionAsync(ioException);
         }
@@ -51,7 +51,7 @@ public partial class MemoryService
         }
     }
 
-                private async ValueTask TryCatch(ReturningNothingFunction returningNothingFunction)
+    private async ValueTask TryCatch(ReturningNothingFunction returningNothingFunction)
     {
         try
         {

--- a/Standard.Agents/Services/Foundations/Memorys/MemoryService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Memorys/MemoryService.Validations.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Services.Foundations.Memorys;
 
 public partial class MemoryService
 {
-            private static void ValidateMemory(string memory)
+    private static void ValidateMemory(string memory)
     {
         if (string.IsNullOrWhiteSpace(memory))
         {

--- a/Standard.Agents/Services/Foundations/Returns/ReturnService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Returns/ReturnService.Exceptions.cs
@@ -12,7 +12,7 @@ public partial class ReturnService
 {
     private delegate ValueTask<string> ReturningStringFunction();
 
-            private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
     {
         try
         {

--- a/Standard.Agents/Services/Foundations/Skills/SkillService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Skills/SkillService.Exceptions.cs
@@ -18,7 +18,7 @@ public partial class SkillService
         {
             return await returningStringFunction();
         }
-                        catch (FileNotFoundException fileNotFoundException)
+        catch (FileNotFoundException fileNotFoundException)
         {
             var failedSkillDependencyException =
                 new FailedSkillDependencyException(

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Exceptions.cs
@@ -16,8 +16,8 @@ public partial class DataOrchestrationService
 {
     private delegate ValueTask<AgentContext> ReturningContextFunction();
 
-                    private async ValueTask<AgentContext> TryCatch(
-        ReturningContextFunction returningContextFunction)
+    private async ValueTask<AgentContext> TryCatch(
+ReturningContextFunction returningContextFunction)
     {
         try
         {

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Validations.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Validations.cs
@@ -10,7 +10,7 @@ namespace Standard.Agents.Services.Orchestrations.Data;
 
 public partial class DataOrchestrationService
 {
-            private static void ValidateContext(AgentContext context)
+    private static void ValidateContext(AgentContext context)
     {
         if (context is null)
         {

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -38,7 +38,7 @@ public partial class DataOrchestrationService : IDataOrchestrationService
         string systemPrompt = await this.skillService.RetrieveSkillsAsync();
         IReadOnlyList<string> memories = await this.memoryService.RecallMemoriesAsync();
 
-                                return context with
+        return context with
         {
             SystemPrompt = systemPrompt,
             Observations = [.. context.Observations, .. memories]

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Exceptions.cs
@@ -16,8 +16,8 @@ public partial class DecisionOrchestrationService
 {
     private delegate ValueTask<AgentContext> ReturningContextFunction();
 
-                private async ValueTask<AgentContext> TryCatch(
-        ReturningContextFunction returningContextFunction)
+    private async ValueTask<AgentContext> TryCatch(
+ReturningContextFunction returningContextFunction)
     {
         try
         {

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -3,12 +3,12 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Text;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Foundations.Brains;
 using Standard.Agents.Services.Foundations.Gates;
 using Standard.Agents.Services.Foundations.Judges;
-using System.Text;
 
 namespace Standard.Agents.Services.Orchestrations.Decision;
 
@@ -21,7 +21,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
     private const string ReturnResponseDirection = "ReturnResponse";
     private const string RespondIntent = "Respond";
 
-        private const double MinimumAcceptableScore = 0.3;
+    private const double MinimumAcceptableScore = 0.3;
 
     private readonly IGateService gateService;
     private readonly IBrainService brainService;
@@ -45,7 +45,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
     {
         ValidateContext(context);
 
-                        string verdict =
+        string verdict =
             await this.gateService.ScreenAsync(context.SystemPrompt, context.Prompt);
 
         if (IsRefusal(verdict))
@@ -59,10 +59,10 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             };
         }
 
-                string reply =
+        string reply =
             (await this.brainService.GenerateAsync(
-                context.SystemPrompt,
-                BuildUserMessage(context))).Trim();
+                systemPrompt: context.SystemPrompt,
+                userPrompt: BuildUserMessage(context))).Trim();
 
         AgentContext decided = Interpret(context, reply);
 
@@ -73,21 +73,24 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         if (isFinalAnswer is false)
         {
-                        return decided;
+            return decided;
         }
 
-                        double score =
-            await this.judgeService.EvaluateAsync(context.SystemPrompt, decided.Payload);
+        double score = 
+            await this.judgeService.EvaluateAsync(
+                judgePrompt: context.SystemPrompt,
+                candidate: decided.Payload);
 
         if (score < MinimumAcceptableScore)
         {
-                                                return context with
+            return context with
             {
                 Observations =
                 [
                     .. context.Observations,
                     $"A previous draft was rejected on review: {decided.Payload}"
                 ],
+
                 Status = AgentStatus.Working
             };
         }
@@ -95,10 +98,10 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
         return decided;
     });
 
-                private static bool IsRefusal(string verdict) =>
-        verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase);
+    private static bool IsRefusal(string verdict) =>
+verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase);
 
-            private static string BuildUserMessage(AgentContext context)
+    private static string BuildUserMessage(AgentContext context)
     {
         StringBuilder userMessage = new();
 
@@ -119,16 +122,16 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
     private static AgentContext Interpret(AgentContext context, string reply)
     {
-                        string firstLine = reply.Split('\n')[0].Trim();
+        string firstLine = reply.Split('\n')[0].Trim();
 
         bool modelChoseToAct =
             firstLine.StartsWith(ActionPrefix, StringComparison.OrdinalIgnoreCase);
 
         if (modelChoseToAct)
         {
-                                    string[] toolCall =
+            string[] toolCall =
                 firstLine[ActionPrefix.Length..]
-                    .Split(':', 2, StringSplitOptions.TrimEntries);
+                .Split(':', 2, StringSplitOptions.TrimEntries);
 
             string toolName = toolCall[0];
             string toolInput = toolCall.Length > 1 ? toolCall[1] : string.Empty;
@@ -142,7 +145,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             };
         }
 
-                                        string answer = reply.StartsWith(FinalPrefix, StringComparison.OrdinalIgnoreCase)
+        string answer = reply.StartsWith(FinalPrefix, StringComparison.OrdinalIgnoreCase)
             ? reply[FinalPrefix.Length..].Trim()
             : reply;
 

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Exceptions.cs
@@ -16,8 +16,8 @@ public partial class DirectionOrchestrationService
 {
     private delegate ValueTask<AgentContext> ReturningContextFunction();
 
-                private async ValueTask<AgentContext> TryCatch(
-        ReturningContextFunction returningContextFunction)
+    private async ValueTask<AgentContext> TryCatch(
+ReturningContextFunction returningContextFunction)
     {
         try
         {

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -40,7 +40,7 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
 
         if (IsTerminal(context.DirectionType))
         {
-                                    string result = await this.returnService.ReturnAsync(context.Payload);
+            string result = await this.returnService.ReturnAsync(context.Payload);
 
             return context with
             {
@@ -51,11 +51,11 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
 
         bool isLocalTool = await this.internalToolService.HandlesAsync(context.DirectionType);
 
-                        string output = isLocalTool
-            ? await this.internalToolService.RunAsync(context.DirectionType, context.Payload)
-            : await this.externalToolService.CallAsync(context.DirectionType, context.Payload);
+        string output = isLocalTool
+? await this.internalToolService.RunAsync(context.DirectionType, context.Payload)
+: await this.externalToolService.CallAsync(context.DirectionType, context.Payload);
 
-                                                                        return context with
+        return context with
         {
             Result = output,
             Observations = [.. context.Observations, $"{context.DirectionType}: {output}"],

--- a/Standard.Agents/StandardAgent.Validations.cs
+++ b/Standard.Agents/StandardAgent.Validations.cs
@@ -9,9 +9,9 @@ namespace Standard.Agents;
 
 public sealed partial class StandardAgent
 {
-                            private void ValidateComposition()
+    private void ValidateComposition()
     {
-                if (this.generatorBroker is null && this.brainSettings is null)
+        if (this.generatorBroker is null && this.brainSettings is null)
         {
             throw new InvalidAgentCompositionException(
                 message:
@@ -19,7 +19,7 @@ public sealed partial class StandardAgent
                         + "or UseGenerator(broker) before processing a prompt.");
         }
 
-                        if (this.classifierBroker is null && this.gateSettings is null && this.brainSettings is null)
+        if (this.classifierBroker is null && this.gateSettings is null && this.brainSettings is null)
         {
             throw new InvalidAgentCompositionException(
                 message:


### PR DESCRIPTION
Puts `System.*` usings back above `Standard.Agents.*`.

## My bug

The restructure (#90) sorted usings alphabetically to keep them tidy. **`Standard` sorts before `System`** — `a` before `y` — so the sort quietly pushed every `System` using **below** the `Standard.Agents` ones, against the C# convention of System-first.

```diff
+using System.Text;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
-using System.Text;
```

It hit **14 files**. The build never cared, so nothing caught it — a style regression is invisible to CI.

The fix was already in the working tree, made by hand while I was pushing. This commits it rather than losing it. A sweep confirms **zero files** are left in the wrong order.

## Also in here

Named arguments on the Brain and Judge calls in `DecisionOrchestrationService`:

```csharp
await this.brainService.GenerateAsync(
    systemPrompt: context.SystemPrompt,
    userPrompt: BuildUserMessage(context))

await this.judgeService.EvaluateAsync(
    judgePrompt: context.SystemPrompt,
    candidate: decided.Payload)
```

Both take **two strings in a row**. The names are what stop an argument swap from compiling cleanly and failing silently — a Judge handed the draft as its rubric would score something nobody asked about, and every test would still pass.

## Verification

```
build       → 0 Warning(s), 0 Error(s)
test        → 198/198
conformance → 6 passed, 0 failed
```
