### PR TITLE
MEDIUM CODE RUB: Name Arguments And Fix Indentation Per The Standard

### DIFF
--- a/Standard.Agents.Conformance/Harness.cs
+++ b/Standard.Agents.Conformance/Harness.cs
@@ -30,7 +30,7 @@ public sealed class ScriptedGeneratorBroker : IGeneratorBroker
 
         return ValueTask.FromResult(reply);
     }
-}
+    }
 
 public sealed class StubTool : ITool
 {
@@ -46,13 +46,13 @@ public sealed class StubTool : ITool
 
     public ValueTask<string> ExecuteAsync(string input) =>
         ValueTask.FromResult(this.output);
-}
+    }
 
 public sealed class StubSkillBroker : ISkillBroker
 {
     public ValueTask<string> SelectSkillsAsync() =>
         ValueTask.FromResult("You are a test agent.");
-}
+    }
 
 public sealed class StubMemoryBroker : IMemoryBroker
 {
@@ -61,31 +61,31 @@ public sealed class StubMemoryBroker : IMemoryBroker
 
     public ValueTask InsertMemoryAsync(string memory) =>
         ValueTask.CompletedTask;
-}
+    }
 
 public sealed class StubKnowledgeBroker : IKnowledgeBroker
 {
     public ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query) =>
         ValueTask.FromResult<IReadOnlyList<string>>([]);
-}
+    }
 
 public sealed class AllowingClassifierBroker : IClassifierBroker
 {
     public ValueTask<string> ClassifyAsync(string systemPrompt, string input) =>
         ValueTask.FromResult("allow");
-}
+    }
 
 public sealed class ApprovingVerifierBroker : IVerifierBroker
 {
     public ValueTask<double> VerifyAsync(string systemPrompt, string candidate) =>
         ValueTask.FromResult(1.0);
-}
+    }
 
 public sealed class NotConfiguredMcpBroker : IMcpBroker
 {
     public ValueTask<string> CallAsync(string name, string input) =>
         ValueTask.FromResult($"[external '{name}' not configured]");
-}
+    }
 
 public sealed class NullLogBroker : ILogBroker
 {
@@ -96,7 +96,7 @@ public sealed class NullLogBroker : ILogBroker
 
     public ValueTask WriteAsync(string content) =>
         ValueTask.CompletedTask;
-}
+    }
 
 public sealed record Vector(
     string Name,

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -53,7 +53,7 @@ foreach (string vectorFile in
         Console.WriteLine($"        expected: {Show(expectation)}");
         Console.WriteLine($"        actual:   {Show(actualResult)}");
     }
-}
+    }
 
 Console.WriteLine();
 Console.WriteLine($"{passed} passed, {failed} failed");
@@ -63,7 +63,7 @@ return failed == 0 ? 0 : 1;
 async Task<string> RunVectorAsync(Vector vector)
 {
     IEnumerable<ITool> tools =
-        (vector.Tools ?? []).Select(pair => (ITool)new StubTool(pair.Key, pair.Value));
+        (vector.Tools ?? []).Select(pair => (ITool)new StubTool(name: pair.Key, output: pair.Value));
 
     IAgent agent = new StandardAgent()
         .UseSkills(new StubSkillBroker())
@@ -77,7 +77,7 @@ async Task<string> RunVectorAsync(Vector vector)
         .Tools(tools);
 
     return await agent.ProcessPromptAsync(vector.Prompt);
-}
+    }
 
 static string Show(string value) =>
     value.Replace("\n", "\\n").Replace("\r", "\\r");
@@ -96,4 +96,4 @@ static string FindRepositoryRoot()
         ?? throw new DirectoryNotFoundException(
             "Could not find the repository root — no 'conformance' directory found "
                 + "walking up from the executable.");
-}
+    }

--- a/Standard.Agents.Demo/Program.cs
+++ b/Standard.Agents.Demo/Program.cs
@@ -19,7 +19,7 @@ string apiKey =
     Environment.GetEnvironmentVariable("STANDARD_AGENTS_APIKEY") ?? string.Empty;
 
 var agent = new StandardAgent()
-    .Skills("Skills")
+    .Skills(path: "Skills")
     .Brain(
         apiUrl: settings.GetValue<string>("ApiUrl")!,
         apiKey: apiKey,
@@ -27,7 +27,7 @@ var agent = new StandardAgent()
         temperature: settings.GetValue<double>("Temperature"),
         maxTokens: settings.GetValue<int>("MaxTokens"))
     .Tool(new CalculatorTool())
-    .LogTo("log.txt");
+    .LogTo(path: "log.txt");
 
 string prompt = args.Length > 0
     ? string.Join(' ', args)
@@ -58,4 +58,4 @@ catch (Exception exception)
     }
 
     return 1;
-}
+    }

--- a/Standard.Agents.Demo/Tools/CalculatorTool.cs
+++ b/Standard.Agents.Demo/Tools/CalculatorTool.cs
@@ -30,4 +30,4 @@ WholeNumberRegex().Replace(expression, "${0}.0");
 
     [GeneratedRegex(@"(?<![\d.])\d+(?![\d.])")]
     private static partial Regex WholeNumberRegex();
