### PR TITLE
ACCEPTANCE: Structured Tool-Call Conformance Vector (§6.1)

### DIFF
--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -71,3 +71,4 @@ the deterministic core of the Standard.
 | `multiline-final` | A `FINAL` answer may span multiple lines |
 | `unknown-tool-recovers` | An unknown tool routes to External and the agent recovers |
 | `max-turns-cap` | A never-terminating Brain is capped by the loop |
+| `structured-tool-call` | A structured `TOOL:` call (§6.1) routes to the tool with its arguments |

--- a/conformance/vectors/07-structured-tool-call.json
+++ b/conformance/vectors/07-structured-tool-call.json
@@ -1,0 +1,8 @@
+{
+  "name": "structured-tool-call",
+  "description": "A structured TOOL: call (SPEC 6.1) routes to the tool with its arguments; the result answers.",
+  "generatorReplies": ["TOOL: {\"tool\":\"calculator\",\"arguments\":{\"expression\":\"47*89\"}}", "FINAL: 4183"],
+  "tools": { "calculator": "4183" },
+  "prompt": "what is 47*89",
+  "expect": { "result": "4183" }
+}


### PR DESCRIPTION
Part of #110. Certifies the SPEC §6.1 structured protocol (parse landed in #114).

New vector `07-structured-tool-call` — a scripted brain emits:
```
TOOL: {"tool":"calculator","arguments":{"expression":"47*89"}}
```
which routes to the `calculator` tool with its arguments; the result feeds back and the next turn answers `FINAL: 4183`. The whole 1·3·9 is real; only the brain is scripted.

**7/7 vectors pass** (the 6 text-protocol vectors are unaffected). CONFORMANCE.md updated.