### PR TITLE
MAJOR FIX: Guardians Run Their Own Rubric, Not The Brain's Prompt

### DIFF
--- a/Standard.Agents.Conformance/Brokers/AllowingClassifierBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/AllowingClassifierBroker.cs
@@ -9,6 +9,6 @@ namespace Standard.Agents.Conformance;
 
 public sealed class AllowingClassifierBroker : IClassifierBroker
 {
-    public ValueTask<string> ClassifyAsync(string systemPrompt, string input) =>
+    public ValueTask<string> ClassifyAsync(string input) =>
         ValueTask.FromResult("allow");
     }

--- a/Standard.Agents.Conformance/Brokers/ApprovingVerifierBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/ApprovingVerifierBroker.cs
@@ -9,6 +9,6 @@ namespace Standard.Agents.Conformance;
 
 public sealed class ApprovingVerifierBroker : IVerifierBroker
 {
-    public ValueTask<double> VerifyAsync(string systemPrompt, string candidate) =>
-        ValueTask.FromResult(1.0);
+    public ValueTask<string> VerifyAsync(string candidate) =>
+        ValueTask.FromResult("1.0");
     }

--- a/Standard.Agents.Demo/appsettings.json
+++ b/Standard.Agents.Demo/appsettings.json
@@ -1,6 +1,6 @@
 {
   "PeerLLMConfigurations": {
-    "ApiUrl": "http://api.peerllm.com/v1/",
+    "ApiUrl": "https://api.peerllm.com/v1/",
     "Model": "LLooMA2.0",
     "Temperature": 0.7,
     "MaxTokens": 1024

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -36,12 +36,12 @@ public class StandardAgentTests
         knowledgeBroker.Setup(b => b.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
 
         var classifierBroker = new Mock<IClassifierBroker>();
-        classifierBroker.Setup(b => b.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+        classifierBroker.Setup(b => b.ClassifyAsync(It.IsAny<string>()))
             .ReturnsAsync("allow");
 
         var verifierBroker = new Mock<IVerifierBroker>();
-        verifierBroker.Setup(b => b.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(1.0);
+        verifierBroker.Setup(b => b.VerifyAsync(It.IsAny<string>()))
+            .ReturnsAsync("1.0");
 
         var mcpBroker = new Mock<IMcpBroker>();
         var logBroker = new Mock<ILogBroker>();
@@ -136,12 +136,12 @@ public class StandardAgentTests
             .ReturnsAsync("FINAL: ok");
 
         var classifierBroker = new Mock<IClassifierBroker>();
-        classifierBroker.Setup(b => b.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+        classifierBroker.Setup(b => b.ClassifyAsync(It.IsAny<string>()))
             .ReturnsAsync("allow");
 
         var verifierBroker = new Mock<IVerifierBroker>();
-        verifierBroker.Setup(b => b.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(1.0);
+        verifierBroker.Setup(b => b.VerifyAsync(It.IsAny<string>()))
+            .ReturnsAsync("1.0");
 
         var skillBroker = new Mock<ISkillBroker>();
         skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("skills");
@@ -201,12 +201,12 @@ public class StandardAgentTests
             .ReturnsAsync("FINAL: composed");
 
         var gate = new Mock<IClassifierBroker>();
-        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>()))
             .ReturnsAsync("allow");
 
         var judge = new Mock<IVerifierBroker>();
-        judge.Setup(b => b.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(1.0);
+        judge.Setup(b => b.VerifyAsync(It.IsAny<string>()))
+            .ReturnsAsync("1.0");
 
         var memory = new Mock<IMemoryBroker>();
         memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
@@ -245,12 +245,12 @@ public class StandardAgentTests
             .ReturnsAsync(() => replies.Dequeue());
 
         var gate = new Mock<IClassifierBroker>();
-        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>()))
             .ReturnsAsync("allow");
 
         var judge = new Mock<IVerifierBroker>();
-        judge.Setup(b => b.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(1.0);
+        judge.Setup(b => b.VerifyAsync(It.IsAny<string>()))
+            .ReturnsAsync("1.0");
 
         var memory = new Mock<IMemoryBroker>();
         memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Exceptions.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Exceptions.Screen.cs
@@ -33,10 +33,9 @@ public partial class GateServiceTests
     [Theory]
     [MemberData(nameof(CriticalDependencyExceptions))]
     public async Task ShouldThrowCriticalDependencyExceptionOnScreenIfCriticalErrorOccursAndLogItAsync(
-Exception criticalDependencyException)
+        Exception criticalDependencyException)
     {
         // given
-        string randomGatePrompt = CreateRandomString();
         string randomInput = CreateRandomString();
 
         var failedGateDependencyException =
@@ -50,12 +49,12 @@ Exception criticalDependencyException)
                 innerException: failedGateDependencyException);
 
         this.classifierBrokerMock.Setup(broker =>
-            broker.ClassifyAsync(randomGatePrompt, randomInput))
+            broker.ClassifyAsync(randomInput))
                 .ThrowsAsync(criticalDependencyException);
 
         // when
         ValueTask<string> screenTask =
-            this.gateService.ScreenAsync(randomGatePrompt, randomInput);
+            this.gateService.ScreenAsync(randomInput);
 
         GateDependencyException actualGateDependencyException =
             await Assert.ThrowsAsync<GateDependencyException>(
@@ -66,7 +65,7 @@ Exception criticalDependencyException)
             .BeEquivalentTo(expectedGateDependencyException);
 
         this.classifierBrokerMock.Verify(broker =>
-            broker.ClassifyAsync(randomGatePrompt, randomInput),
+            broker.ClassifyAsync(randomInput),
                 Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>
@@ -84,7 +83,6 @@ Exception criticalDependencyException)
         Exception dependencyException)
     {
         // given
-        string randomGatePrompt = CreateRandomString();
         string randomInput = CreateRandomString();
 
         var failedGateDependencyException =
@@ -98,12 +96,12 @@ Exception criticalDependencyException)
                 innerException: failedGateDependencyException);
 
         this.classifierBrokerMock.Setup(broker =>
-            broker.ClassifyAsync(randomGatePrompt, randomInput))
+            broker.ClassifyAsync(randomInput))
                 .ThrowsAsync(dependencyException);
 
         // when
         ValueTask<string> screenTask =