-}
+        }

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -64,7 +64,7 @@ public class StandardAgentTests
         StandardAgent agent = CreateFullyStubbedAgent("FINAL: 42");
 
         // when
-        string actualResult = await agent.ProcessPromptAsync("what is the answer?");
+        string actualResult = await agent.ProcessPromptAsync(prompt: "what is the answer?");
 
         // then
         actualResult.Should().Be("42");
@@ -78,12 +78,12 @@ public class StandardAgentTests
 
         // when
         StandardAgent chained = agent
-            .Skills("Skills")
-            .Brain("https://x/", "key", "model")
-            .Memory("memory.txt")
-            .Knowledge("Knowledge")
-            .Mcp("https://mcp/")
-            .LogTo("log.txt");
+            .Skills(path: "Skills")
+            .Brain(apiUrl: "https://x/", apiKey: "key", model: "model")
+            .Memory(path: "memory.txt")
+            .Knowledge(path: "Knowledge")
+            .Mcp(endpointUrl: "https://mcp/")
+            .LogTo(path: "log.txt");
 
         // then
         chained.Should().BeSameAs(agent);
@@ -95,7 +95,7 @@ public class StandardAgentTests
         // given
         StandardAgent agent = CreateFullyStubbedAgent("FINAL: first");
 
-        string firstResult = await agent.ProcessPromptAsync("prompt");
+        string firstResult = await agent.ProcessPromptAsync(prompt: "prompt");
 
         var newGenerator = new Mock<IGeneratorBroker>();
         newGenerator.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
@@ -103,7 +103,7 @@ public class StandardAgentTests
 
         // when
         agent.UseGenerator(newGenerator.Object);
-        string secondResult = await agent.ProcessPromptAsync("prompt");
+        string secondResult = await agent.ProcessPromptAsync(prompt: "prompt");
 
         // then
         firstResult.Should().Be("first");
@@ -117,7 +117,7 @@ public class StandardAgentTests
         var agent = new StandardAgent();
 
         // when
-        ValueTask<string> processTask = agent.ProcessPromptAsync("prompt");
+        ValueTask<string> processTask = agent.ProcessPromptAsync(prompt: "prompt");
 
         InvalidAgentCompositionException actualException =
             await Assert.ThrowsAsync<InvalidAgentCompositionException>(
@@ -163,7 +163,7 @@ public class StandardAgentTests
     .UseLog(logBroker.Object);
 
         // when
-        string actualResult = await agent.ProcessPromptAsync("prompt");
+        string actualResult = await agent.ProcessPromptAsync(prompt: "prompt");
 
         // then
         actualResult.Should().Be("ok");
@@ -179,7 +179,7 @@ public class StandardAgentTests
             .UseGenerator(generatorBroker.Object);
 
         // when
-        ValueTask<string> processTask = agent.ProcessPromptAsync("prompt");
+        ValueTask<string> processTask = agent.ProcessPromptAsync(prompt: "prompt");
 
         InvalidAgentCompositionException actualException =
             await Assert.ThrowsAsync<InvalidAgentCompositionException>(
@@ -221,7 +221,7 @@ public class StandardAgentTests
     .UseLog(new Mock<ILogBroker>().Object);
 
         // when
-        string actualResult = await agent.ProcessPromptAsync("prompt");
+        string actualResult = await agent.ProcessPromptAsync(prompt: "prompt");
 
         // then
         actualResult.Should().Be("composed");
@@ -265,9 +265,9 @@ public class StandardAgentTests
             .UseLog(new Mock<ILogBroker>().Object);
 
         // when
-        string actualResult = await agent.ProcessPromptAsync("weather today?");
+        string actualResult = await agent.ProcessPromptAsync(prompt: "weather today?");
 
         // then
         actualResult.Should().Be("could not get weather");
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Exceptions.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Exceptions.ProcessPrompt.cs
@@ -119,4 +119,4 @@ Xeption orchestrationException)
             broker.LogErrorAsync(It.Is(SameExceptionAs(expectedException))),
                 Times.Once);
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
@@ -240,4 +240,4 @@ Times.Exactly(7));
 
         recalledContexts[1].Observations.Should().BeEmpty();
     }
-}
+                    }

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.cs
@@ -76,9 +76,11 @@ public partial class AgentCoordinationServiceTests
         new()
         {
             new Models.Orchestrations.Agents.Exceptions.AgentOrchestrationDependencyException(
-                "orchestration dependency", new Xeption("inner")),
+                message: "orchestration dependency",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Orchestrations.Agents.Exceptions.AgentOrchestrationServiceException(
-                "orchestration service", new Xeption("inner"))
+                message: "orchestration service",
+                innerException: new Xeption(message: "inner"))
         };
