### PR TITLE
FEAT: Streaming — Watch The Agent Think And Answer

### DIFF
--- a/Standard.Agents.Conformance/Brokers/ScriptedGeneratorBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/ScriptedGeneratorBroker.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
 using Standard.Agents.Brokers.Generators;
 
 namespace Standard.Agents.Conformance;
@@ -21,5 +22,18 @@ public sealed class ScriptedGeneratorBroker : IGeneratorBroker
         this.index++;
 
         return ValueTask.FromResult(reply);
+    }
+
+    public async IAsyncEnumerable<string> GenerateStreamAsync(
+        string systemPrompt,
+        string userPrompt,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        string reply = this.replies[Math.Min(this.index, this.replies.Count - 1)];
+        this.index++;
+
+        await Task.CompletedTask;
+
+        yield return reply;
     }
     }

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -3,6 +3,8 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using Moq;
 using Standard.Agents.Brokers.Classifiers;
@@ -13,6 +15,7 @@ using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Brokers.Verifiers;
+using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Clients.Agents.Exceptions;
 using Xunit;
 
@@ -276,5 +279,52 @@ public class StandardAgentTests
 
         // then
         actualResult.Should().Be("could not get weather");
+    }
+
+    [Fact]
+    public async Task ShouldStreamResponseOnStreamPromptAsync()
+    {
+        // given
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var generatorBroker = new Mock<IGeneratorBroker>();
+        generatorBroker.Setup(b => b.GenerateStreamAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(ToAsyncStream("Hi ", "there."));
+
+        var agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memory.Object)
+            .UseGenerator(generatorBroker.Object)
+            .UseLog(new Mock<ILogBroker>().Object);
+
+        // when
+        List<AgentStreamEvent> actualEvents = [];
+
+        await foreach (AgentStreamEvent streamEvent in agent.StreamPromptAsync(prompt: "Hi there!"))
+        {
+            actualEvents.Add(streamEvent);
+        }
+
+        // then
+        string streamedResponse = string.Concat(actualEvents
+            .Where(streamEvent => streamEvent.Type == AgentStreamEventType.Response)
+            .Select(streamEvent => streamEvent.Content));
+
+        streamedResponse.Should().Be("Hi there.");
+    }
+
+    private static async IAsyncEnumerable<string> ToAsyncStream(params string[] tokens)
+    {
+        foreach (string token in tokens)
+        {
+            await Task.Yield();
+
+            yield return token;
+        }
     }
     }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Exceptions.GenerateStream.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Exceptions.GenerateStream.cs
