### PR TITLE
MAJOR FIX: A Bare Brain Is A Valid Agent

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -170,23 +170,30 @@ public class StandardAgentTests
     }
 
     [Fact]
-    public async Task ShouldThrowCompositionExceptionOnProcessPromptIfGateHasNoSettingsAsync()
+    public async Task ShouldComposeBareBrainOnProcessPromptWithoutGuardiansAsync()
     {
         // given
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
         var generatorBroker = new Mock<IGeneratorBroker>();
+        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync("Hello there!");
 
         var agent = new StandardAgent()
-            .UseGenerator(generatorBroker.Object);
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memory.Object)
+            .UseGenerator(generatorBroker.Object)
+            .UseLog(new Mock<ILogBroker>().Object);
 
         // when
-        ValueTask<string> processTask = agent.ProcessPromptAsync(prompt: "prompt");
-
-        InvalidAgentCompositionException actualException =
-            await Assert.ThrowsAsync<InvalidAgentCompositionException>(
-                processTask.AsTask);
+        string actualResult = await agent.ProcessPromptAsync(prompt: "Hi there!");
 
         // then
-        actualException.Message.Should().Contain("gate");
+        actualResult.Should().Be("Hello there!");
     }
 
     [Fact]

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
@@ -157,6 +157,30 @@ public partial class DecisionOrchestrationServiceTests
         actualContext.Payload.Should().Be("just an answer, no prefix");
     }
 
+    [Theory]
+    [InlineData("ACTION:")]
+    [InlineData("ACTION: ")]
+    [InlineData("ACTION: : missing tool name")]
+    public async Task ShouldTreatEmptyActionAsAnswerOnThinkAsync(string reply)
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(reply);
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("ReturnResponse");
+        actualContext.Intent.Should().Be("Respond");
+    }
+
     [Fact]
     public async Task ShouldPassObservationsToBrainOnThinkAsync()
     {

--- a/Standard.Agents/Brokers/Classifiers/NotConfiguredClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/NotConfiguredClassifierBroker.cs
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Classifiers;
+
+public sealed class NotConfiguredClassifierBroker : IClassifierBroker
+{
+    private const string Allow = "allow";
+
+    public ValueTask<string> ClassifyAsync(string input) =>
+        ValueTask.FromResult(Allow);
+}

--- a/Standard.Agents/Brokers/Knowledges/KnowledgeBroker.cs
+++ b/Standard.Agents/Brokers/Knowledges/KnowledgeBroker.cs
@@ -19,12 +19,15 @@ public sealed class KnowledgeBroker : IKnowledgeBroker
         this.knowledgePath = Path.GetFullPath(knowledgePath);
         this.searchPattern = searchPattern;
         this.maxResults = maxResults;
-
-        Directory.CreateDirectory(this.knowledgePath);
     }
 
     public async ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query)
     {
+        if (Directory.Exists(this.knowledgePath) is false)
+        {
+            return [];
+        }
+
         List<string> matches = [];
 
         IOrderedEnumerable<string> documentPaths =

--- a/Standard.Agents/Brokers/Memorys/MemoryBroker.cs
+++ b/Standard.Agents/Brokers/Memorys/MemoryBroker.cs
@@ -9,25 +9,18 @@ public sealed class MemoryBroker : IMemoryBroker
 {
     private readonly string memoryPath;
 
-    public MemoryBroker(string memoryPath)
-    {
+    public MemoryBroker(string memoryPath) =>
         this.memoryPath = Path.GetFullPath(memoryPath);
 
-        EnsureStoreExists(this.memoryPath);
-    }
-
     public async ValueTask<IReadOnlyList<string>> SelectMemoriesAsync() =>
-        await File.ReadAllLinesAsync(this.memoryPath);
+        File.Exists(this.memoryPath)
+            ? await File.ReadAllLinesAsync(this.memoryPath)
+            : [];
 
-    public async ValueTask InsertMemoryAsync(string memory) =>
-        await File.AppendAllLinesAsync(this.memoryPath, [memory]);
-
-    private static void EnsureStoreExists(string memoryPath)
+    public async ValueTask InsertMemoryAsync(string memory)
     {
-        string directoryPath = Path.GetDirectoryName(memoryPath)!;
+        Directory.CreateDirectory(Path.GetDirectoryName(this.memoryPath)!);
 
-        Directory.CreateDirectory(directoryPath);
-
-        File.AppendAllText(memoryPath, string.Empty);
+        await File.AppendAllLinesAsync(this.memoryPath, [memory]);
     }
     }

--- a/Standard.Agents/Brokers/Skills/SkillBroker.cs
+++ b/Standard.Agents/Brokers/Skills/SkillBroker.cs
@@ -17,6 +17,11 @@ public sealed class SkillBroker : ISkillBroker
 
     public async ValueTask<string> SelectSkillsAsync()
     {
+        if (Directory.Exists(this.skillsPath) is false)
+        {
+            return string.Empty;
+        }
+
         List<string> skills = [];
 
         IOrderedEnumerable<string> skillFilePaths =

--- a/Standard.Agents/Brokers/Verifiers/NotConfiguredVerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/NotConfiguredVerifierBroker.cs
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Standard.Agents.Brokers.Verifiers;
+
+public sealed class NotConfiguredVerifierBroker : IVerifierBroker
+{
+    private static readonly string PassingScore =
+        (1.0).ToString(CultureInfo.InvariantCulture);
+
+    public ValueTask<string> VerifyAsync(string candidate) =>
+        ValueTask.FromResult(PassingScore);
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -134,13 +134,20 @@ verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase
             string toolName = toolCall[0];
             string toolInput = toolCall.Length > 1 ? toolCall[1] : string.Empty;
 
-            return context with
+            // A model can emit the "ACTION:" prefix with no tool name behind it (small
+            // models parrot the protocol template). That is not a tool call — fall
+            // through and treat the reply as the answer rather than routing an empty
+            // tool name into Direction, where it would fault.
+            if (string.IsNullOrWhiteSpace(toolName) is false)
             {
-                Intent = toolName,
-                DirectionType = toolName,
-                Payload = toolInput,
-                RawReply = reply
-            };
+                return context with
+                {
+                    Intent = toolName,
+                    DirectionType = toolName,
+                    Payload = toolInput,
+                    RawReply = reply
+                };
+            }
         }
 
         string answer = reply.StartsWith(FinalPrefix, StringComparison.OrdinalIgnoreCase)

--- a/Standard.Agents/StandardAgent.Validations.cs
+++ b/Standard.Agents/StandardAgent.Validations.cs
@@ -18,23 +18,5 @@ public sealed partial class StandardAgent
                     "Agent has no brain. Call Brain(apiUrl, apiKey, model) "
                         + "or UseGenerator(broker) before processing a prompt.");
         }