-}
+        }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Exceptions.Generate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Exceptions.Generate.cs
@@ -14,21 +14,21 @@ namespace Standard.Agents.Tests.Unit.Services.Foundations.Brains;
 public partial class BrainServiceTests
 {
     public static TheoryData<Exception> CriticalDependencyExceptions() =>
-new()
-{
+        new()
+        {
             new HttpResponseUnauthorizedException(),
             new HttpResponseForbiddenException(),
             new HttpResponseNotFoundException(),
             new HttpResponseUrlNotFoundException(),
             new HttpRequestException()
-};
+        };
 
     public static TheoryData<Exception> DependencyExceptions() =>
-new()
-{
+        new()
+        {
             new HttpResponseInternalServerErrorException(),
             new HttpResponseServiceUnavailableException()
-};
+        };
 
     [Theory]
     [MemberData(nameof(CriticalDependencyExceptions))]
@@ -218,4 +218,4 @@ new()
         this.generatorBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.Generate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.Generate.cs
@@ -69,4 +69,4 @@ public partial class BrainServiceTests
         this.generatorBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Validations.Generate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Validations.Generate.cs
@@ -86,4 +86,4 @@ string? emptySystemPrompt)
         this.generatorBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.cs
@@ -34,4 +34,4 @@ public partial class BrainServiceTests
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Exceptions.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Exceptions.Call.cs
@@ -218,4 +218,4 @@ Exception criticalDependencyException)
         this.mcpBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Logic.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Logic.Call.cs
@@ -68,4 +68,4 @@ public partial class ExternalToolServiceTests
         this.mcpBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Validations.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Validations.Call.cs
@@ -55,4 +55,4 @@ Times.Never);
         this.mcpBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.cs
@@ -34,4 +34,4 @@ public partial class ExternalToolServiceTests
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Exceptions.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Exceptions.Screen.cs
@@ -218,4 +218,4 @@ Exception criticalDependencyException)
         this.classifierBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Logic.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Logic.Screen.cs
@@ -98,4 +98,4 @@ public partial class GateServiceTests
         this.classifierBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Validations.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Validations.Screen.cs
@@ -99,4 +99,4 @@ string? invalidGatePrompt)
         this.classifierBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.cs
@@ -34,4 +34,4 @@ public partial class GateServiceTests
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Exceptions.Handles.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Exceptions.Handles.cs
@@ -58,4 +58,4 @@ public partial class InternalToolServiceTests
         this.toolBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Exceptions.Run.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Exceptions.Run.cs
@@ -109,4 +109,4 @@ public partial class InternalToolServiceTests
         this.toolBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Logic.Handles.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Logic.Handles.cs
@@ -39,4 +39,4 @@ public partial class InternalToolServiceTests
         this.toolBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Logic.Run.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Logic.Run.cs
@@ -70,4 +70,4 @@ public partial class InternalToolServiceTests
         this.toolBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Validations.Handles.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Validations.Handles.cs
@@ -53,4 +53,4 @@ public partial class InternalToolServiceTests
         this.toolBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Validations.Run.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.Validations.Run.cs
@@ -86,4 +86,4 @@ public partial class InternalToolServiceTests
         this.toolBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/InternalTools/InternalToolServiceTests.cs
@@ -34,4 +34,4 @@ public partial class InternalToolServiceTests
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Logic.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Logic.Evaluate.cs
@@ -68,4 +68,4 @@ public partial class JudgeServiceTests
         this.verifierBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Validations.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Validations.Evaluate.cs
@@ -149,4 +149,4 @@ double outOfRangeScore)
         this.verifierBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.cs
@@ -34,4 +34,4 @@ public partial class JudgeServiceTests
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Exceptions.RetrieveKnowledge.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Exceptions.RetrieveKnowledge.cs
@@ -159,4 +159,4 @@ public partial class KnowledgeServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Logic.RetrieveKnowledge.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Logic.RetrieveKnowledge.cs
@@ -67,4 +67,4 @@ public partial class KnowledgeServiceTests
         this.knowledgeBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Validations.RetrieveKnowledge.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Validations.RetrieveKnowledge.cs
@@ -53,4 +53,4 @@ string? invalidQuery)
         this.knowledgeBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.cs
@@ -37,4 +37,4 @@ public partial class KnowledgeServiceTests
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Exceptions.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Exceptions.cs
@@ -200,4 +200,4 @@ public partial class MemoryServiceTests
         this.memoryBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Logic.RecallMemories.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Logic.RecallMemories.cs
@@ -64,4 +64,4 @@ public partial class MemoryServiceTests
         this.memoryBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Logic.Remember.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Logic.Remember.cs
@@ -28,4 +28,4 @@ public partial class MemoryServiceTests
         this.memoryBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Validations.Remember.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Validations.Remember.cs
@@ -53,4 +53,4 @@ string? invalidMemory)
         this.memoryBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.cs
@@ -37,4 +37,4 @@ public partial class MemoryServiceTests
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Returns/ReturnServiceTests.Logic.Return.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Returns/ReturnServiceTests.Logic.Return.cs
@@ -26,4 +26,4 @@ public partial class ReturnServiceTests
 
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Returns/ReturnServiceTests.Validations.Return.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Returns/ReturnServiceTests.Validations.Return.cs
@@ -48,4 +48,4 @@ public partial class ReturnServiceTests
 
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Returns/ReturnServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Returns/ReturnServiceTests.cs
@@ -30,4 +30,4 @@ public partial class ReturnServiceTests
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.Exceptions.RetrieveSkills.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.Exceptions.RetrieveSkills.cs
@@ -154,4 +154,4 @@ public partial class SkillServiceTests
         this.skillBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.Logic.RetrieveSkills.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.Logic.RetrieveSkills.cs
