### PR TITLE
RELEASES: Bump Package Version To 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,42 @@ Orchestration is not a fourth nature. It is the composition operator — the loo
 dotnet add package Standard.Agents
 ```
 
+The bare minimum is a brain — nothing else required:
+
 ```csharp
 var agent = new StandardAgent()
-    .Skills("Skills")
-    .Brain(apiUrl: "https://api.peerllm.com/v1/", apiKey: key, model: "LLooMA2.0")
-    .Tool(new CalculatorTool())
-    .LogTo("log.txt");
+    .Brain(apiUrl: "https://api.peerllm.com/v1/", apiKey: key, model: "LLooMA2.0");
 
 string answer = await agent.ProcessPromptAsync("What is 47 * 89?");
+```
+
+Add skills, tools, and guardians as you grow. Skills and tools are picked up when
+present; the Gate and Judge are **opt-in** (SPEC.md §8.1 — the Core profile may leave
+them pass-through):
+
+```csharp
+var agent = new StandardAgent()
+    .Brain(apiUrl: "https://api.peerllm.com/v1/", apiKey: key, model: "LLooMA2.0")
+    .Skills("Skills")
+    .Tool(new CalculatorTool())
+    .Gate(apiUrl: "https://api.peerllm.com/v1/", apiKey: key, model: "LLooMA2.0")
+    .LogTo("log.txt");
+```
+
+Stream the agent thinking and answering — each event is tagged, and the answer
+arrives live:
+
+```csharp
+await foreach (AgentStreamEvent streamEvent in agent.StreamPromptAsync("What is 47 * 89?"))
+{
+    switch (streamEvent.Type)
+    {
+        case AgentStreamEventType.Thinking: /* the model deliberating / tool reasoning */ break;
+        case AgentStreamEventType.Response: /* the answer, token by token */              break;
+        case AgentStreamEventType.Tool:     /* a tool ran, and its result */              break;
+        case AgentStreamEventType.Status:   /* lifecycle: turns, gate, judge */           break;
+    }
+}
 ```
 
 No DI container. `Compose()` hand-wires the whole graph — SPEC.md §9: *"DI is OPTIONAL. A

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -12,12 +12,12 @@
     <!-- The Standard's release format is v1.2.3.4 — model . service/routine . fix/config
          . automated build. Deliberately NOT semver; the segments say what KIND of change
          happened, so a model change can never hide in the service segment.
-         0.3.0.0: a bare brain is now a valid agent — guardians are opt-in, the data
-         brokers are lazy, and a malformed tool directive no longer faults. That is a
-         change in service/routine behaviour with no model change, so segment 2 advances
-         and 3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1 goes to 1 when the
-         spec settles. -->
-    <Version>0.3.0.0</Version>
+         0.4.0.0: streaming — StreamPromptAsync yields typed AgentStreamEvents (thinking
+         and responses) live over SSE. New service routines and supporting wire/client
+         models, but the spec's core AgentContext model is unchanged, so this is a
+         service/routine change: segment 2 advances, 3/4 reset. Still tracks SPEC.md v0.1
+         (draft): segment 1 goes to 1 when the spec settles. -->
+    <Version>0.4.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>


### PR DESCRIPTION
Releases streaming (#100). `StreamPromptAsync` yields typed `AgentStreamEvent`s live over SSE. New service routines + supporting models, spec's `AgentContext` unchanged → service/routine change, segment 2: `0.3.0.0 → 0.4.0.0`. README now leads with the bare-minimum brain and shows a streaming example.