-            this.gateService.ScreenAsync(randomGatePrompt, randomInput);
+            this.gateService.ScreenAsync(randomInput);
 
         GateDependencyException actualGateDependencyException =
             await Assert.ThrowsAsync<GateDependencyException>(
@@ -114,7 +112,7 @@ Exception criticalDependencyException)
             .BeEquivalentTo(expectedGateDependencyException);
 
         this.classifierBrokerMock.Verify(broker =>
-            broker.ClassifyAsync(randomGatePrompt, randomInput),
+            broker.ClassifyAsync(randomInput),
                 Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>
@@ -130,7 +128,6 @@ Exception criticalDependencyException)
     public async Task ShouldThrowDependencyValidationExceptionOnScreenIfBadRequestErrorOccursAndLogItAsync()
     {
         // given
-        string randomGatePrompt = CreateRandomString();
         string randomInput = CreateRandomString();
         var badRequestException = new HttpResponseBadRequestException();
 
@@ -144,12 +141,12 @@ Exception criticalDependencyException)
                 innerException: invalidGateException);
 
         this.classifierBrokerMock.Setup(broker =>
-            broker.ClassifyAsync(randomGatePrompt, randomInput))
+            broker.ClassifyAsync(randomInput))
                 .ThrowsAsync(badRequestException);
 
         // when
         ValueTask<string> screenTask =
-            this.gateService.ScreenAsync(randomGatePrompt, randomInput);
+            this.gateService.ScreenAsync(randomInput);
 
         GateDependencyValidationException actualGateDependencyValidationException =
             await Assert.ThrowsAsync<GateDependencyValidationException>(
@@ -160,7 +157,7 @@ Exception criticalDependencyException)
             .BeEquivalentTo(expectedGateDependencyValidationException);
 
         this.classifierBrokerMock.Verify(broker =>
-            broker.ClassifyAsync(randomGatePrompt, randomInput),
+            broker.ClassifyAsync(randomInput),
                 Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>
@@ -176,7 +173,6 @@ Exception criticalDependencyException)
     public async Task ShouldThrowServiceExceptionOnScreenIfServiceErrorOccursAndLogItAsync()
     {
         // given
-        string randomGatePrompt = CreateRandomString();
         string randomInput = CreateRandomString();
         var serviceException = new Exception();
 
@@ -191,12 +187,12 @@ Exception criticalDependencyException)
                 innerException: failedGateServiceException);
 
         this.classifierBrokerMock.Setup(broker =>
-            broker.ClassifyAsync(randomGatePrompt, randomInput))
+            broker.ClassifyAsync(randomInput))
                 .ThrowsAsync(serviceException);
 
         // when
         ValueTask<string> screenTask =
