### PR TITLE
CLIENTS: Local Brain Builder

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -316,6 +316,31 @@ public class StandardAgentTests
         streamedResponse.Should().Be("Hi there.");
     }
 
+    [Fact]
+    public async Task ShouldUseLocalBrainOnProcessPromptAsync()
+    {
+        // given
+        string expectedAnswer = "answer from the local model";
+
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memory.Object)
+            .LocalBrain((systemPrompt, userPrompt) => ValueTask.FromResult(expectedAnswer))
+            .UseLog(new Mock<ILogBroker>().Object);
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "compute something");
+
+        // then
+        actualResult.Should().Be(expectedAnswer);
+    }
+
     private static async IAsyncEnumerable<string> ToAsyncStream(params string[] tokens)
     {
         foreach (string token in tokens)

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -78,6 +78,13 @@ public sealed partial class StandardAgent : IAgent
         Set(() => this.brainSettings =
             new InferenceSettings(apiUrl, apiKey, model, temperature, maxTokens, timeoutSeconds));
 
+    // The local, in-process counterpart to Brain(apiUrl, ...): plug your own inference
+    // with a delegate and the agent makes no API calls. Pick one — a local brain or an
+    // external one. For a runtime that streams natively, implement IGeneratorBroker and
+    // pass it to UseGenerator instead.
+    public StandardAgent LocalBrain(Func<string, string, ValueTask<string>> generate) =>
+        this;
+
     // Guardians are opt-in. A bare agent (brain only) runs no gate — SPEC.md 8.1 says
     // the Core profile MAY leave Gate and Judge as pass-through. Calling this turns the
     // Gate on; it may share the Brain's endpoint (SPEC.md 9's collapsible substrate) or

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -83,7 +83,7 @@ public sealed partial class StandardAgent : IAgent
     // external one. For a runtime that streams natively, implement IGeneratorBroker and
     // pass it to UseGenerator instead.
     public StandardAgent LocalBrain(Func<string, string, ValueTask<string>> generate) =>
-        this;
+        Set(() => this.generatorBroker = new FunctionGeneratorBroker(generate));
 
     // Guardians are opt-in. A bare agent (brain only) runs no gate — SPEC.md 8.1 says
     // the Core profile MAY leave Gate and Judge as pass-through. Calling this turns the


### PR DESCRIPTION
Closes #108. Part of #102. Follows #107 (`FunctionGeneratorBroker`, already merged).

Adds `.LocalBrain(...)` — the local, in-process counterpart to `.Brain(apiUrl, apiKey, model)`. You pick one; the local path makes **no API calls**:

```csharp
var agent = new StandardAgent()
    .LocalBrain((systemPrompt, userPrompt) => RunMyLocalModelAsync(systemPrompt, userPrompt));
```

Delegate-based BYO inference — no interface to implement (wraps `FunctionGeneratorBroker`). For native streaming, implement `IGeneratorBroker` and use `.UseGenerator(...)`. Distinct builder methods per #102 (`.Brain(url)` external vs `.LocalBrain(...)` local); no auto-switching.

## FAIL → PASS
- `ShouldUseLocalBrainOnProcessPromptAsync -> FAIL` — test + unwired `.LocalBrain` signature; composition threw "Agent has no brain."
- `ShouldUseLocalBrainOnProcessPromptAsync -> PASS` — `.LocalBrain` wires a `FunctionGeneratorBroker`. 213 tests pass, 0 warnings.

(Re-opened against main after #107 merged and its branch was deleted; diff is the client change only.)