@@ -1,0 +1,139 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Threading;
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Brains.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Brains;
+
+public partial class BrainServiceTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ShouldThrowValidationExceptionOnGenerateStreamIfPromptIsInvalidAndLogItAsync(
+        string? invalidUserPrompt)
+    {
+        // given
+        string randomSystemPrompt = CreateRandomString();
+
+        var invalidBrainException =
+            new InvalidBrainException(
+                message: "Invalid brain input. Please correct the error and try again.");
+
+        var expectedBrainValidationException =
+            new BrainValidationException(
+                message: "Brain validation error occurred, fix the error and try again.",
+                innerException: invalidBrainException);
+
+        // when
+        BrainValidationException actualBrainValidationException =
+            await Assert.ThrowsAsync<BrainValidationException>(() =>
+                DrainAsync(this.brainService.GenerateStreamAsync(
+                    randomSystemPrompt, invalidUserPrompt!)));
+
+        // then
+        actualBrainValidationException.Should()
+            .BeEquivalentTo(expectedBrainValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedBrainValidationException))),
+                    Times.Once);
+
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                    Times.Never);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowCriticalDependencyExceptionOnGenerateStreamIfHttpRequestErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomSystemPrompt = CreateRandomString();
+        string randomUserPrompt = CreateRandomString();
+        var httpRequestException = new HttpRequestException();
+
+        var failedBrainDependencyException =
+            new FailedBrainDependencyException(
+                message: "Failed brain dependency error occurred, contact support.",
+                innerException: httpRequestException);
+
+        var expectedBrainDependencyException =
+            new BrainDependencyException(
+                message: "Brain dependency error occurred, contact support.",
+                innerException: failedBrainDependencyException);
+
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateStreamAsync(
+                randomSystemPrompt, randomUserPrompt, It.IsAny<CancellationToken>()))
+                    .Returns(ThrowingStream(httpRequestException));
+
+        // when
+        BrainDependencyException actualBrainDependencyException =
+            await Assert.ThrowsAsync<BrainDependencyException>(() =>
+                DrainAsync(this.brainService.GenerateStreamAsync(
+                    randomSystemPrompt, randomUserPrompt)));
+
+        // then
+        actualBrainDependencyException.Should()
+            .BeEquivalentTo(expectedBrainDependencyException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogCriticalAsync(It.Is(SameExceptionAs(
+                expectedBrainDependencyException))),
+                    Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnGenerateStreamIfServiceErrorOccursAndLogItAsync()
+    {
+        // given
+        string randomSystemPrompt = CreateRandomString();
+        string randomUserPrompt = CreateRandomString();
+        var serviceException = new Exception();
+
+        var failedBrainServiceException =
+            new FailedBrainServiceException(
+                message: "Failed brain service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedBrainServiceException =
+            new BrainServiceException(
+                message: "Brain service error occurred, contact support.",
+                innerException: failedBrainServiceException);
+
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateStreamAsync(
+                randomSystemPrompt, randomUserPrompt, It.IsAny<CancellationToken>()))
+                    .Returns(ThrowingStream(serviceException));
+
+        // when
+        BrainServiceException actualBrainServiceException =
+            await Assert.ThrowsAsync<BrainServiceException>(() =>
+                DrainAsync(this.brainService.GenerateStreamAsync(
+                    randomSystemPrompt, randomUserPrompt)));
+
+        // then
+        actualBrainServiceException.Should()
+            .BeEquivalentTo(expectedBrainServiceException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedBrainServiceException))),
+                    Times.Once);
+
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.GenerateStream.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.GenerateStream.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Threading;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Brains;
+
+public partial class BrainServiceTests
+{
+    [Fact]
+    public async Task ShouldGenerateStreamAsync()
+    {
+        // given
+        string randomSystemPrompt = CreateRandomString();
+        string randomUserPrompt = CreateRandomString();
+        string[] randomTokens = ["Hello", ", ", "world"];
+        string[] expectedTokens = randomTokens;
+
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateStreamAsync(
+                randomSystemPrompt,
+                randomUserPrompt,
+                It.IsAny<CancellationToken>()))
+                    .Returns(ToAsyncStream(randomTokens));
+
+        // when
+        List<string> actualTokens =
+            await DrainAsync(
+                this.brainService.GenerateStreamAsync(randomSystemPrompt, randomUserPrompt));
+
+        // then
+        actualTokens.Should().Equal(expectedTokens);
+
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateStreamAsync(
+                randomSystemPrompt,
+                randomUserPrompt,
+                It.IsAny<CancellationToken>()),
+                    Times.Once);
+
+        this.generatorBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+    }

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.cs
@@ -34,4 +34,38 @@ public partial class BrainServiceTests
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);
+
+    private static async IAsyncEnumerable<string> ToAsyncStream(params string[] tokens)
+    {
+        foreach (string token in tokens)
+        {
+            await Task.Yield();
+
+            yield return token;
+        }
+    }
+
+    private static async IAsyncEnumerable<string> ThrowingStream(Exception exception)
+    {
+        await Task.CompletedTask;
+
+        if (exception is not null)
+        {
+            throw exception;
+        }
+
+        yield break;
+    }
+
+    private static async Task<List<string>> DrainAsync(IAsyncEnumerable<string> stream)
+    {
+        List<string> tokens = [];
+
+        await foreach (string token in stream)
+        {
+            tokens.Add(token);
+        }
+
+        return tokens;
+    }
     }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.ThinkStream.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.ThinkStream.cs