-            this.gateService.ScreenAsync(randomGatePrompt, randomInput);
+            this.gateService.ScreenAsync(randomInput);
 
         GateServiceException actualGateServiceException =
             await Assert.ThrowsAsync<GateServiceException>(
@@ -207,7 +203,7 @@ Exception criticalDependencyException)
             .BeEquivalentTo(expectedGateServiceException);
 
         this.classifierBrokerMock.Verify(broker =>
-            broker.ClassifyAsync(randomGatePrompt, randomInput),
+            broker.ClassifyAsync(randomInput),
                 Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Logic.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Logic.Screen.cs
@@ -15,26 +15,24 @@ public partial class GateServiceTests
     public async Task ShouldScreenAsync()
     {
         // given
-        string randomGatePrompt = CreateRandomString();
         string randomInput = CreateRandomString();
         string randomVerdict = CreateRandomString();
-        string inputGatePrompt = randomGatePrompt;
         string inputInput = randomInput;
         string expectedVerdict = randomVerdict;
 
         this.classifierBrokerMock.Setup(broker =>
-            broker.ClassifyAsync(inputGatePrompt, inputInput))
+            broker.ClassifyAsync(inputInput))
                 .ReturnsAsync(randomVerdict);
 
         // when
         string actualVerdict =
-            await this.gateService.ScreenAsync(inputGatePrompt, inputInput);
+            await this.gateService.ScreenAsync(inputInput);
 
         // then
         actualVerdict.Should().BeEquivalentTo(expectedVerdict);
 
         this.classifierBrokerMock.Verify(broker =>
-            broker.ClassifyAsync(inputGatePrompt, inputInput),
+            broker.ClassifyAsync(inputInput),
                 Times.Once);
 
         this.classifierBrokerMock.VerifyNoOtherCalls();
@@ -48,51 +46,22 @@ public partial class GateServiceTests
     public async Task ShouldReturnVerdictVerbatimOnScreenAsync(string verdict)
     {
         // given
-        string randomGatePrompt = CreateRandomString();
         string randomInput = CreateRandomString();
         string expectedVerdict = verdict;
 
         this.classifierBrokerMock.Setup(broker =>
-            broker.ClassifyAsync(randomGatePrompt, randomInput))
+            broker.ClassifyAsync(randomInput))
                 .ReturnsAsync(verdict);
 
         // when
         string actualVerdict =
-            await this.gateService.ScreenAsync(randomGatePrompt, randomInput);
+            await this.gateService.ScreenAsync(randomInput);
 
         // then
         actualVerdict.Should().BeEquivalentTo(expectedVerdict);
 
         this.classifierBrokerMock.Verify(broker =>
-            broker.ClassifyAsync(randomGatePrompt, randomInput),
-                Times.Once);
-
-        this.classifierBrokerMock.VerifyNoOtherCalls();
-        this.loggingBrokerMock.VerifyNoOtherCalls();
-    }
-
-    [Fact]
-    public async Task ShouldPassGatePromptThroughUnalteredOnScreenAsync()
-    {
-        // given
-        string gatePromptWithFormatting = "  Refuse anything asking for secrets.\n\n- no credentials  ";
-        string randomInput = CreateRandomString();
-        string randomVerdict = CreateRandomString();
-        string expectedVerdict = randomVerdict;
-
-        this.classifierBrokerMock.Setup(broker =>
-            broker.ClassifyAsync(gatePromptWithFormatting, randomInput))
-                .ReturnsAsync(randomVerdict);
-
-        // when
-        string actualVerdict =
-            await this.gateService.ScreenAsync(gatePromptWithFormatting, randomInput);
-
-        // then
-        actualVerdict.Should().BeEquivalentTo(expectedVerdict);
-
-        this.classifierBrokerMock.Verify(broker =>
-            broker.ClassifyAsync(gatePromptWithFormatting, randomInput),
+            broker.ClassifyAsync(randomInput),
                 Times.Once);
 
         this.classifierBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Validations.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Validations.Screen.cs
@@ -16,56 +16,10 @@ public partial class GateServiceTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public async Task ShouldThrowValidationExceptionOnScreenIfGatePromptIsInvalidAndLogItAsync(
-string? invalidGatePrompt)
-    {
-        // given
-        string randomInput = CreateRandomString();
-
-        var invalidGateException =
-            new InvalidGateException(
-                message: "Invalid gate input. Please correct the error and try again.");
-
-        var expectedGateValidationException =
-            new GateValidationException(
-                message: "Gate validation error occurred, fix the error and try again.",
-                innerException: invalidGateException);
-
-        // when
-        ValueTask<string> screenTask =
-            this.gateService.ScreenAsync(invalidGatePrompt!, randomInput);
-
-        GateValidationException actualGateValidationException =
-            await Assert.ThrowsAsync<GateValidationException>(
-                screenTask.AsTask);
-
-        // then
-        actualGateValidationException.Should()
-            .BeEquivalentTo(expectedGateValidationException);
-
-        this.loggingBrokerMock.Verify(broker =>
-            broker.LogErrorAsync(It.Is(SameExceptionAs(
-                expectedGateValidationException))),
-                    Times.Once);
-
-        this.classifierBrokerMock.Verify(broker =>
-            broker.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()),
-                Times.Never);
-
-        this.classifierBrokerMock.VerifyNoOtherCalls();
-        this.loggingBrokerMock.VerifyNoOtherCalls();
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData(" ")]
     public async Task ShouldThrowValidationExceptionOnScreenIfInputIsInvalidAndLogItAsync(
         string? invalidInput)
     {
         // given
-        string randomGatePrompt = CreateRandomString();
-
         var invalidGateException =
             new InvalidGateException(
                 message: "Invalid gate input. Please correct the error and try again.");
@@ -77,7 +31,7 @@ string? invalidGatePrompt)
 
         // when
         ValueTask<string> screenTask =
-            this.gateService.ScreenAsync(randomGatePrompt, invalidInput!);
+            this.gateService.ScreenAsync(invalidInput!);
 
         GateValidationException actualGateValidationException =
             await Assert.ThrowsAsync<GateValidationException>(
@@ -93,7 +47,7 @@ string? invalidGatePrompt)
                     Times.Once);
 
         this.classifierBrokerMock.Verify(broker =>
-            broker.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()),
+            broker.ClassifyAsync(It.IsAny<string>()),
                 Times.Never);
 
         this.classifierBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Logic.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Logic.Evaluate.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Globalization;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -18,51 +19,52 @@ public partial class JudgeServiceTests
     public async Task ShouldEvaluateAsync(double score)
     {
         // given
-        string randomJudgePrompt = CreateRandomString();
         string randomCandidate = CreateRandomString();
+        string verdict = score.ToString(CultureInfo.InvariantCulture);
         double expectedScore = score;
 
         this.verifierBrokerMock.Setup(broker =>
-            broker.VerifyAsync(randomJudgePrompt, randomCandidate))
-                .ReturnsAsync(score);
+            broker.VerifyAsync(randomCandidate))
+                .ReturnsAsync(verdict);
 
         // when
         double actualScore =
-            await this.judgeService.EvaluateAsync(randomJudgePrompt, randomCandidate);
+            await this.judgeService.EvaluateAsync(randomCandidate);
 
         // then
         actualScore.Should().Be(expectedScore);
 
         this.verifierBrokerMock.Verify(broker =>
-            broker.VerifyAsync(randomJudgePrompt, randomCandidate),
+            broker.VerifyAsync(randomCandidate),
                 Times.Once);
 
         this.verifierBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
