### PR TITLE
CLIENTS: Define Sub-Agent Handoff On AgentTool

### DIFF
--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
@@ -129,4 +129,37 @@ public class AgentToolTests
         // then
         actualException.Message.Should().Be("inner agent failed");
     }
+
+    [Fact]
+    public async Task ShouldApplyHandoffTemplateOnExecuteAsync()
+    {
+        // given
+        string randomInput = CreateRandomString();
+        string randomAnswer = CreateRandomString();
+        string handoff = "You are a researcher. Research this and report: {input}";
+        string expectedHandoffPrompt = $"You are a researcher. Research this and report: {randomInput}";
+
+        var nestedAgentMock = new Mock<IAgent>();
+
+        nestedAgentMock.Setup(agent =>
+            agent.ProcessPromptAsync(expectedHandoffPrompt))
+                .ReturnsAsync(randomAnswer);
+
+        var agentTool = new AgentTool(
+            name: "researcher",
+            agent: nestedAgentMock.Object,
+            handoff: handoff);
+
+        // when
+        string actualOutput = await agentTool.ExecuteAsync(randomInput);
+
+        // then
+        actualOutput.Should().Be(randomAnswer);
+
+        nestedAgentMock.Verify(agent =>
+            agent.ProcessPromptAsync(expectedHandoffPrompt),
+                Times.Once);
+
+        nestedAgentMock.VerifyNoOtherCalls();
+    }
 }

--- a/Standard.Agents/Tools/AgentTool.cs
+++ b/Standard.Agents/Tools/AgentTool.cs
@@ -7,14 +7,22 @@ namespace Standard.Agents.Tools;
 
 public sealed class AgentTool : ITool
 {
+    private const string InputPlaceholder = "{input}";
+
     private readonly IAgent agent;
+    private readonly string handoff;
 
     public string Name { get; }
 
-    public AgentTool(string name, IAgent agent)
+    // The handoff is what the outer agent tells this sub-agent to do: a template whose
+    // "{input}" is replaced with the string the outer agent placed after its ACTION.
+    // Left at its default it is exactly "{input}", so the raw input passes through
+    // unchanged and the sub-agent behaves as before.
+    public AgentTool(string name, IAgent agent, string handoff = InputPlaceholder)
     {
         this.Name = name;
         this.agent = agent;
+        this.handoff = handoff;
     }
 
     // The nested agent runs its own full loop — its own Recall, Think, Act, its own

--- a/Standard.Agents/Tools/AgentTool.cs
+++ b/Standard.Agents/Tools/AgentTool.cs
@@ -29,5 +29,5 @@ public sealed class AgentTool : ITool
     // turn cap, its own guardians. The outer agent sees one tool call and a string
     // back, and cannot tell whether a function or a mind answered it.
     public async ValueTask<string> ExecuteAsync(string input) =>
-        await this.agent.ProcessPromptAsync(input);
+        await this.agent.ProcessPromptAsync(this.handoff.Replace(InputPlaceholder, input));
 }


### PR DESCRIPTION
Closes #104. Implements the handoff decision from #103.

`AgentTool` now takes an optional **handoff template** — what the outer agent tells the sub-agent — instead of always forwarding the raw `ACTION` input:

```csharp
var researcher = new AgentTool(
    name: "researcher",
    agent: innerAgent,
    handoff: "You are a meticulous researcher. Research this and report findings: {input}");

var outer = new StandardAgent().Brain(...).Tool(researcher);
```

- `{input}` is replaced with the string the outer agent placed after `ACTION: researcher: …`.
- **Default is `{input}`** → raw pass-through, fully backward compatible (existing `AgentTool(name, agent)` unchanged).
- **Many sub-agents** = register multiple `AgentTool`s, each with its own handoff. No new team type.

## FAIL → PASS
- `ShouldApplyHandoffTemplateOnExecuteAsync -> FAIL` — added the test + the `handoff` parameter (stored, not yet applied); the sub-agent received raw input, so the assertion failed. Observed failing.
- `ShouldApplyHandoffTemplateOnExecuteAsync -> PASS` — `ExecuteAsync` applies the template before calling the sub-agent. 213 tests pass.

Brokers-free change; existing pass-through tests (`ShouldRunNestedAgentAsToolAsync`, `ShouldNestAgentInsideAgentAsync`) still hold.

## Open Standard ruling (§7.2) — needs your call
The handoff template is a prompt, and §7.2 says prompts load from Data, not hardcoded. This PR keeps the **library prompt-neutral**: it authors no prompt; the developer supplies the template string and *may* source it from a skill/config. If you'd rather `AgentTool` take a **Data path** (load the handoff from a file) to enforce §7.2, that's a small follow-up — flagging per your 360-cycle so it can be settled in SPEC + Standard Skills. Tracked in #103.
