### PR TITLE
ORCHESTRATIONS: Interpret Structured Tool-Calls

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
@@ -211,4 +211,46 @@ public partial class DecisionOrchestrationServiceTests
                 It.Is<string>(userMessage => userMessage.Contains(observation))),
                     Times.Once);
     }
+
+    [Fact]
+    public async Task ShouldRouteStructuredToolCallOnThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(
+                    "TOOL: {\"tool\":\"calculator\",\"arguments\":{\"expression\":\"47*89\"}}");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("calculator");
+        actualContext.Intent.Should().Be("calculator");
+        actualContext.Payload.Should().Contain("47*89");
+    }
+
+    [Fact]
+    public async Task ShouldTreatMalformedToolCallAsAnswerOnThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("TOOL: this is not valid json");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("ReturnResponse");
+    }
 }

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -5,6 +5,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.Json;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Orchestrations.Agents;
@@ -17,6 +18,7 @@ namespace Standard.Agents.Services.Orchestrations.Decision;
 public partial class DecisionOrchestrationService : IDecisionOrchestrationService
 {
     private const string ActionPrefix = "ACTION:";
+    private const string ToolPrefix = "TOOL:";
     private const string FinalPrefix = "FINAL:";
     private const string RefuseVerdict = "refuse";
     private const string RefuseDirection = "Refuse";
@@ -219,6 +221,18 @@ verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase
     {
         string firstLine = reply.Split('\n')[0].Trim();
 
+        if (firstLine.StartsWith(ToolPrefix, StringComparison.OrdinalIgnoreCase)
+            && TryParseToolCall(firstLine[ToolPrefix.Length..], out string calledTool, out string arguments))
+        {
+            return context with
+            {
+                Intent = calledTool,
+                DirectionType = calledTool,
+                Payload = arguments,
+                RawReply = reply
+            };
+        }
+
         bool modelChoseToAct =
             firstLine.StartsWith(ActionPrefix, StringComparison.OrdinalIgnoreCase);
 
@@ -258,5 +272,47 @@ verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase
             Payload = answer,
             RawReply = reply
         };
+    }
+
+    private static bool TryParseToolCall(string json, out string toolName, out string arguments)
+    {
+        toolName = string.Empty;
+        arguments = string.Empty;
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(json);
+            JsonElement root = document.RootElement;
+
+            if (root.ValueKind is not JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            if (root.TryGetProperty("tool", out JsonElement toolElement) is false
+                || toolElement.ValueKind is not JsonValueKind.String)
+            {
+                return false;
+            }
+
+            string parsedTool = toolElement.GetString() ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(parsedTool))
+            {
+                return false;
+            }
+
+            toolName = parsedTool;
+
+            arguments = root.TryGetProperty("arguments", out JsonElement argumentsElement)
+                ? argumentsElement.GetRawText()
+                : "{}";
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Closes #113. Implements SPEC §6.1 parsing. Part of #110.

`Interpret` now recognises a structured tool-call on the first line, alongside the text `ACTION:` / `FINAL:` forms (unchanged, Core):

```
TOOL: {"tool":"calculator","arguments":{"expression":"47*89"}}
```

→ `DirectionType = "calculator"`, `Payload = {"expression":"47*89"}` (raw JSON arguments passed to the tool).

- Parses `tool` (non-blank string) + `arguments` (object, raw-JSON).
- A **malformed** `TOOL:` line (bad JSON, missing/blank `tool`) **recovers** — `TryParseToolCall` returns false and the reply falls through to the answer branch (§6.1), never faulting.

## FAIL → PASS
- `ShouldRouteStructuredToolCallOnThinkAsync -> FAIL` — `TOOL:` unrecognised, treated as a (rejected) answer; `DirectionType` was not `"calculator"`.
- `ShouldRouteStructuredToolCallOnThinkAsync -> PASS` — parsing routes it. Companion `ShouldTreatMalformedToolCallAsAnswerOnThinkAsync` holds. 216 tests, 6/6 vectors, 0 warnings.