-    [Fact]
-    public async Task ShouldPassJudgePromptThroughUnalteredOnEvaluateAsync()
+    [Theory]
+    [InlineData(" 0.75 ", 0.75)]
+    [InlineData("0.5\n", 0.5)]
+    public async Task ShouldParseSurroundingWhitespaceOnEvaluateAsync(
+        string verdict,
+        double expectedScore)
     {
         // given
-        string judgePromptWithFormatting = "  Score 0..1 for groundedness.\n\n- cite sources  ";
         string randomCandidate = CreateRandomString();
-        double expectedScore = 0.75;
 
         this.verifierBrokerMock.Setup(broker =>
-            broker.VerifyAsync(judgePromptWithFormatting, randomCandidate))
-                .ReturnsAsync(expectedScore);
+            broker.VerifyAsync(randomCandidate))
+                .ReturnsAsync(verdict);
 
         // when
-        double actualScore = await this.judgeService.EvaluateAsync(
-            judgePromptWithFormatting,
-            randomCandidate);
+        double actualScore =
+            await this.judgeService.EvaluateAsync(randomCandidate);
 
         // then
         actualScore.Should().Be(expectedScore);
 
         this.verifierBrokerMock.Verify(broker =>
-            broker.VerifyAsync(judgePromptWithFormatting, randomCandidate),
+            broker.VerifyAsync(randomCandidate),
                 Times.Once);
 
         this.verifierBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Validations.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Validations.Evaluate.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Globalization;
 using FluentAssertions;
 using Moq;
 using Standard.Agents.Models.Foundations.Judges.Exceptions;
@@ -16,12 +17,10 @@ public partial class JudgeServiceTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public async Task ShouldThrowValidationExceptionOnEvaluateIfJudgePromptIsInvalidAndLogItAsync(
-        string? invalidJudgePrompt)
+    public async Task ShouldThrowValidationExceptionOnEvaluateIfCandidateIsInvalidAndLogItAsync(
+        string? invalidCandidate)
     {
         // given
-        string randomCandidate = CreateRandomString();
-
         var invalidJudgeException =
             new InvalidJudgeException(
                 message: "Invalid judge input. Please correct the error and try again.");
@@ -33,7 +32,7 @@ public partial class JudgeServiceTests
 
         // when
         ValueTask<double> evaluateTask =
-            this.judgeService.EvaluateAsync(invalidJudgePrompt!, randomCandidate);
+            this.judgeService.EvaluateAsync(invalidCandidate!);
 
         JudgeValidationException actualJudgeValidationException =
             await Assert.ThrowsAsync<JudgeValidationException>(
@@ -49,7 +48,7 @@ public partial class JudgeServiceTests
                     Times.Once);
 
         this.verifierBrokerMock.Verify(broker =>
-            broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()),
+            broker.VerifyAsync(It.IsAny<string>()),
                 Times.Never);
 
         this.verifierBrokerMock.VerifyNoOtherCalls();
@@ -60,24 +59,31 @@ public partial class JudgeServiceTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public async Task ShouldThrowValidationExceptionOnEvaluateIfCandidateIsInvalidAndLogItAsync(
-        string? invalidCandidate)
+    [InlineData("allow")]
+    [InlineData("ACTION: calculator: 47 * 89")]
+    [InlineData("I would rate this a 9 out of 10.")]
+    public async Task ShouldThrowValidationExceptionOnEvaluateIfScoreIsNotNumericAndLogItAsync(
+        string? nonNumericVerdict)
     {
         // given
-        string randomJudgePrompt = CreateRandomString();
+        string randomCandidate = CreateRandomString();
 
-        var invalidJudgeException =
-            new InvalidJudgeException(
-                message: "Invalid judge input. Please correct the error and try again.");
+        var invalidJudgeScoreException =
+            new InvalidJudgeScoreException(
+                message: "Invalid judge score. Score must be a number between 0.0 and 1.0.");
 
         var expectedJudgeValidationException =
             new JudgeValidationException(
                 message: "Judge validation error occurred, fix the error and try again.",
-                innerException: invalidJudgeException);
+                innerException: invalidJudgeScoreException);
+
+        this.verifierBrokerMock.Setup(broker =>
+            broker.VerifyAsync(randomCandidate))
+                .ReturnsAsync(nonNumericVerdict!);
 
         // when
         ValueTask<double> evaluateTask =
-            this.judgeService.EvaluateAsync(randomJudgePrompt, invalidCandidate!);
+            this.judgeService.EvaluateAsync(randomCandidate);
 
         JudgeValidationException actualJudgeValidationException =
             await Assert.ThrowsAsync<JudgeValidationException>(
@@ -87,14 +93,14 @@ public partial class JudgeServiceTests
         actualJudgeValidationException.Should()
             .BeEquivalentTo(expectedJudgeValidationException);
 
+        this.verifierBrokerMock.Verify(broker =>
+            broker.VerifyAsync(randomCandidate),
+                Times.Once);
+
         this.loggingBrokerMock.Verify(broker =>
             broker.LogErrorAsync(It.Is(SameExceptionAs(
                 expectedJudgeValidationException))),
                     Times.Once);
-
-        this.verifierBrokerMock.Verify(broker =>
-            broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()),
-                Times.Never);
 
         this.verifierBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