@@ -1,0 +1,164 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldStreamAnswerAsResponseOnThinkStreamAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(ToAsyncStream("Hello ", "there!"));
+
+        // when
+        IDecisionStream decisionStream =
+            this.decisionOrchestrationService.ThinkStreamAsync(inputContext);
+
+        List<AgentStreamEvent> actualEvents = await DrainAsync(decisionStream);
+
+        // then
+        actualEvents.Should().OnlyContain(streamEvent =>
+            streamEvent.Type == AgentStreamEventType.Response);
+
+        string streamedResponse =
+            string.Concat(actualEvents.Select(streamEvent => streamEvent.Content));
+
+        streamedResponse.Should().Be("Hello there!");
+        decisionStream.Result.DirectionType.Should().Be("ReturnResponse");
+        decisionStream.Result.Payload.Should().Be("Hello there!");
+    }
+
+    [Fact]
+    public async Task ShouldStreamToolReasoningAsThinkingOnThinkStreamAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(ToAsyncStream("ACTION: cal", "culator: 2+2"));
+
+        // when
+        IDecisionStream decisionStream =
+            this.decisionOrchestrationService.ThinkStreamAsync(inputContext);
+
+        List<AgentStreamEvent> actualEvents = await DrainAsync(decisionStream);
+
+        // then
+        actualEvents.Should().Contain(streamEvent =>
+            streamEvent.Type == AgentStreamEventType.Thinking);
+
+        actualEvents.Should().NotContain(streamEvent =>
+            streamEvent.Type == AgentStreamEventType.Response);
+
+        decisionStream.Result.DirectionType.Should().Be("calculator");
+        decisionStream.Result.Payload.Should().Be("2+2");
+
+        this.judgeServiceMock.Verify(service =>
+            service.EvaluateAsync(It.IsAny<string>()),
+                Times.Never);
+    }
+
+    [Fact]
+    public async Task ShouldSplitFinalPrefixIntoThinkingAndResponseOnThinkStreamAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(ToAsyncStream("FINAL: ", "The answer is 42."));
+
+        // when
+        IDecisionStream decisionStream =
+            this.decisionOrchestrationService.ThinkStreamAsync(inputContext);
+
+        List<AgentStreamEvent> actualEvents = await DrainAsync(decisionStream);
+
+        // then
+        actualEvents.Should().Contain(streamEvent =>
+            streamEvent.Type == AgentStreamEventType.Thinking);
+
+        string streamedResponse = string.Concat(actualEvents
+            .Where(streamEvent => streamEvent.Type == AgentStreamEventType.Response)
+            .Select(streamEvent => streamEvent.Content));
+
+        streamedResponse.Should().Be("The answer is 42.");
+        decisionStream.Result.Payload.Should().Be("The answer is 42.");
+    }
+
+    [Fact]
+    public async Task ShouldStreamRefusalAsResponseOnThinkStreamIfGateRefusesAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>()))
+                .ReturnsAsync("refuse: policy");
+
+        // when
+        IDecisionStream decisionStream =
+            this.decisionOrchestrationService.ThinkStreamAsync(inputContext);
+
+        List<AgentStreamEvent> actualEvents = await DrainAsync(decisionStream);
+
+        // then
+        actualEvents.Should().Contain(streamEvent =>
+            streamEvent.Type == AgentStreamEventType.Response
+                && streamEvent.Content == "I'm not able to help with that.");
+
+        decisionStream.Result.DirectionType.Should().Be("Refuse");
+
+        this.brainServiceMock.Verify(service =>
+            service.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                    Times.Never);
+    }
+
+    private static async IAsyncEnumerable<string> ToAsyncStream(params string[] tokens)
+    {
+        foreach (string token in tokens)
+        {
+            await Task.Yield();
+
+            yield return token;
+        }
+    }
+
+    private static async Task<List<AgentStreamEvent>> DrainAsync(IDecisionStream decisionStream)
+    {
+        List<AgentStreamEvent> events = [];
+
+        await foreach (AgentStreamEvent streamEvent in decisionStream)
+        {
+            events.Add(streamEvent);
+        }
+
+        return events;
+    }
+    }

--- a/Standard.Agents/Brokers/Generators/GeneratorBroker.cs
+++ b/Standard.Agents/Brokers/Generators/GeneratorBroker.cs
@@ -4,6 +4,8 @@
 // ---------------------------------------------------------------
 
 using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json;
 using RESTFulSense.Clients;
 using Standard.Agents.Models.Brokers.Generators;
@@ -15,6 +17,8 @@ public sealed class GeneratorBroker : IGeneratorBroker
     private const string ChatCompletionsRelativeUrl = "chat/completions";
 
     private const string JsonMediaType = "application/json";