@@ -36,4 +36,4 @@ public partial class SkillServiceTests
         this.skillBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.cs
@@ -34,4 +34,4 @@ public partial class SkillServiceTests
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Exceptions.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Exceptions.Recall.cs
@@ -164,4 +164,4 @@ Xeption foundationException)
 
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Recall.cs
@@ -122,4 +122,4 @@ public partial class DataOrchestrationServiceTests
         // then
         actualContext.Observations.Should().Contain(priorObservation);
     }
-}
+        }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
@@ -49,28 +49,34 @@ public partial class DataOrchestrationServiceTests
         actualException => actualException.SameExceptionAs(expectedException);
 
     public static TheoryData<Xeption> DependencyValidationExceptions() =>
-new()
-{
+        new()
+        {
             new Models.Foundations.Memorys.Exceptions.MemoryValidationException(
-                "memory validation", new Xeption("inner")),
+                message: "memory validation",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.Knowledges.Exceptions.KnowledgeValidationException(
-                "knowledge validation", new Xeption("inner"))
-};
+                message: "knowledge validation",
+                innerException: new Xeption(message: "inner"))
+        };
 
     public static TheoryData<Xeption> DependencyExceptions() =>
         new()
         {
             new Models.Foundations.Skills.Exceptions.SkillDependencyException(
-                "skill dependency", new Xeption("inner")),
+                message: "skill dependency",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.Skills.Exceptions.SkillServiceException(
-                "skill service", new Xeption("inner")),
+                message: "skill service",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.Memorys.Exceptions.MemoryDependencyException(
-                "memory dependency", new Xeption("inner")),
+                message: "memory dependency",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.Knowledges.Exceptions.KnowledgeDependencyException(
-                "knowledge dependency", new Xeption("inner"))
+                message: "knowledge dependency",
+                innerException: new Xeption(message: "inner"))
         };
-}
+        }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Exceptions.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Exceptions.Think.cs
@@ -164,4 +164,4 @@ Xeption foundationException)
 
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
@@ -174,4 +174,4 @@ public partial class DecisionOrchestrationServiceTests
             service.EvaluateAsync(inputContext.SystemPrompt, "the draft"),
                 Times.Once);
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
@@ -187,4 +187,4 @@ public partial class DecisionOrchestrationServiceTests
                 It.Is<string>(userMessage => userMessage.Contains(observation))),
                     Times.Once);
     }
-}
+        }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
@@ -50,7 +50,7 @@ public partial class DecisionOrchestrationServiceTests
         };
 
     private void SetupGateAllows() =>
-this.gateServiceMock.Setup(service =>
+        this.gateServiceMock.Setup(service =>
     service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
         .ReturnsAsync("allow");
 
@@ -63,34 +63,42 @@ this.gateServiceMock.Setup(service =>
         actualException => actualException.SameExceptionAs(expectedException);
 
     public static TheoryData<Xeption> DependencyValidationExceptions() =>
-new()
-{
+        new()
+        {
             new Models.Foundations.Gates.Exceptions.GateValidationException(
-                "gate validation", new Xeption("inner")),
+                message: "gate validation",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.Brains.Exceptions.BrainValidationException(
-                "brain validation", new Xeption("inner")),
+                message: "brain validation",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.Judges.Exceptions.JudgeValidationException(
-                "judge validation", new Xeption("inner")),
+                message: "judge validation",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.Brains.Exceptions.BrainDependencyValidationException(
-                "brain dependency validation", new Xeption("inner"))
-};
+                message: "brain dependency validation",
+                innerException: new Xeption(message: "inner"))
+        };
 
     public static TheoryData<Xeption> DependencyExceptions() =>
         new()
         {
             new Models.Foundations.Gates.Exceptions.GateDependencyException(
-                "gate dependency", new Xeption("inner")),
+                message: "gate dependency",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.Gates.Exceptions.GateServiceException(
-                "gate service", new Xeption("inner")),
+                message: "gate service",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.Brains.Exceptions.BrainDependencyException(
-                "brain dependency", new Xeption("inner")),
+                message: "brain dependency",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.Judges.Exceptions.JudgeDependencyException(
-                "judge dependency", new Xeption("inner"))
+                message: "judge dependency",
+                innerException: new Xeption(message: "inner"))
         };
-}
+        }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Exceptions.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Exceptions.Act.cs
@@ -164,4 +164,4 @@ Xeption foundationException)
 
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
@@ -229,4 +229,4 @@ public partial class DirectionOrchestrationServiceTests
         actualContext.Observations.Should()
             .ContainSingle(o => o.Contains("calculator") && o.Contains("2"));
     }
