### PR TITLE
CLIENTS: ITool Carries Description And Parameters

### DIFF
--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
@@ -162,4 +162,22 @@ public class AgentToolTests
 
         nestedAgentMock.VerifyNoOtherCalls();
     }
+
+    [Fact]
+    public void ShouldExposeDescriptionAndParametersOnAgentTool()
+    {
+        // given
+        string description = "Delegates a research question to a specialist.";
+        string parameters = "{\"query\":\"string\"}";
+
+        var agentTool = new AgentTool(
+            name: "researcher",
+            agent: new Mock<IAgent>().Object,
+            description: description,
+            parameters: parameters);
+
+        // then
+        agentTool.Description.Should().Be(description);
+        agentTool.Parameters.Should().Be(parameters);
+    }
 }

--- a/Standard.Agents/Tools/AgentTool.cs
+++ b/Standard.Agents/Tools/AgentTool.cs
@@ -14,11 +14,21 @@ public sealed class AgentTool : ITool
 
     public string Name { get; }
 
-    // The handoff is what the outer agent tells this sub-agent to do: a template whose
-    // "{input}" is replaced with the string the outer agent placed after its ACTION.
-    // Left at its default it is exactly "{input}", so the raw input passes through
-    // unchanged and the sub-agent behaves as before.
-    public AgentTool(string name, IAgent agent, string handoff = InputPlaceholder)
+    public string Description { get; } = string.Empty;
+
+    public string Parameters { get; } = "{}";
+
+    // The three things that define the sub-agent as a tool (SPEC §6.1): the handoff (what
+    // the outer agent tells it to do — a template whose "{input}" is replaced with the
+    // string the outer agent supplied), a description (what it does / when to use it), and
+    // parameters (a schema of its inputs). Handoff left at its default is exactly "{input}",
+    // so the raw input passes through unchanged and the sub-agent behaves as before.
+    public AgentTool(
+        string name,
+        IAgent agent,
+        string handoff = InputPlaceholder,
+        string description = "",
+        string parameters = "{}")
     {
         this.Name = name;
         this.agent = agent;

--- a/Standard.Agents/Tools/AgentTool.cs
+++ b/Standard.Agents/Tools/AgentTool.cs
@@ -14,9 +14,9 @@ public sealed class AgentTool : ITool
 
     public string Name { get; }
 
-    public string Description { get; } = string.Empty;
+    public string Description { get; }
 
-    public string Parameters { get; } = "{}";
+    public string Parameters { get; }
 
     // The three things that define the sub-agent as a tool (SPEC §6.1): the handoff (what
     // the outer agent tells it to do — a template whose "{input}" is replaced with the
@@ -33,6 +33,8 @@ public sealed class AgentTool : ITool
         this.Name = name;
         this.agent = agent;
         this.handoff = handoff;
+        this.Description = description;
+        this.Parameters = parameters;
     }
 
     // The nested agent runs its own full loop — its own Recall, Think, Act, its own

--- a/Standard.Agents/Tools/ITool.cs
+++ b/Standard.Agents/Tools/ITool.cs
@@ -9,5 +9,9 @@ public interface ITool
 {
     string Name { get; }
 
+    string Description => string.Empty;
+
+    string Parameters => "{}";
+
     ValueTask<string> ExecuteAsync(string input);
 }


### PR DESCRIPTION
Closes #115. Implements the SPEC §6.1 tool contract. Part of #110.

`ITool` gains `Description` and `Parameters` as **default interface members** (`""` and `"{}"`), so it's **non-breaking** — every existing tool compiles unchanged; a tool opts in by overriding.

`AgentTool` now carries the full three-field handoff:
```csharp
new AgentTool(
    name: "researcher",
    agent: innerAgent,
    handoff: "Research and report: {input}",       // prompt (#105)
    description: "Delegates a research question to a specialist.",
    parameters: "{ \"query\": \"string\" }");
```

## FAIL → PASS
- `ShouldExposeDescriptionAndParametersOnAgentTool -> FAIL` — properties declared + constructor params added, but not wired; `Description` was `""`.
- `ShouldExposeDescriptionAndParametersOnAgentTool -> PASS` — constructor assigns them. 215 tests, 0 warnings.

Non-breaking via default interface members; no other `ITool` implementer changes.