### PR TITLE
RELEASES: Bump Package Version To 0.2.0

### DIFF
--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -12,9 +12,11 @@
     <!-- The Standard's release format is v1.2.3.4 — model . service/routine . fix/config
          . automated build. Deliberately NOT semver; the segments say what KIND of change
          happened, so a model change can never hide in the service segment.
-         0.1.0.0 tracks SPEC.md v0.1 (draft): the spec is not settled, so neither is the
-         model. Segment 1 goes to 1 when the spec does. -->
-    <Version>0.1.0.0</Version>
+         0.2.0.0: the guardian fix changed service/broker routines (ScreenAsync,
+         EvaluateAsync, ClassifyAsync, VerifyAsync) but no model, so segment 2 advances
+         and 3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1 goes to 1 when the
+         spec settles. -->
+    <Version>0.2.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>


### PR DESCRIPTION
Bumps the NuGet package version `0.1.0.0 → 0.2.0.0` for the guardian fix in #94.

Under The Standard's `v1.2.3.4` release format (model . service/routine . fix/config . build), that fix changed **service and broker routines** — `ScreenAsync`, `EvaluateAsync`, `ClassifyAsync`, `VerifyAsync` — without touching any model. So the **service segment** advances and the lower segments reset: `0.1.0.0 → 0.2.0.0`. Segment 1 stays at 0 until SPEC.md settles past v0.1.

Verified `dotnet pack` produces `Standard.Agents.0.2.0.nupkg` with both embedded guardian rubrics present in the shipped DLL.