-}
+    }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.cs
@@ -59,25 +59,31 @@ public partial class DirectionOrchestrationServiceTests
         new()
         {
             new Models.Foundations.InternalTools.Exceptions.InternalToolValidationException(
-                "internal tool validation", new Xeption("inner")),
+                message: "internal tool validation",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.ExternalTools.Exceptions.ExternalToolValidationException(
-                "external tool validation", new Xeption("inner"))
+                message: "external tool validation",
+                innerException: new Xeption(message: "inner"))
         };
 
     public static TheoryData<Xeption> DependencyExceptions() =>
         new()
         {
             new Models.Foundations.InternalTools.Exceptions.InternalToolDependencyException(
-                "internal tool dependency", new Xeption("inner")),
+                message: "internal tool dependency",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.InternalTools.Exceptions.InternalToolServiceException(
-                "internal tool service", new Xeption("inner")),
+                message: "internal tool service",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.ExternalTools.Exceptions.ExternalToolDependencyException(
-                "external tool dependency", new Xeption("inner")),
+                message: "external tool dependency",
+                innerException: new Xeption(message: "inner")),
 
             new Models.Foundations.Returns.Exceptions.ReturnServiceException(
-                "return service", new Xeption("inner"))
+                message: "return service",
+                innerException: new Xeption(message: "inner"))
         };
-}
+        }

--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
@@ -31,7 +31,7 @@ public class AgentToolTests
             agent.ProcessPromptAsync(randomInput))
                 .ReturnsAsync(randomAnswer);
 
-        var agentTool = new AgentTool(randomName, nestedAgentMock.Object);
+        var agentTool = new AgentTool(name: randomName, agent: nestedAgentMock.Object);
 
         // when
         string actualOutput = await agentTool.ExecuteAsync(randomInput);
@@ -57,7 +57,7 @@ public class AgentToolTests
             agent.ProcessPromptAsync(It.IsAny<string>()))
                 .ReturnsAsync("the capital is Paris");
 
-        var researcher = new AgentTool("researcher", innerAgent.Object);
+        var researcher = new AgentTool(name: "researcher", agent: innerAgent.Object);
 
         var outerBrain = new Mock<Brokers.Generators.IGeneratorBroker>();
         var replies = new Queue<string>(
@@ -96,13 +96,13 @@ public class AgentToolTests
             .Tool(researcher);
 
         // when
-        string actualResult = await outerAgent.ProcessPromptAsync("what is the capital of France?");
+        string actualResult = await outerAgent.ProcessPromptAsync(prompt: "what is the capital of France?");
 
         // then
         actualResult.Should().Be("Paris");
 
         innerAgent.Verify(agent =>
-    agent.ProcessPromptAsync("capital of France"),
+    agent.ProcessPromptAsync(prompt: "capital of France"),
         Times.Once);
     }
 
@@ -111,16 +111,16 @@ public class AgentToolTests
     {
         // given
         var nestedAgentMock = new Mock<IAgent>();
-        var nestedFailure = new InvalidOperationException("inner agent failed");
+        var nestedFailure = new InvalidOperationException(message: "inner agent failed");
 
         nestedAgentMock.Setup(agent =>
             agent.ProcessPromptAsync(It.IsAny<string>()))
                 .ThrowsAsync(nestedFailure);
 
-        var agentTool = new AgentTool("nested", nestedAgentMock.Object);
+        var agentTool = new AgentTool(name: "nested", agent: nestedAgentMock.Object);
 
         // when
-        ValueTask<string> executeTask = agentTool.ExecuteAsync("anything");
+        ValueTask<string> executeTask = agentTool.ExecuteAsync(input: "anything");
 
         InvalidOperationException actualException =
             await Assert.ThrowsAsync<InvalidOperationException>(
@@ -129,4 +129,4 @@ public class AgentToolTests
         // then
         actualException.Message.Should().Be("inner agent failed");
     }
-}
+    }

--- a/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
@@ -40,7 +40,7 @@ public sealed class ClassifierBroker : IClassifierBroker
         };
 
         httpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", apiKey);
+            new AuthenticationHeaderValue(scheme: "Bearer", parameter: apiKey);
 
         this.apiClient = new RESTFulApiFactoryClient(httpClient);
         this.model = model;
@@ -54,8 +54,8 @@ public sealed class ClassifierBroker : IClassifierBroker
             Model: this.model,
             Messages:
             [
-                new ChatMessage("system", systemPrompt),
-                new ChatMessage("user", input)
+                new ChatMessage(Role: "system", Content: systemPrompt),
+                new ChatMessage(Role: "user", Content: input)
             ],
             Stream: false,
             Temperature: this.temperature,
@@ -97,4 +97,4 @@ public sealed class ClassifierBroker : IClassifierBroker
 
     private sealed record ChatChoice(
         ChatMessage Message);
-}
+    }

--- a/Standard.Agents/Brokers/Generators/GeneratorBroker.cs
+++ b/Standard.Agents/Brokers/Generators/GeneratorBroker.cs
@@ -41,7 +41,7 @@ public sealed class GeneratorBroker : IGeneratorBroker
         };
 
         httpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", apiKey);
+            new AuthenticationHeaderValue(scheme: "Bearer", parameter: apiKey);
 
         this.apiClient = new RESTFulApiFactoryClient(httpClient);
         this.model = model;
@@ -55,8 +55,8 @@ public sealed class GeneratorBroker : IGeneratorBroker
             Model: this.model,
             Messages:
             [
-                new ChatMessage("system", systemPrompt),
-                new ChatMessage("user", userPrompt)
+                new ChatMessage(Role: "system", Content: systemPrompt),
+                new ChatMessage(Role: "user", Content: userPrompt)
             ],
             Stream: false,
             Temperature: this.temperature,