-
-        if (this.classifierBroker is null && this.gateSettings is null && this.brainSettings is null)
-        {
-            throw new InvalidAgentCompositionException(
-                message:
-                    "Agent has no gate. Call Gate(apiUrl, apiKey, model) or "
-                        + "UseGate(broker) — a swapped-in brain leaves the gate "
-                        + "nothing to fall back to.");
-        }
-
-        if (this.verifierBroker is null && this.judgeSettings is null && this.brainSettings is null)
-        {
-            throw new InvalidAgentCompositionException(
-                message:
-                    "Agent has no judge. Call Judge(apiUrl, apiKey, model) or "
-                        + "UseJudge(broker) — a swapped-in brain leaves the judge "
-                        + "nothing to fall back to.");
-        }
     }
         }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -77,13 +77,12 @@ public sealed partial class StandardAgent : IAgent
         Set(() => this.brainSettings =
             new InferenceSettings(apiUrl, apiKey, model, temperature, maxTokens, timeoutSeconds));
 
-    // Optional, and pointing it at a different model is the whole point. Left unset,
-    // the Gate falls back to the Brain's endpoint — SPEC.md 9 permits collapsing the
-    // three Decision brokers onto one endpoint, and Theory Ch.5 calls it "three
-    // interfaces, collapsible substrate: at small scale one model wears all three
-    // hats". Even collapsed, the Gate is never the Brain: it runs its own screening
-    // rubric (Data, not the agent's system prompt), honouring invariant 6. For a truly
-    // independent guardian, point this at a different model.
+    // Guardians are opt-in. A bare agent (brain only) runs no gate — SPEC.md 8.1 says
+    // the Core profile MAY leave Gate and Judge as pass-through. Calling this turns the
+    // Gate on; it may share the Brain's endpoint (SPEC.md 9's collapsible substrate) or
+    // point at a different model. Even collapsed onto one endpoint the Gate is never the
+    // Brain: it runs its own screening rubric (Data, not the agent's system prompt),
+    // honouring invariant 6.
     public StandardAgent Gate(
         string apiUrl,
         string apiKey,
@@ -186,8 +185,6 @@ public sealed partial class StandardAgent : IAgent
         ValidateComposition();
 
         InferenceSettings? brain = this.brainSettings;
-        InferenceSettings? gate = this.gateSettings ?? brain;
-        InferenceSettings? judge = this.judgeSettings ?? brain;
 
         ISkillBroker skill =
             this.skillBroker ?? new SkillBroker(this.skillsPath);
@@ -205,16 +202,20 @@ public sealed partial class StandardAgent : IAgent
                 this.knowledgePath, this.knowledgePattern, this.knowledgeMaxResults);
 
         IClassifierBroker classifier =