+    private const string DataFieldPrefix = "data:";
+    private const string DoneSentinel = "[DONE]";
 
     private static readonly JsonSerializerOptions jsonOptions = new()
     {
@@ -23,6 +27,7 @@ public sealed class GeneratorBroker : IGeneratorBroker
     };
 
     private readonly IRESTFulApiFactoryClient apiClient;
+    private readonly HttpClient httpClient;
     private readonly string model;
     private readonly double temperature;
     private readonly int maxTokens;
@@ -35,16 +40,16 @@ public sealed class GeneratorBroker : IGeneratorBroker
         int maxTokens,
         int timeoutSeconds)
     {
-        var httpClient = new HttpClient
+        this.httpClient = new HttpClient
         {
             BaseAddress = new Uri(apiUrl),
             Timeout = TimeSpan.FromSeconds(timeoutSeconds)
         };
 
-        httpClient.DefaultRequestHeaders.Authorization =
+        this.httpClient.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue(scheme: "Bearer", parameter: apiKey);
 
-        this.apiClient = new RESTFulApiFactoryClient(httpClient);
+        this.apiClient = new RESTFulApiFactoryClient(this.httpClient);
         this.model = model;
         this.temperature = temperature;
         this.maxTokens = maxTokens;
@@ -69,6 +74,78 @@ public sealed class GeneratorBroker : IGeneratorBroker
                 chatCompletionRequest);
 
         return chatCompletionResponse.Choices[0].Message.Content;
+    }
+
+    public async IAsyncEnumerable<string> GenerateStreamAsync(
+        string systemPrompt,
+        string userPrompt,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ChatCompletionRequest chatCompletionRequest = new(
+            Model: this.model,
+            Messages:
+            [
+                new ChatMessage(Role: "system", Content: systemPrompt),
+                new ChatMessage(Role: "user", Content: userPrompt)
+            ],
+            Stream: true,
+            Temperature: this.temperature,
+            MaxTokens: this.maxTokens);
+
+        string requestJson = JsonSerializer.Serialize(chatCompletionRequest, jsonOptions);
+
+        using var httpRequest = new HttpRequestMessage(
+            HttpMethod.Post,
+            ChatCompletionsRelativeUrl)
+        {
+            Content = new StringContent(requestJson, Encoding.UTF8, JsonMediaType)
+        };
+
+        using HttpResponseMessage httpResponse = await this.httpClient.SendAsync(
+            httpRequest,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+
+        httpResponse.EnsureSuccessStatusCode();
+
+        await using Stream responseStream =
+            await httpResponse.Content.ReadAsStreamAsync(cancellationToken);
+
+        using var reader = new StreamReader(responseStream);
+
+        while (true)
+        {
+            string? line = await reader.ReadLineAsync(cancellationToken);
+
+            if (line is null)
+            {
+                break;
+            }
+
+            if (line.StartsWith(DataFieldPrefix) is false)
+            {
+                continue;
+            }
+
+            string data = line[DataFieldPrefix.Length..].Trim();
+
+            if (data == DoneSentinel)
+            {
+                break;
+            }
+
+            ChatCompletionChunk? chunk =
+                JsonSerializer.Deserialize<ChatCompletionChunk>(data, jsonOptions);
+
+            string? content = chunk?.Choices is { Count: > 0 }
+                ? chunk.Choices[0].Delta.Content
+                : null;
+
+            if (string.IsNullOrEmpty(content) is false)
+            {
+                yield return content;
+            }
+        }
     }
 
     private async ValueTask<TResult> PostAsync<TContent, TResult>(

--- a/Standard.Agents/Brokers/Generators/IGeneratorBroker.cs
+++ b/Standard.Agents/Brokers/Generators/IGeneratorBroker.cs
@@ -8,4 +8,9 @@ namespace Standard.Agents.Brokers.Generators;
 public interface IGeneratorBroker
 {
     ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt);
+
+    IAsyncEnumerable<string> GenerateStreamAsync(
+        string systemPrompt,
+        string userPrompt,
+        CancellationToken cancellationToken = default);
 }

--- a/Standard.Agents/IAgent.cs
+++ b/Standard.Agents/IAgent.cs
@@ -3,9 +3,15 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using Standard.Agents.Models.Clients.Agents;
+
 namespace Standard.Agents;
 
 public interface IAgent
 {
     ValueTask<string> ProcessPromptAsync(string prompt);
+
+    IAsyncEnumerable<AgentStreamEvent> StreamPromptAsync(
+        string prompt,
+        CancellationToken cancellationToken = default);
 }

--- a/Standard.Agents/Models/Brokers/Generators/ChatChoiceDelta.cs
+++ b/Standard.Agents/Models/Brokers/Generators/ChatChoiceDelta.cs
@@ -1,0 +1,9 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Brokers.Generators;
+
+internal sealed record ChatChoiceDelta(
+    ChatDelta Delta);

--- a/Standard.Agents/Models/Brokers/Generators/ChatCompletionChunk.cs
+++ b/Standard.Agents/Models/Brokers/Generators/ChatCompletionChunk.cs
@@ -1,0 +1,9 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Brokers.Generators;
+
+internal sealed record ChatCompletionChunk(
+    IReadOnlyList<ChatChoiceDelta> Choices);

--- a/Standard.Agents/Models/Brokers/Generators/ChatDelta.cs
+++ b/Standard.Agents/Models/Brokers/Generators/ChatDelta.cs
@@ -1,0 +1,9 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Brokers.Generators;
+
+internal sealed record ChatDelta(
+    string? Content);

--- a/Standard.Agents/Models/Clients/Agents/AgentStreamEvent.cs
+++ b/Standard.Agents/Models/Clients/Agents/AgentStreamEvent.cs
@@ -1,0 +1,10 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Clients.Agents;
+
+public sealed record AgentStreamEvent(
+    AgentStreamEventType Type,
+    string Content);

--- a/Standard.Agents/Models/Clients/Agents/AgentStreamEventType.cs
+++ b/Standard.Agents/Models/Clients/Agents/AgentStreamEventType.cs
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Clients.Agents;
+
+public enum AgentStreamEventType
+{
+    Status,
+    Thinking,
+    Tool,
+    Response
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -3,8 +3,10 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Logs;
+using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Orchestrations.Data;
 using Standard.Agents.Services.Orchestrations.Decision;
@@ -61,6 +63,50 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
         return context.Result;
     });