@@ -98,4 +98,4 @@ public sealed class GeneratorBroker : IGeneratorBroker
 
     private sealed record ChatChoice(
         ChatMessage Message);
-}
+    }

--- a/Standard.Agents/Brokers/Knowledges/KnowledgeBroker.cs
+++ b/Standard.Agents/Brokers/Knowledges/KnowledgeBroker.cs
@@ -51,4 +51,4 @@ public sealed class KnowledgeBroker : IKnowledgeBroker
 
         return matches;
     }
-}
+            }

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -15,7 +15,7 @@ public sealed class LoggingBroker : ILoggingBroker
         this.logger = logger;
 
     public async ValueTask LogInformationAsync(string message) =>
-this.logger.LogInformation(message);
+        this.logger.LogInformation(message);
 
     public async ValueTask LogTraceAsync(string message) =>
         this.logger.LogTrace(message);

--- a/Standard.Agents/Brokers/Mcps/McpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/McpBroker.cs
@@ -110,4 +110,4 @@ public sealed class McpBroker : IMcpBroker
     private sealed record JsonRpcError(
         int Code,
         string Message);
-}
+        }

--- a/Standard.Agents/Brokers/Memorys/MemoryBroker.cs
+++ b/Standard.Agents/Brokers/Memorys/MemoryBroker.cs
@@ -20,7 +20,7 @@ public sealed class MemoryBroker : IMemoryBroker
         await File.ReadAllLinesAsync(this.memoryPath);
 
     public async ValueTask InsertMemoryAsync(string memory) =>
-await File.AppendAllLinesAsync(this.memoryPath, [memory]);
+        await File.AppendAllLinesAsync(this.memoryPath, [memory]);
 
     private static void EnsureStoreExists(string memoryPath)
     {
@@ -30,4 +30,4 @@ await File.AppendAllLinesAsync(this.memoryPath, [memory]);
 
         File.AppendAllText(memoryPath, string.Empty);
     }
-}
+    }

--- a/Standard.Agents/Brokers/Skills/SkillBroker.cs
+++ b/Standard.Agents/Brokers/Skills/SkillBroker.cs
@@ -30,4 +30,4 @@ public sealed class SkillBroker : ISkillBroker
 
         return string.Join(SkillSeparator, skills);
     }
-}
+        }

--- a/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
@@ -41,7 +41,7 @@ public sealed class VerifierBroker : IVerifierBroker
         };
 
         httpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", apiKey);
+            new AuthenticationHeaderValue(scheme: "Bearer", parameter: apiKey);
 
         this.apiClient = new RESTFulApiFactoryClient(httpClient);
         this.model = model;
@@ -55,8 +55,8 @@ public sealed class VerifierBroker : IVerifierBroker
             Model: this.model,
             Messages:
             [
-                new ChatMessage("system", systemPrompt),
-                new ChatMessage("user", candidate)
+                new ChatMessage(Role: "system", Content: systemPrompt),
+                new ChatMessage(Role: "user", Content: candidate)
             ],
             Stream: false,
             Temperature: this.temperature,
@@ -104,4 +104,4 @@ CultureInfo.InvariantCulture);
 
     private sealed record ChatChoice(
         ChatMessage Message);
-}
+    }

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Exceptions.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Exceptions.cs
@@ -68,7 +68,8 @@ public partial class AgentCoordinationService
         return agentCoordinationValidationException;
     }
 
-    private async ValueTask<AgentCoordinationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+    private async ValueTask<AgentCoordinationDependencyValidationException>
+        CreateAndLogDependencyValidationExceptionAsync(
         Xeption? exception)
     {
         var agentCoordinationDependencyValidationException =
@@ -106,4 +107,4 @@ public partial class AgentCoordinationService
 
         return agentCoordinationServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Validations.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Validations.cs
@@ -17,4 +17,4 @@ public partial class AgentCoordinationService
                 message: "Invalid prompt. Please correct the error and try again.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -66,4 +66,4 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         await this.logBroker.WriteAsync(
             $"turn {turn} | intent: {context.Intent} | direction: {context.DirectionType} " +
             $"| status: {context.Status}");
-}
+            }

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.Exceptions.cs
@@ -152,4 +152,4 @@ public partial class BrainService
 
         return brainServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.Validations.cs
@@ -17,4 +17,4 @@ public partial class BrainService
                 message: "Invalid brain input. Please correct the error and try again.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.cs
@@ -28,4 +28,4 @@ public partial class BrainService : IBrainService
 
         return await this.generatorBroker.GenerateAsync(systemPrompt, userPrompt);
     });
-}
+    }

--- a/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.Exceptions.cs
@@ -152,4 +152,4 @@ public partial class ExternalToolService
 
         return externalToolServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.Validations.cs
@@ -17,4 +17,4 @@ public partial class ExternalToolService
                 message: "Invalid external tool. Please correct the error and try again.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.cs
@@ -28,4 +28,4 @@ public partial class ExternalToolService : IExternalToolService
 
         return await this.mcpBroker.CallAsync(name, input);
     });
-}
+    }

