### PR TITLE
RELEASES: Bump Package Version To 0.3.0

### DIFF
--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -12,12 +12,12 @@
     <!-- The Standard's release format is v1.2.3.4 — model . service/routine . fix/config
          . automated build. Deliberately NOT semver; the segments say what KIND of change
          happened, so a model change can never hide in the service segment.
-         0.2.2.0: a packaging fix — the README logo is now a wide, centered cover
-         image (NuGet escapes the HTML that would otherwise center it, so a full-width
-         canvas is the only way to appear centered on both NuGet and GitHub). No service
-         or model change, so only segment 3 advances. Still tracks SPEC.md v0.1 (draft):
-         segment 1 goes to 1 when the spec settles. -->
-    <Version>0.2.2.0</Version>
+         0.3.0.0: a bare brain is now a valid agent — guardians are opt-in, the data
+         brokers are lazy, and a malformed tool directive no longer faults. That is a
+         change in service/routine behaviour with no model change, so segment 2 advances
+         and 3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1 goes to 1 when the
+         spec settles. -->
+    <Version>0.3.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>


### PR DESCRIPTION
Releases the bare-minimum-brain fix (#98). Guardians opt-in, lazy data brokers, malformed-tool-directive handling — service/routine behaviour change, no model change → `0.2.2.0 → 0.3.0.0` under the `v1.2.3.4` format.