+
+    public async IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
+        string prompt,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ValidatePrompt(prompt);
+
+        await this.logBroker.ResetAsync();
+
+        AgentContext context = new() { Prompt = prompt };
+
+        for (int turn = 1; turn <= MaxTurns; turn++)
+        {
+            context = await this.dataOrchestrationService.RecallAsync(context);
+
+            IDecisionStream decisionStream =
+                this.decisionOrchestrationService.ThinkStreamAsync(context, cancellationToken);
+
+            await foreach (AgentStreamEvent decisionEvent in
+                decisionStream.WithCancellation(cancellationToken))
+            {
+                yield return decisionEvent;
+            }
+
+            context = decisionStream.Result;
+
+            context = await this.directionOrchestrationService.ActAsync(context);
+
+            if (context.Status is AgentStatus.Working
+                && string.IsNullOrEmpty(context.Result) is false)
+            {
+                yield return new AgentStreamEvent(
+                    AgentStreamEventType.Tool,
+                    $"{context.DirectionType}: {context.Result}");
+            }
+
+            await LogTurnAsync(turn, context);
+
+            if (context.Status is not AgentStatus.Working)
+            {
+                break;
+            }
+        }
+    }
 
     private async ValueTask LogTurnAsync(int turn, AgentContext context) =>
         await this.logBroker.WriteAsync(

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.Exceptions.cs
@@ -78,6 +78,21 @@ public partial class BrainService
         }
     }
 
+    private async ValueTask<Exception> MapStreamExceptionAsync(Exception exception) =>
+        exception switch
+        {
+            InvalidBrainException invalidBrainException =>
+                await CreateAndLogValidationExceptionAsync(invalidBrainException),
+
+            HttpRequestException httpRequestException =>
+                await CreateAndLogCriticalDependencyExceptionAsync(httpRequestException),
+
+            _ => await CreateAndLogServiceExceptionAsync(
+                new FailedBrainServiceException(
+                    message: "Failed brain service error occurred, contact support.",
+                    innerException: exception))
+        };
+
     private async ValueTask<BrainValidationException> CreateAndLogValidationExceptionAsync(
         Xeption? exception)
     {

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
 using Standard.Agents.Brokers.Generators;
 using Standard.Agents.Brokers.Loggings;
 
@@ -28,4 +29,53 @@ public partial class BrainService : IBrainService
 
         return await this.generatorBroker.GenerateAsync(systemPrompt, userPrompt);
     });