--- a/Standard.Agents/Services/Foundations/Gates/GateService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Gates/GateService.Exceptions.cs
@@ -152,4 +152,4 @@ public partial class GateService
 
         return gateServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Foundations/Gates/GateService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Gates/GateService.Validations.cs
@@ -17,4 +17,4 @@ public partial class GateService
                 message: "Invalid gate input. Please correct the error and try again.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Foundations/Gates/GateService.cs
+++ b/Standard.Agents/Services/Foundations/Gates/GateService.cs
@@ -28,4 +28,4 @@ public partial class GateService : IGateService
 
         return await this.classifierBroker.ClassifyAsync(gatePrompt, input);
     });
-}
+    }

--- a/Standard.Agents/Services/Foundations/InternalTools/InternalToolService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/InternalTools/InternalToolService.Exceptions.cs
@@ -104,4 +104,4 @@ public partial class InternalToolService
 
         return internalToolServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Foundations/InternalTools/InternalToolService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/InternalTools/InternalToolService.Validations.cs
@@ -17,4 +17,4 @@ public partial class InternalToolService
                 message: "Invalid internal tool. Please correct the error and try again.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.Exceptions.cs
@@ -156,4 +156,4 @@ public partial class JudgeService
 
         return gateServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.Validations.cs
@@ -31,4 +31,4 @@ public partial class JudgeService
                 message: "Invalid judge score. Score must be between 0.0 and 1.0.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
@@ -32,4 +32,4 @@ public partial class JudgeService : IJudgeService
 
         return score;
     });
-}
+    }

--- a/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.Exceptions.cs
@@ -111,4 +111,4 @@ public partial class KnowledgeService
 
         return knowledgeServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.Validations.cs
@@ -17,4 +17,4 @@ public partial class KnowledgeService
                 message: "Invalid knowledge query. Please correct the error and try again.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.cs
+++ b/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.cs
@@ -28,4 +28,4 @@ public partial class KnowledgeService : IKnowledgeService
 
         return await this.knowledgeBroker.SelectKnowledgeAsync(query);
     });
-}
+    }

--- a/Standard.Agents/Services/Foundations/Memorys/MemoryService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Memorys/MemoryService.Exceptions.cs
@@ -149,4 +149,4 @@ public partial class MemoryService
 
         return memoryServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Foundations/Memorys/MemoryService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Memorys/MemoryService.Validations.cs
@@ -17,4 +17,4 @@ public partial class MemoryService
                 message: "Invalid memory. Please correct the error and try again.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Foundations/Memorys/MemoryService.cs
+++ b/Standard.Agents/Services/Foundations/Memorys/MemoryService.cs
@@ -32,4 +32,4 @@ public partial class MemoryService : IMemoryService
 
         await this.memoryBroker.InsertMemoryAsync(memory);
     });
-}
+    }

--- a/Standard.Agents/Services/Foundations/Returns/ReturnService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Returns/ReturnService.Exceptions.cs
@@ -58,4 +58,4 @@ public partial class ReturnService
 
         return returnServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Foundations/Returns/ReturnService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Returns/ReturnService.Validations.cs
@@ -17,4 +17,4 @@ public partial class ReturnService
                 message: "Invalid return payload. Please correct the error and try again.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Foundations/Returns/ReturnService.cs
+++ b/Standard.Agents/Services/Foundations/Returns/ReturnService.cs
@@ -21,4 +21,4 @@ public partial class ReturnService : IReturnService
 
         return ValueTask.FromResult(payload);
     });
-}
+    }

--- a/Standard.Agents/Services/Foundations/Skills/SkillService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Skills/SkillService.Exceptions.cs
@@ -108,4 +108,4 @@ public partial class SkillService
 
         return skillServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Foundations/Skills/SkillService.cs
+++ b/Standard.Agents/Services/Foundations/Skills/SkillService.cs
@@ -24,4 +24,4 @@ public partial class SkillService : ISkillService
     public ValueTask<string> RetrieveSkillsAsync() =>
     TryCatch(async () =>
         await this.skillBroker.SelectSkillsAsync());
-}
+    }

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Exceptions.cs
@@ -92,7 +92,8 @@ ReturningContextFunction returningContextFunction)
         return agentOrchestrationValidationException;
     }
 
-    private async ValueTask<AgentOrchestrationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+    private async ValueTask<AgentOrchestrationDependencyValidationException>
+        CreateAndLogDependencyValidationExceptionAsync(
         Xeption? exception)
     {
         var agentOrchestrationDependencyValidationException =
@@ -130,4 +131,4 @@ ReturningContextFunction returningContextFunction)
 
         return agentOrchestrationServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Validations.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.Validations.cs
@@ -18,4 +18,4 @@ public partial class DataOrchestrationService
                 message: "Agent context is null.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -44,4 +44,4 @@ public partial class DataOrchestrationService : IDataOrchestrationService
             Observations = [.. context.Observations, .. memories]
         };
     });
-}
+        }

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Exceptions.cs
@@ -112,7 +112,8 @@ ReturningContextFunction returningContextFunction)
         return agentOrchestrationValidationException;
     }
 