@@ -106,11 +112,11 @@ public partial class JudgeServiceTests
     [InlineData(87)]
     [InlineData(double.NaN)]
     public async Task ShouldThrowValidationExceptionOnEvaluateIfScoreIsOutOfRangeAndLogItAsync(
-double outOfRangeScore)
+        double outOfRangeScore)
     {
         // given
-        string randomJudgePrompt = CreateRandomString();
         string randomCandidate = CreateRandomString();
+        string verdict = outOfRangeScore.ToString(CultureInfo.InvariantCulture);
 
         var invalidJudgeScoreException =
             new InvalidJudgeScoreException(
@@ -122,12 +128,12 @@ double outOfRangeScore)
                 innerException: invalidJudgeScoreException);
 
         this.verifierBrokerMock.Setup(broker =>
-            broker.VerifyAsync(randomJudgePrompt, randomCandidate))
-                .ReturnsAsync(outOfRangeScore);
+            broker.VerifyAsync(randomCandidate))
+                .ReturnsAsync(verdict);
 
         // when
         ValueTask<double> evaluateTask =
-            this.judgeService.EvaluateAsync(randomJudgePrompt, randomCandidate);
+            this.judgeService.EvaluateAsync(randomCandidate);
 
         JudgeValidationException actualJudgeValidationException =
             await Assert.ThrowsAsync<JudgeValidationException>(
@@ -138,7 +144,7 @@ double outOfRangeScore)
             .BeEquivalentTo(expectedJudgeValidationException);
 
         this.verifierBrokerMock.Verify(broker =>
-            broker.VerifyAsync(randomJudgePrompt, randomCandidate),
+            broker.VerifyAsync(randomCandidate),
                 Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Exceptions.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Exceptions.Think.cs
@@ -47,7 +47,7 @@ public partial class DecisionOrchestrationServiceTests
                     Times.Once);
 
         this.gateServiceMock.Verify(service =>
-            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()),
+            service.ScreenAsync(It.IsAny<string>()),
                 Times.Never);
 
         this.gateServiceMock.VerifyNoOtherCalls();
@@ -70,7 +70,7 @@ Xeption foundationException)
                 innerException: foundationException.InnerException as Xeption);
 
         this.gateServiceMock.Setup(service =>
-            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+            service.ScreenAsync(It.IsAny<string>()))
                 .ThrowsAsync(foundationException);
 
         // when
@@ -105,7 +105,7 @@ Xeption foundationException)
                 innerException: foundationException.InnerException as Xeption);
 
         this.gateServiceMock.Setup(service =>
-            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+            service.ScreenAsync(It.IsAny<string>()))
                 .ThrowsAsync(foundationException);
 
         // when
@@ -144,7 +144,7 @@ Xeption foundationException)
                 innerException: failedAgentOrchestrationServiceException);
 
         this.gateServiceMock.Setup(service =>
-            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+            service.ScreenAsync(It.IsAny<string>()))
                 .ThrowsAsync(serviceException);
 
         // when

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
@@ -19,7 +19,7 @@ public partial class DecisionOrchestrationServiceTests
         AgentContext inputContext = CreateRandomAgentContext();
 
         this.gateServiceMock.Setup(service =>
-            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+            service.ScreenAsync(It.IsAny<string>()))
                 .ReturnsAsync("refuse");
 
         // when
@@ -42,7 +42,7 @@ public partial class DecisionOrchestrationServiceTests
         AgentContext inputContext = CreateRandomAgentContext();
 
         this.gateServiceMock.Setup(service =>
-            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+            service.ScreenAsync(It.IsAny<string>()))
                 .ReturnsAsync(verdict);
 
         // when
@@ -61,7 +61,7 @@ public partial class DecisionOrchestrationServiceTests
         AgentContext inputContext = CreateRandomAgentContext();
 
         this.gateServiceMock.Setup(service =>
-            service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+            service.ScreenAsync(It.IsAny<string>()))
                 .ReturnsAsync("refuse");
 
         // when
@@ -73,7 +73,7 @@ public partial class DecisionOrchestrationServiceTests
                 Times.Never);
 
         this.judgeServiceMock.Verify(service =>
-            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()),
+            service.EvaluateAsync(It.IsAny<string>()),
                 Times.Never);
 
         this.brainServiceMock.VerifyNoOtherCalls();
@@ -92,7 +92,7 @@ public partial class DecisionOrchestrationServiceTests
                 .ReturnsAsync("FINAL: a poor answer");
 
         this.judgeServiceMock.Setup(service =>
-            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()))
+            service.EvaluateAsync(It.IsAny<string>()))
                 .ReturnsAsync(0.1);
 
         // when
@@ -116,7 +116,7 @@ public partial class DecisionOrchestrationServiceTests
                 .ReturnsAsync("FINAL: a poor answer");
 
         this.judgeServiceMock.Setup(service =>
-            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()))
+            service.EvaluateAsync(It.IsAny<string>()))
                 .ReturnsAsync(0.1);
 
         // when
@@ -144,7 +144,7 @@ public partial class DecisionOrchestrationServiceTests
 
         // then
         this.judgeServiceMock.Verify(service =>
-            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()),
+            service.EvaluateAsync(It.IsAny<string>()),
                 Times.Never);
 
         this.judgeServiceMock.VerifyNoOtherCalls();
@@ -167,11 +167,11 @@ public partial class DecisionOrchestrationServiceTests
 
         // then
         this.gateServiceMock.Verify(service =>
-            service.ScreenAsync(inputContext.SystemPrompt, inputContext.Prompt),
+            service.ScreenAsync(inputContext.Prompt),
                 Times.Once);
 
         this.judgeServiceMock.Verify(service =>
-            service.EvaluateAsync(inputContext.SystemPrompt, "the draft"),
+            service.EvaluateAsync("the draft"),
                 Times.Once);
     }
     }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