+
+    public async IAsyncEnumerable<string> GenerateStreamAsync(
+        string systemPrompt,
+        string userPrompt,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        IAsyncEnumerator<string> tokens;
+
+        try
+        {
+            ValidateUserPrompt(userPrompt);
+
+            tokens = this.generatorBroker
+                .GenerateStreamAsync(systemPrompt, userPrompt, cancellationToken)
+                .GetAsyncEnumerator(cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            throw await MapStreamExceptionAsync(exception);
+        }
+
+        try
+        {
+            while (true)
+            {
+                string token;
+
+                try
+                {
+                    if (await tokens.MoveNextAsync() is false)
+                    {
+                        break;
+                    }
+
+                    token = tokens.Current;
+                }
+                catch (Exception exception)
+                {
+                    throw await MapStreamExceptionAsync(exception);
+                }
+
+                yield return token;
+            }
+        }
+        finally
+        {
+            await tokens.DisposeAsync();
+        }
+    }
     }

--- a/Standard.Agents/Services/Foundations/Brains/IBrainService.cs
+++ b/Standard.Agents/Services/Foundations/Brains/IBrainService.cs
@@ -8,4 +8,9 @@ namespace Standard.Agents.Services.Foundations.Brains;
 public interface IBrainService
 {
     ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt);
+
+    IAsyncEnumerable<string> GenerateStreamAsync(
+        string systemPrompt,
+        string userPrompt,
+        CancellationToken cancellationToken = default);
 }

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -3,8 +3,10 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
 using System.Text;
 using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Foundations.Brains;
 using Standard.Agents.Services.Foundations.Gates;
@@ -20,6 +22,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
     private const string RefuseDirection = "Refuse";
     private const string ReturnResponseDirection = "ReturnResponse";
     private const string RespondIntent = "Respond";
+    private const string RefusalMessage = "I'm not able to help with that.";
 
     private const double MinimumAcceptableScore = 0.3;
 
@@ -54,7 +57,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             {
                 Intent = RefuseDirection,
                 DirectionType = RefuseDirection,
-                Payload = "I'm not able to help with that.",
+                Payload = RefusalMessage,
                 RawReply = verdict
             };
         }
@@ -95,6 +98,100 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         return decided;
     });