-            this.classifierBroker ?? new ClassifierBroker(
-                gate!.ApiUrl, gate.ApiKey, gate.Model,
-                gate.Temperature, gate.MaxTokens, gate.TimeoutSeconds,
-                GuardianPrompts.Gate);
+            this.classifierBroker ?? (this.gateSettings is null
+                ? new NotConfiguredClassifierBroker()
+                : new ClassifierBroker(
+                    this.gateSettings.ApiUrl, this.gateSettings.ApiKey, this.gateSettings.Model,
+                    this.gateSettings.Temperature, this.gateSettings.MaxTokens,
+                    this.gateSettings.TimeoutSeconds, GuardianPrompts.Gate));
 
         IVerifierBroker verifier =
-            this.verifierBroker ?? new VerifierBroker(
-                judge!.ApiUrl, judge.ApiKey, judge.Model,
-                judge.Temperature, judge.MaxTokens, judge.TimeoutSeconds,
-                GuardianPrompts.Judge);
+            this.verifierBroker ?? (this.judgeSettings is null
+                ? new NotConfiguredVerifierBroker()
+                : new VerifierBroker(
+                    this.judgeSettings.ApiUrl, this.judgeSettings.ApiKey, this.judgeSettings.Model,
+                    this.judgeSettings.Temperature, this.judgeSettings.MaxTokens,
+                    this.judgeSettings.TimeoutSeconds, GuardianPrompts.Judge));
 
         IToolBroker toolBroker = new ToolBroker(this.tools);
 


### PR DESCRIPTION
The minimum viable agent should be a brain and nothing else — `new StandardAgent().Brain(...)`. It blew up three ways; all fixed.

## 1. `InvalidInternalToolException` on a plain greeting
For "Hi there!", the brain emitted an `ACTION:` prefix with **no tool name** behind it (small models parrot the protocol template). `Interpret` routed an empty tool name into Direction → `InvalidInternalToolException`. Happened **with or without tools registered** — which is why adding a tool didn't help. `Interpret` now falls through and treats such a reply as the answer.

## 2. Guardians were mandatory + active by default
A "bare brain" fired a gate screen **and** a judge score on the brain's endpoint every turn — 3 LLM calls for a greeting, and two more failure surfaces. **Gate and Judge are now opt-in** (SPEC §8.1 Core: they MAY be pass-through). A bare agent runs only the brain; guardians stay correct when turned on via `Gate()`/`Judge()`/`UseGate()`/`UseJudge()` (the 0.2.0 rubric work is preserved). `ValidateComposition` now requires only a brain.

## 3. Data brokers assumed their files existed
`SkillBroker` threw on a missing folder; `Memory`/`Knowledge` created files/dirs on disk in their constructors. They're now **lazy and forgiving**: missing sources yield empty results, and nothing is written until an actual write.

## Verification
- **201** unit tests pass (new: bare-brain composes without guardians; empty-`ACTION:` → answer, FAIL→PASS verified).
- **6/6** conformance vectors pass.
- A genuinely bare brain answers a live prompt end-to-end: `new StandardAgent().Brain(...).ProcessPromptAsync("Hi there!")` → *"Hello! How can I assist you today?"* — no skills, no tools, no guardians, no crash.

Streaming (thinking + responses) is the next change, tracked separately.