### PR TITLE
RELEASES: Bump Package Version To 0.5.0

### DIFF
--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -12,12 +12,12 @@
     <!-- The Standard's release format is v1.2.3.4 — model . service/routine . fix/config
          . automated build. Deliberately NOT semver; the segments say what KIND of change
          happened, so a model change can never hide in the service segment.
-         0.4.0.0: streaming — StreamPromptAsync yields typed AgentStreamEvents (thinking
-         and responses) live over SSE. New service routines and supporting wire/client
-         models, but the spec's core AgentContext model is unchanged, so this is a
-         service/routine change: segment 2 advances, 3/4 reset. Still tracks SPEC.md v0.1
-         (draft): segment 1 goes to 1 when the spec settles. -->
-    <Version>0.4.0.0</Version>
+         0.5.0.0: sub-agent handoff templates (AgentTool) and a local, in-process brain
+         (.LocalBrain + FunctionGeneratorBroker, no API calls). New client routines and a
+         broker, the spec's core AgentContext model unchanged, so this is a service/routine
+         change: segment 2 advances, 3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1
+         goes to 1 when the spec settles. -->
+    <Version>0.5.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>


### PR DESCRIPTION
Releases sub-agent handoff (#105) and local brain (#107 + #111). New client routines + a broker, spec's `AgentContext` unchanged → service/routine change, segment 2: `0.4.0.0 → 0.5.0.0`. Structured tool-calls remain gated on spec §6.1 (specs#3) for a later release.