+
+    public IDecisionStream ThinkStreamAsync(
+        AgentContext context,
+        CancellationToken cancellationToken = default) =>
+        new DecisionStream(setResult =>
+            StreamThinkAsync(context, setResult, cancellationToken));
+
+    private async IAsyncEnumerable<AgentStreamEvent> StreamThinkAsync(
+        AgentContext context,
+        Action<AgentContext> setResult,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        string verdict = await this.gateService.ScreenAsync(context.Prompt);
+
+        if (IsRefusal(verdict))
+        {
+            setResult(context with
+            {
+                Intent = RefuseDirection,
+                DirectionType = RefuseDirection,
+                Payload = RefusalMessage,
+                RawReply = verdict
+            });
+
+            yield return new AgentStreamEvent(
+                AgentStreamEventType.Status, "gate refused the request");
+
+            yield return new AgentStreamEvent(
+                AgentStreamEventType.Response, RefusalMessage);
+
+            yield break;
+        }
+
+        var classifier = new ReplyStreamClassifier();
+        var reply = new StringBuilder();
+
+        IAsyncEnumerable<string> tokens = this.brainService.GenerateStreamAsync(
+            systemPrompt: context.SystemPrompt,
+            userPrompt: BuildUserMessage(context),
+            cancellationToken: cancellationToken);
+
+        await foreach (string delta in tokens.WithCancellation(cancellationToken))
+        {
+            reply.Append(delta);
+
+            foreach (AgentStreamEvent segment in classifier.Classify(delta))
+            {
+                yield return segment;
+            }
+        }
+
+        foreach (AgentStreamEvent segment in classifier.Flush())
+        {
+            yield return segment;
+        }
+
+        AgentContext decided = Interpret(context, reply.ToString().Trim());
+
+        bool isFinalAnswer = decided.DirectionType.Equals(
+            ReturnResponseDirection, StringComparison.OrdinalIgnoreCase);
+
+        if (isFinalAnswer is false)
+        {
+            setResult(decided);
+
+            yield return new AgentStreamEvent(
+                AgentStreamEventType.Status, $"using tool: {decided.DirectionType}");
+
+            yield break;
+        }
+
+        double score = await this.judgeService.EvaluateAsync(candidate: decided.Payload);
+
+        if (score < MinimumAcceptableScore)
+        {
+            setResult(context with
+            {
+                Observations =
+                [
+                    .. context.Observations,
+                    $"A previous draft was rejected on review: {decided.Payload}"
+                ],
+
+                Status = AgentStatus.Working
+            });
+
+            yield return new AgentStreamEvent(
+                AgentStreamEventType.Status, "judge rejected the draft; revising");
+
+            yield break;
+        }
+
+        setResult(decided);
+    }
 
     private static bool IsRefusal(string verdict) =>
 verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase);

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionStream.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionStream.cs
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+
+namespace Standard.Agents.Services.Orchestrations.Decision;
+
+internal sealed class DecisionStream : IDecisionStream
+{
+    private readonly IAsyncEnumerable<AgentStreamEvent> events;
+
+    public AgentContext Result { get; private set; } = new();
+
+    public DecisionStream(
+        Func<Action<AgentContext>, IAsyncEnumerable<AgentStreamEvent>> build) =>
+        this.events = build(context => this.Result = context);
+
+    public IAsyncEnumerator<AgentStreamEvent> GetAsyncEnumerator(
+        CancellationToken cancellationToken = default) =>
+        this.events.GetAsyncEnumerator(cancellationToken);
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/IDecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/IDecisionOrchestrationService.cs
@@ -10,4 +10,8 @@ namespace Standard.Agents.Services.Orchestrations.Decision;
 public interface IDecisionOrchestrationService
 {
     ValueTask<AgentContext> ThinkAsync(AgentContext context);
+
+    IDecisionStream ThinkStreamAsync(
+        AgentContext context,
+        CancellationToken cancellationToken = default);
 }

--- a/Standard.Agents/Services/Orchestrations/Decision/IDecisionStream.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/IDecisionStream.cs
@@ -4,14 +4,11 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
 
-namespace Standard.Agents.Services.Coordinations;
+namespace Standard.Agents.Services.Orchestrations.Decision;
 
-public interface IAgentCoordinationService
+public interface IDecisionStream : IAsyncEnumerable<AgentStreamEvent>
 {
-    ValueTask<string> ProcessPromptAsync(string prompt);
-
-    IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
-        string prompt,
-        CancellationToken cancellationToken = default);
+    AgentContext Result { get; }
 }

