### PR TITLE
BROKERS: Function Generator Broker For Local Inference

### DIFF
--- a/Standard.Agents/Brokers/Generators/FunctionGeneratorBroker.cs
+++ b/Standard.Agents/Brokers/Generators/FunctionGeneratorBroker.cs
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+namespace Standard.Agents.Brokers.Generators;
+
+public sealed class FunctionGeneratorBroker : IGeneratorBroker
+{
+    private readonly Func<string, string, ValueTask<string>> generate;
+
+    public FunctionGeneratorBroker(Func<string, string, ValueTask<string>> generate) =>
+        this.generate = generate;
+
+    public async ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt) =>
+        await this.generate(systemPrompt, userPrompt);
+
+    public async IAsyncEnumerable<string> GenerateStreamAsync(
+        string systemPrompt,
+        string userPrompt,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield return await this.generate(systemPrompt, userPrompt);
+    }
+}


### PR DESCRIPTION
Closes #106. Part of #102 (local LLM, bring-your-own, no native dependency).

`FunctionGeneratorBroker` lets a caller plug **in-process local inference** behind the brain's `IGeneratorBroker` port with a single delegate — no HTTP, no API key, and no need to implement streaming:

```csharp
var localBrain = new FunctionGeneratorBroker(
    (systemPrompt, userPrompt) => RunMyLocalModelAsync(systemPrompt, userPrompt));
```

- `GenerateAsync` invokes the delegate.
- `GenerateStreamAsync` yields the delegate's full result as one chunk (a runtime that streams natively can implement `IGeneratorBroker` directly).

Thin liaison to the caller's local runtime — no flow control, no logic. Per The Standard, brokers carry **no unit tests** → single `BROKERS:` commit. The `.LocalBrain(...)` builder that consumes this is a separate `CLIENTS` PR (#102).