-    private async ValueTask<AgentOrchestrationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+    private async ValueTask<AgentOrchestrationDependencyValidationException>
+        CreateAndLogDependencyValidationExceptionAsync(
         Xeption? exception)
     {
         var agentOrchestrationDependencyValidationException =
@@ -150,4 +151,4 @@ ReturningContextFunction returningContextFunction)
 
         return agentOrchestrationServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Validations.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Validations.cs
@@ -18,4 +18,4 @@ public partial class DecisionOrchestrationService
                 message: "Agent context is null.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -157,4 +157,4 @@ verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase
             RawReply = reply
         };
     }
-}
+        }

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Exceptions.cs
@@ -97,7 +97,8 @@ ReturningContextFunction returningContextFunction)
         return agentOrchestrationValidationException;
     }
 
-    private async ValueTask<AgentOrchestrationDependencyValidationException> CreateAndLogDependencyValidationExceptionAsync(
+    private async ValueTask<AgentOrchestrationDependencyValidationException>
+        CreateAndLogDependencyValidationExceptionAsync(
         Xeption? exception)
     {
         var agentOrchestrationDependencyValidationException =
@@ -135,4 +136,4 @@ ReturningContextFunction returningContextFunction)
 
         return agentOrchestrationServiceException;
     }
-}
+    }

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Validations.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Validations.cs
@@ -18,4 +18,4 @@ public partial class DirectionOrchestrationService
                 message: "Agent context is null.");
         }
     }
-}
+        }

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -71,4 +71,4 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
         directionType.Equals(RefuseDirection, StringComparison.OrdinalIgnoreCase)
             ? AgentStatus.Refused
             : AgentStatus.Responded;
-}
+        }

--- a/Standard.Agents/StandardAgent.Validations.cs
+++ b/Standard.Agents/StandardAgent.Validations.cs
@@ -37,4 +37,4 @@ public sealed partial class StandardAgent
                         + "nothing to fall back to.");
         }
     }
-}
+        }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -252,4 +252,4 @@ public sealed partial class StandardAgent : IAgent
         double Temperature,
         int MaxTokens,
         int TimeoutSeconds);
-}
+    }

--- a/Standard.Agents/Tools/AgentTool.cs
+++ b/Standard.Agents/Tools/AgentTool.cs
@@ -22,4 +22,4 @@ public sealed class AgentTool : ITool
     // back, and cannot tell whether a function or a mind answered it.
     public async ValueTask<string> ExecuteAsync(string input) =>
         await this.agent.ProcessPromptAsync(input);
-}
+    }


### PR DESCRIPTION
Named arguments and indentation, per The Standard.

## Named arguments — §1.0.4, §4.2.0

The rule: **a literal must carry its alias; a variable whose name matches the parameter in part or in full need not.**

I checked this against [Standard.AI.OpenAI](https://github.com/hassanhabib/Standard.AI.OpenAI) rather than guessing — it draws the line in exactly that place:

```csharp
await this.apiClient.PostContentAsync(relativeUrl, content);   // bare — names match
    mediaType: "application/json",                             // aliased — literal
new InvalidConfigurationCompletionException(
    message: "...", innerException: ...);                      // aliased — literal
```

Applied here:

```csharp
new ChatMessage(Role: "system", Content: systemPrompt)
new AuthenticationHeaderValue(scheme: "Bearer", parameter: apiKey)
new AgentTool(name: "researcher", agent: innerAgent)
new StubTool(name: pair.Key, output: pair.Value)
new Xeption(message: "inner")
.Skills(path: "Skills")   .LogTo(path: "log.txt")
ProcessPromptAsync(prompt: "prompt")
```

`ChatMessage` takes **`Role`/`Content` capitalised** — a positional record exposes its parameters in PascalCase. The Standard's own §1.1.4 example does the same (`MinimumScore: 130`).

**Left alone: assertion DSLs.** `Times.Exactly(7)`, `ReturnsAsync("allow")`, `Should().Be(x)` read worse aliased, and the reference doesn't alias them either. Say the word if you want them too.

## Indentation

- **§1.1.3** — 4 method declarations ran past 120 chars, now broken after the return type. **0 lines over 120 remain.**
- **7 lines sat at column zero inside a type body** — fat-arrow bodies in `LoggingBroker`/`MemoryBroker`, and `TheoryData` blocks in three test files.

## Those 7 were mine, and already on main

Shipped in the comment-removal commit (#88). The blank-line collapse was:

```python
re.sub(r"(\r?\n)\s*(\r?\n)\s*(\r?\n)+", r"\1\2", src)
```

The `\s*` eats **the indentation of the line that follows**, not just the blank lines between:

```csharp
    public async ValueTask LogInformationAsync(string message) =>
this.logger.LogInformation(message);        // ← column 0
```

It compiled, so nothing caught it. **CI can't see a style regression** — the same blind spot that let the using-order break through in #91. Two style bugs from the same class of scripted edit; worth me being slower with regex over whole trees.

## Verification

```
build       → 0 Warning(s), 0 Error(s)
test        → 198/198
conformance → 6 passed, 0 failed

lines > 120        → 0
tabs               → 0
de-indented lines  → 0
```

104 files touched; **only 15 have non-whitespace changes** (the aliases and the wrapped declarations).