--- a/Standard.Agents/Services/Orchestrations/Decision/ReplyStreamClassifier.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/ReplyStreamClassifier.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text;
+using Standard.Agents.Models.Clients.Agents;
+
+namespace Standard.Agents.Services.Orchestrations.Decision;
+
+internal sealed class ReplyStreamClassifier
+{
+    private const string ActionPrefix = "ACTION:";
+    private const string FinalPrefix = "FINAL:";
+
+    private readonly StringBuilder pending = new();
+    private Channel channel = Channel.Undecided;
+
+    private enum Channel
+    {
+        Undecided,
+        Thinking,
+        Responding
+    }
+
+    public IEnumerable<AgentStreamEvent> Classify(string delta)
+    {
+        if (this.channel is Channel.Thinking)
+        {
+            return [new AgentStreamEvent(AgentStreamEventType.Thinking, delta)];
+        }
+
+        if (this.channel is Channel.Responding)
+        {
+            return [new AgentStreamEvent(AgentStreamEventType.Response, delta)];
+        }
+
+        this.pending.Append(delta);
+
+        return Decide(isFinal: false);
+    }
+
+    public IEnumerable<AgentStreamEvent> Flush() =>
+        this.channel is Channel.Undecided
+            ? Decide(isFinal: true)
+            : [];
+
+    private IEnumerable<AgentStreamEvent> Decide(bool isFinal)
+    {
+        string buffered = this.pending.ToString();
+        string leading = buffered.TrimStart();
+
+        bool canDecide =
+            leading.Length >= ActionPrefix.Length
+                || buffered.Contains('\n')
+                || isFinal;
+
+        if (canDecide is false)
+        {
+            return [];
+        }
+
+        this.pending.Clear();
+
+        if (leading.StartsWith(ActionPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            this.channel = Channel.Thinking;
+
+            return [new AgentStreamEvent(AgentStreamEventType.Thinking, buffered)];
+        }
+
+        this.channel = Channel.Responding;
+
+        int finalIndex = buffered.IndexOf(FinalPrefix, StringComparison.OrdinalIgnoreCase);
+
+        if (finalIndex < 0)
+        {
+            return [new AgentStreamEvent(AgentStreamEventType.Response, buffered)];
+        }
+
+        string head = buffered[..(finalIndex + FinalPrefix.Length)];
+        string answer = buffered[(finalIndex + FinalPrefix.Length)..].TrimStart();
+
+        List<AgentStreamEvent> events = [new AgentStreamEvent(AgentStreamEventType.Thinking, head)];
+
+        if (answer.Length > 0)
+        {
+            events.Add(new AgentStreamEvent(AgentStreamEventType.Response, answer));
+        }
+
+        return events;
+    }
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging.Abstractions;
 using Standard.Agents.Brokers.Classifiers;
 using Standard.Agents.Brokers.Generators;
@@ -167,6 +168,23 @@ public sealed partial class StandardAgent : IAgent
         this.agent ??= Compose();
 
         return await this.agent.ProcessPromptAsync(prompt);
+    }
+
+    // async iterator, so a composition failure surfaces when the caller starts
+    // enumerating rather than at the call site — mirroring ProcessPromptAsync.
+    public async IAsyncEnumerable<AgentStreamEvent> StreamPromptAsync(
+        string prompt,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        this.agent ??= Compose();
+
+        IAsyncEnumerable<AgentStreamEvent> events =
+            this.agent.ProcessPromptStreamAsync(prompt, cancellationToken);
+
+        await foreach (AgentStreamEvent streamEvent in events.WithCancellation(cancellationToken))
+        {
+            yield return streamEvent;
+        }
     }
 
     // Every builder method drops the cached composition, so configuration set after a


### PR DESCRIPTION
Adds a streamed alternative to `ProcessPromptAsync`, per the requested typed-event model:

```csharp
await foreach (AgentStreamEvent e in agent.StreamPromptAsync(prompt))
{
    switch (e.Type)
    {
        case AgentStreamEventType.Thinking: /* model deliberating */ break;
        case AgentStreamEventType.Response: /* the answer, live */    break;
        case AgentStreamEventType.Tool:     /* a tool ran */          break;
        case AgentStreamEventType.Status:   /* lifecycle */           break;
    }
}
```

Response tokens arrive **live** from an OpenAI-compatible SSE endpoint (`stream: true`). A first-line classifier routes tool deliberation (`ACTION: …`) to **Thinking** and the answer (after any `FINAL:`) to **Response**, so a bare direct answer streams straight through as Response.

## Layers (bottom → top)
- `GeneratorBroker.GenerateStreamAsync` — SSE, parses `data:` chunks into deltas.
- `BrainService.GenerateStreamAsync` — localizes stream exceptions (map around `MoveNextAsync`, yield outside) into the same brain exception categories.
- `DecisionOrchestrationService.ThinkStreamAsync` → `IDecisionStream` — an event stream that also carries the decided `AgentContext` as `Result` once enumerated. Gate/brain/interpret/judge preserved.
- `AgentCoordinationService.ProcessPromptStreamAsync` — the streamed loop.
- `StandardAgent.StreamPromptAsync` — client entry point.

Guardians remain **opt-in**; when configured, a rejected draft yields a `Status` and the next turn re-streams.

## Verification
- **212** unit tests (brain stream happy-path + exception localization; decision classification: answer / tool / FINAL-split / refusal; client end-to-end).
- **6/6** conformance vectors, **0** warnings.
- A bare brain streams a live answer end-to-end against a real endpoint: `[Response] Hello! One` / ` color is ` / `blue.`