@@ -51,12 +51,12 @@ public partial class DecisionOrchestrationServiceTests
 
     private void SetupGateAllows() =>
         this.gateServiceMock.Setup(service =>
-    service.ScreenAsync(It.IsAny<string>(), It.IsAny<string>()))
+    service.ScreenAsync(It.IsAny<string>()))
         .ReturnsAsync("allow");
 
     private void SetupJudgeApproves() =>
         this.judgeServiceMock.Setup(service =>
-            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()))
+            service.EvaluateAsync(It.IsAny<string>()))
                 .ReturnsAsync(1.0);
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>

--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
@@ -77,12 +77,12 @@ public class AgentToolTests
         memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var gate = new Mock<Brokers.Classifiers.IClassifierBroker>();
-        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>()))
             .ReturnsAsync("allow");
 
         var judge = new Mock<Brokers.Verifiers.IVerifierBroker>();
-        judge.Setup(b => b.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(1.0);
+        judge.Setup(b => b.VerifyAsync(It.IsAny<string>()))
+            .ReturnsAsync("1.0");
 
         var outerAgent = new StandardAgent()
             .UseSkills(skills.Object)

--- a/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
@@ -25,6 +25,7 @@ public sealed class ClassifierBroker : IClassifierBroker
     private readonly string model;
     private readonly double temperature;
     private readonly int maxTokens;
+    private readonly string systemPrompt;
 
     public ClassifierBroker(
         string apiUrl,
@@ -32,7 +33,8 @@ public sealed class ClassifierBroker : IClassifierBroker
         string model,
         double temperature,
         int maxTokens,
-        int timeoutSeconds)
+        int timeoutSeconds,
+        string systemPrompt)
     {
         var httpClient = new HttpClient
         {
@@ -47,15 +49,16 @@ public sealed class ClassifierBroker : IClassifierBroker
         this.model = model;
         this.temperature = temperature;
         this.maxTokens = maxTokens;
+        this.systemPrompt = systemPrompt;
     }
 
-    public async ValueTask<string> ClassifyAsync(string systemPrompt, string input)
+    public async ValueTask<string> ClassifyAsync(string input)
     {
         ChatCompletionRequest chatCompletionRequest = new(
             Model: this.model,
             Messages:
             [
-                new ChatMessage(Role: "system", Content: systemPrompt),
+                new ChatMessage(Role: "system", Content: this.systemPrompt),
                 new ChatMessage(Role: "user", Content: input)
             ],
             Stream: false,

--- a/Standard.Agents/Brokers/Classifiers/IClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/IClassifierBroker.cs
@@ -7,5 +7,5 @@ namespace Standard.Agents.Brokers.Classifiers;
 
 public interface IClassifierBroker
 {
-    ValueTask<string> ClassifyAsync(string systemPrompt, string input);
+    ValueTask<string> ClassifyAsync(string input);
 }

--- a/Standard.Agents/Brokers/Verifiers/IVerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/IVerifierBroker.cs
@@ -7,5 +7,5 @@ namespace Standard.Agents.Brokers.Verifiers;
 
 public interface IVerifierBroker
 {
-    ValueTask<double> VerifyAsync(string systemPrompt, string candidate);
+    ValueTask<string> VerifyAsync(string candidate);
 }

--- a/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
@@ -3,7 +3,6 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
-using System.Globalization;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using RESTFulSense.Clients;
@@ -26,6 +25,7 @@ public sealed class VerifierBroker : IVerifierBroker
     private readonly string model;
     private readonly double temperature;
     private readonly int maxTokens;
+    private readonly string systemPrompt;
 
     public VerifierBroker(
         string apiUrl,
@@ -33,7 +33,8 @@ public sealed class VerifierBroker : IVerifierBroker
         string model,
         double temperature,
         int maxTokens,
-        int timeoutSeconds)
+        int timeoutSeconds,
+        string systemPrompt)
     {
         var httpClient = new HttpClient
         {
@@ -48,15 +49,16 @@ public sealed class VerifierBroker : IVerifierBroker
         this.model = model;
         this.temperature = temperature;
         this.maxTokens = maxTokens;
+        this.systemPrompt = systemPrompt;
     }
 
-    public async ValueTask<double> VerifyAsync(string systemPrompt, string candidate)
+    public async ValueTask<string> VerifyAsync(string candidate)
     {
         ChatCompletionRequest chatCompletionRequest = new(
             Model: this.model,
             Messages:
             [
-                new ChatMessage(Role: "system", Content: systemPrompt),
+                new ChatMessage(Role: "system", Content: this.systemPrompt),
                 new ChatMessage(Role: "user", Content: candidate)
             ],
             Stream: false,
@@ -68,14 +70,8 @@ public sealed class VerifierBroker : IVerifierBroker
                 ChatCompletionsRelativeUrl,
                 chatCompletionRequest);
 
-        return ToScore(chatCompletionResponse.Choices[0].Message.Content);
+        return chatCompletionResponse.Choices[0].Message.Content;
     }
-
-    private static double ToScore(string content) =>
-double.Parse(
-content.Trim(),
-NumberStyles.Float,
-CultureInfo.InvariantCulture);
 
     private async ValueTask<TResult> PostAsync<TContent, TResult>(
         string relativeUrl,

--- a/Standard.Agents/Prompts/GuardianPrompts.cs
+++ b/Standard.Agents/Prompts/GuardianPrompts.cs
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Standard.Agents.Prompts;
+
+internal static class GuardianPrompts
+{
+    private const string GateResourceName = "Standard.Agents.Prompts.Guardians.gate.md";
+    private const string JudgeResourceName = "Standard.Agents.Prompts.Guardians.judge.md";
+
+    internal static string Gate => Read(GateResourceName);
+
+    internal static string Judge => Read(JudgeResourceName);
+
+    private static string Read(string resourceName)
+    {
+        Assembly assembly = typeof(GuardianPrompts).Assembly;
+
+        using Stream stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded guardian prompt '{resourceName}' was not found.");
+
+        using StreamReader reader = new(stream);
+
+        return reader.ReadToEnd();
+    }
+}

--- a/Standard.Agents/Prompts/Guardians/gate.md
+++ b/Standard.Agents/Prompts/Guardians/gate.md
@@ -1,0 +1,15 @@
+You are the Gate — the conscience that screens a task before the Brain ever sees it.
+
+You are not the Brain. You do not answer, solve, plan, or use tools. Your only job is to
+decide whether the task in front of you is safe and permissible to attempt.
+
+Judge the task, not the phrasing. Refuse only when attempting it would cause real harm:
+requests for credentials, secrets, or private data; instructions to damage systems or data;
+clearly illegal or dangerous acts.
+
+Reply with exactly one line and nothing else:
+
+- `allow` — if the task may proceed.
+- `refuse: <short reason>` — if it must not.
+
+Do not explain an allow. Do not add anything before or after the single line.

--- a/Standard.Agents/Prompts/Guardians/judge.md
+++ b/Standard.Agents/Prompts/Guardians/judge.md
@@ -1,0 +1,9 @@
+You are the Judge — the conscience that reviews the Brain's answer before it is returned.
+
+You are not the Brain. You do not rewrite, improve, or continue the answer. Your only job is
+to score how well the candidate answer addresses the task it was given.
+
+Consider correctness, completeness, and relevance. A confident but wrong answer scores low.
+
+Reply with exactly one decimal number between 0.0 and 1.0 and nothing else — no words, no
+punctuation, no explanation. Just the number.

--- a/Standard.Agents/Services/Foundations/Gates/GateService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Gates/GateService.Validations.cs
@@ -9,9 +9,9 @@ namespace Standard.Agents.Services.Foundations.Gates;
 
 public partial class GateService
 {
-    private static void ValidateScreen(string gatePrompt, string input)
+    private static void ValidateScreen(string input)
     {
-        if (string.IsNullOrWhiteSpace(gatePrompt) || string.IsNullOrWhiteSpace(input))
+        if (string.IsNullOrWhiteSpace(input))
         {
             throw new InvalidGateException(
                 message: "Invalid gate input. Please correct the error and try again.");

--- a/Standard.Agents/Services/Foundations/Gates/GateService.cs
+++ b/Standard.Agents/Services/Foundations/Gates/GateService.cs
@@ -21,11 +21,11 @@ public partial class GateService : IGateService
         this.loggingBroker = loggingBroker;
     }
 
-    public ValueTask<string> ScreenAsync(string gatePrompt, string input) =>
+    public ValueTask<string> ScreenAsync(string input) =>
     TryCatch(async () =>
     {
-        ValidateScreen(gatePrompt, input);
+        ValidateScreen(input);
 
-        return await this.classifierBroker.ClassifyAsync(gatePrompt, input);
+        return await this.classifierBroker.ClassifyAsync(input);
     });
     }

--- a/Standard.Agents/Services/Foundations/Gates/IGateService.cs
+++ b/Standard.Agents/Services/Foundations/Gates/IGateService.cs
@@ -7,5 +7,5 @@ namespace Standard.Agents.Services.Foundations.Gates;
 
 public interface IGateService
 {
-    ValueTask<string> ScreenAsync(string gatePrompt, string input);
+    ValueTask<string> ScreenAsync(string input);
 }

--- a/Standard.Agents/Services/Foundations/Judges/IJudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Judges/IJudgeService.cs
@@ -7,5 +7,5 @@ namespace Standard.Agents.Services.Foundations.Judges;
 
 public interface IJudgeService
 {
-    ValueTask<double> EvaluateAsync(string judgePrompt, string candidate);
+    ValueTask<double> EvaluateAsync(string candidate);
 }

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.Validations.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Globalization;
 using Standard.Agents.Models.Foundations.Judges.Exceptions;
 
 namespace Standard.Agents.Services.Foundations.Judges;
@@ -12,13 +13,30 @@ public partial class JudgeService
     private const double MinimumScore = 0.0;
     private const double MaximumScore = 1.0;
 
-    private static void ValidateEvaluate(string judgePrompt, string candidate)
+    private static void ValidateEvaluate(string candidate)
     {
-        if (string.IsNullOrWhiteSpace(judgePrompt) || string.IsNullOrWhiteSpace(candidate))
+        if (string.IsNullOrWhiteSpace(candidate))
         {
             throw new InvalidJudgeException(
                 message: "Invalid judge input. Please correct the error and try again.");
         }
+    }
+
+    private static double ParseScore(string verdict)
+    {
+        bool isNumeric = double.TryParse(
+            verdict?.Trim(),
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture,
+            out double score);
+
+        if (isNumeric is false)
+        {
+            throw new InvalidJudgeScoreException(
+                message: "Invalid judge score. Score must be a number between 0.0 and 1.0.");
+        }
+
+        return score;
     }
 
     private static void ValidateScore(double score)

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
@@ -21,12 +21,14 @@ public partial class JudgeService : IJudgeService
         this.loggingBroker = loggingBroker;
     }
 
-    public ValueTask<double> EvaluateAsync(string judgePrompt, string candidate) =>
+    public ValueTask<double> EvaluateAsync(string candidate) =>
     TryCatch(async () =>
     {
-        ValidateEvaluate(judgePrompt, candidate);
+        ValidateEvaluate(candidate);
 
-        double score = await this.verifierBroker.VerifyAsync(judgePrompt, candidate);
+        string verdict = await this.verifierBroker.VerifyAsync(candidate);
+
+        double score = ParseScore(verdict);
 
         ValidateScore(score);
 

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -46,7 +46,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
         ValidateContext(context);
 
         string verdict =
-            await this.gateService.ScreenAsync(context.SystemPrompt, context.Prompt);
+            await this.gateService.ScreenAsync(context.Prompt);
 
         if (IsRefusal(verdict))
         {
@@ -76,10 +76,8 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             return decided;
         }
 
-        double score = 
-            await this.judgeService.EvaluateAsync(
-                judgePrompt: context.SystemPrompt,
-                candidate: decided.Payload);
+        double score =
+            await this.judgeService.EvaluateAsync(candidate: decided.Payload);
 
         if (score < MinimumAcceptableScore)
         {

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -45,6 +45,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Prompts\Guardians\gate.md" />
+    <EmbeddedResource Include="Prompts\Guardians\judge.md" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="RESTFulSense" Version="3.2.0" />
     <PackageReference Include="Xeption" Version="2.9.0" />

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -15,6 +15,7 @@ using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Brokers.Tools;
 using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Prompts;
 using Standard.Agents.Services.Coordinations;
 using Standard.Agents.Services.Foundations.Brains;
 using Standard.Agents.Services.Foundations.ExternalTools;
@@ -80,8 +81,9 @@ public sealed partial class StandardAgent : IAgent
     // the Gate falls back to the Brain's endpoint — SPEC.md 9 permits collapsing the
     // three Decision brokers onto one endpoint, and Theory Ch.5 calls it "three
     // interfaces, collapsible substrate: at small scale one model wears all three
-    // hats". For anything safety-critical, set this — invariant 7.6 says the guardian
-    // must not be the brain.
+    // hats". Even collapsed, the Gate is never the Brain: it runs its own screening
+    // rubric (Data, not the agent's system prompt), honouring invariant 6. For a truly
+    // independent guardian, point this at a different model.
     public StandardAgent Gate(
         string apiUrl,
         string apiKey,
@@ -205,12 +207,14 @@ public sealed partial class StandardAgent : IAgent
         IClassifierBroker classifier =
             this.classifierBroker ?? new ClassifierBroker(
                 gate!.ApiUrl, gate.ApiKey, gate.Model,
-                gate.Temperature, gate.MaxTokens, gate.TimeoutSeconds);
+                gate.Temperature, gate.MaxTokens, gate.TimeoutSeconds,
+                GuardianPrompts.Gate);
 
         IVerifierBroker verifier =
             this.verifierBroker ?? new VerifierBroker(
                 judge!.ApiUrl, judge.ApiKey, judge.Model,
-                judge.Temperature, judge.MaxTokens, judge.TimeoutSeconds);
+                judge.Temperature, judge.MaxTokens, judge.TimeoutSeconds,
+                GuardianPrompts.Judge);
 
         IToolBroker toolBroker = new ToolBroker(this.tools);
 


### PR DESCRIPTION
## What broke

The Demo blew up with `AgentCoordinationDependencyException` → `Failed judge service error occurred`. Two independent defects, one masking the other.

### 1. `http://` in the demo config
`http://api.peerllm.com/v1/` 301-redirects; .NET turns the POST into a GET → `405 Method Not Allowed`, which is not on the HTTP exception ladder → catch-all. Fixed to `https://`.

### 2. Guardians were the Brain (SPEC invariant 6 violation)
`DecisionOrchestrationService` passed `context.SystemPrompt` — the agent's own instructions — as *both* the gate rubric and the judge rubric. So each guardian ran as a second Brain:

- The **Judge**, handed the agent prompt, replied `ACTION: calculator: 47 * 89` (dutifully following the agent's ACTION/FINAL protocol). `double.Parse` threw `FormatException` → catch-all → `FailedJudgeServiceException`.
- The **Gate** replied `Allow.` and, because refusal is matched by `StartsWith("refuse")`, silently **failed open** — a guardian that can never refuse.

> SPEC §7 invariant 6: *"No self-certification. A guardian (Gate/Judge) MUST NOT be the Brain."*

## The fix

- **Default guardian rubrics ship as embedded Data** (`Prompts/Guardians/gate.md`, `judge.md`), loaded distinct from the agent's system prompt.
- **The rubric is the guardian broker's configuration** — baked into the classifier/verifier broker as its fixed system prompt. `ClassifyAsync`/`VerifyAsync` now take only the input to screen/verify. This maps to the tri-nature: the Brain reasons over *dynamic* Data (`context.SystemPrompt`), the guardians apply *fixed* rules.
- **Score parsing moved out of `VerifierBroker` into `JudgeService`** (logic doesn't belong in a broker). A non-numeric verdict now raises `InvalidJudgeScoreException` — a validation rung that already existed on the ladder but was unreachable — instead of the catch-all.
- A Full-profile consumer still overrides via `.UseGate(...)` / `.UseJudge(...)` with a broker carrying their own rubric.

## Verification

- **198** unit tests pass. FAIL→PASS observed for the new non-numeric rung.
- **6/6** conformance vectors pass.
- Demo answers correctly against the live endpoint — trace shows the gate allowing and the judge scoring the draft above threshold:
  ```
  turn 1 | intent: calculator | direction: calculator | status: Working
  turn 2 | intent: Respond    | direction: ReturnResponse | status: Responded
  ```