### PR TITLE
RELEASES: Bump Package Version To 0.6.0

### DIFF
--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -12,12 +12,14 @@
     <!-- The Standard's release format is v1.2.3.4 — model . service/routine . fix/config
          . automated build. Deliberately NOT semver; the segments say what KIND of change
          happened, so a model change can never hide in the service segment.
-         0.5.0.0: sub-agent handoff templates (AgentTool) and a local, in-process brain
-         (.LocalBrain + FunctionGeneratorBroker, no API calls). New client routines and a
-         broker, the spec's core AgentContext model unchanged, so this is a service/routine
-         change: segment 2 advances, 3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1
-         goes to 1 when the spec settles. -->
-    <Version>0.5.0.0</Version>
+         0.6.0.0: structured tool-calls (SPEC 6.1) — the Brain may emit a JSON
+         'TOOL: { tool, arguments }' call, parsed alongside the text ACTION:/FINAL:
+         protocol (Core, unchanged); tools carry description + parameters via default
+         interface members. New interpret routine + tool contract, the spec's core
+         AgentContext model unchanged, so this is a service/routine change: segment 2
+         advances, 3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1 goes to 1
+         when the spec settles. -->
+    <Version>0.6.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>


### PR DESCRIPTION
Releases structured tool-calls (SPEC §6.1): #114 (interpret TOOL:), #116 (ITool description/parameters), #117 (conformance vector). Text `ACTION:`/`FINAL:` unchanged (Core). Service/routine change, segment 2: `0.5.0.0 → 0.6.0.0`. 217 tests, 7/7 vectors.