### PR TITLE
ORCHESTRATIONS: Advertise Described Tools At The {{tools}} Marker

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -341,6 +341,49 @@ public class StandardAgentTests
         actualResult.Should().Be(expectedAnswer);
     }
 
+    [Fact]
+    public async Task ShouldAdvertiseOnlyDescribedToolsAtToolsMarkerOnProcessPromptAsync()
+    {
+        // given
+        string capturedSystemPrompt = string.Empty;
+
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("Tools:\n{{tools}}");
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var generatorBroker = new Mock<IGeneratorBroker>();
+        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string>((systemPrompt, userPrompt) => capturedSystemPrompt = systemPrompt)
+            .ReturnsAsync("FINAL: done");
+
+        var describedTool = new Mock<Standard.Agents.Tools.ITool>();
+        describedTool.SetupGet(tool => tool.Name).Returns("calculator");
+        describedTool.SetupGet(tool => tool.Description).Returns("Evaluate arithmetic.");
+        describedTool.SetupGet(tool => tool.Parameters).Returns("{}");
+
+        var hiddenTool = new Mock<Standard.Agents.Tools.ITool>();
+        hiddenTool.SetupGet(tool => tool.Name).Returns("secret");
+        hiddenTool.SetupGet(tool => tool.Description).Returns(string.Empty);
+
+        var agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memory.Object)
+            .UseGenerator(generatorBroker.Object)
+            .UseLog(new Mock<ILogBroker>().Object)
+            .Tool(describedTool.Object)
+            .Tool(hiddenTool.Object);
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "compute something");
+
+        // then
+        capturedSystemPrompt.Should().Contain("calculator");
+        capturedSystemPrompt.Should().NotContain("secret");
+        capturedSystemPrompt.Should().NotContain("{{tools}}");
+    }
+
     private static async IAsyncEnumerable<string> ToAsyncStream(params string[] tokens)
     {
         foreach (string token in tokens)

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Recall.cs
@@ -122,4 +122,28 @@ public partial class DataOrchestrationServiceTests
         // then
         actualContext.Observations.Should().Contain(priorObservation);
     }
+
+    [Fact]
+    public async Task ShouldExpandToolsMarkerInSystemPromptOnRecallAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        string skillsWithMarker = "You may use these tools:\n{{tools}}\nChoose one.";
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync())
+                .ReturnsAsync(skillsWithMarker);
+
+        this.memoryServiceMock.Setup(service =>
+            service.RecallMemoriesAsync())
+                .ReturnsAsync([]);
+
+        // when
+        AgentContext actualContext =
+            await this.dataOrchestrationService.RecallAsync(inputContext);
+
+        // then
+        actualContext.SystemPrompt.Should().Contain(ToolCatalog);
+        actualContext.SystemPrompt.Should().NotContain("{{tools}}");
+    }
 }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
@@ -19,6 +19,8 @@ namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Data;
 
 public partial class DataOrchestrationServiceTests
 {
+    private const string ToolCatalog = "- calculator — Evaluate arithmetic. parameters: {}";
+
     private readonly Mock<ISkillService> skillServiceMock;
     private readonly Mock<IMemoryService> memoryServiceMock;
     private readonly Mock<IKnowledgeService> knowledgeServiceMock;
@@ -36,6 +38,7 @@ public partial class DataOrchestrationServiceTests
             skillService: this.skillServiceMock.Object,
             memoryService: this.memoryServiceMock.Object,
             knowledgeService: this.knowledgeServiceMock.Object,
+            toolCatalog: ToolCatalog,
             loggingBroker: this.loggingBrokerMock.Object);
     }
 

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -13,20 +13,25 @@ namespace Standard.Agents.Services.Orchestrations.Data;
 
 public partial class DataOrchestrationService : IDataOrchestrationService
 {
+    private const string ToolsMarker = "{{tools}}";
+
     private readonly ISkillService skillService;
     private readonly IMemoryService memoryService;
     private readonly IKnowledgeService knowledgeService;
+    private readonly string toolCatalog;
     private readonly ILoggingBroker loggingBroker;
 
     public DataOrchestrationService(
         ISkillService skillService,
         IMemoryService memoryService,
         IKnowledgeService knowledgeService,
+        string toolCatalog,
         ILoggingBroker loggingBroker)
     {
         this.skillService = skillService;
         this.memoryService = memoryService;
         this.knowledgeService = knowledgeService;
+        this.toolCatalog = toolCatalog;
         this.loggingBroker = loggingBroker;
     }
 

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -40,8 +40,10 @@ public partial class DataOrchestrationService : IDataOrchestrationService
     {
         ValidateContext(context);
 
-        string systemPrompt = await this.skillService.RetrieveSkillsAsync();
+        string skills = await this.skillService.RetrieveSkillsAsync();
         IReadOnlyList<string> memories = await this.memoryService.RecallMemoriesAsync();
+
+        string systemPrompt = skills.Replace(ToolsMarker, this.toolCatalog);
 
         return context with
         {

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -259,6 +259,7 @@ public sealed partial class StandardAgent : IAgent
             new SkillService(skill, logging),
             new MemoryService(memory, logging),
             new KnowledgeService(knowledge, logging),
+            RenderToolCatalog(),
             logging);
 
         DecisionOrchestrationService decision = new(
@@ -274,6 +275,19 @@ public sealed partial class StandardAgent : IAgent
             logging);
 
         return new AgentCoordinationService(data, decision, direction, log, logging);
+    }
+
+    // The catalog a "{{tools}}" marker in the agent's Data expands into. Only tools that
+    // carry a description are listed — a description is the opt-in (SPEC 6.1); a tool with
+    // none is callable but not advertised. Derived from the registered tools, so it never
+    // drifts from what is actually there.
+    private string RenderToolCatalog()
+    {
+        IEnumerable<string> describedTools = this.tools
+            .Where(tool => string.IsNullOrWhiteSpace(tool.Description) is false)
+            .Select(tool => $"- {tool.Name} — {tool.Description} parameters: {tool.Parameters}");
+
+        return string.Join("\n", describedTools);
     }
 
 }


### PR DESCRIPTION
Implements SPEC §6.1 developer-controlled advertisement. Part of #110.

Recall now expands a `{{tools}}` marker in the agent's Data (a skill) into the catalog of **described** tools:

```
Tools:
{{tools}}
```
becomes
```
Tools:
- calculator — Evaluate arithmetic. parameters: {}
```

- **Developer-controlled** — no marker, no advertisement; you place it and frame it.
- **Description is the opt-in** — `RenderToolCatalog` lists only tools with a non-blank `Description`; a description-less tool is **callable but hidden**.
- **No drift** — the catalog is derived from the registered tools.

The catalog is rendered at the composition root from the registered tools and threaded to `DataOrchestrationService` as Data; Recall does the substitution.

## FAIL → PASS
- `ShouldExpandToolsMarkerInSystemPromptOnRecallAsync -> FAIL` — catalog injected but the marker left un-expanded.
- `ShouldExpandToolsMarkerInSystemPromptOnRecallAsync -> PASS` — Recall substitutes the marker. Plus a client end-to-end test: a described tool reaches the Brain's system prompt, a description-less one does not, and no marker leaks. 219 tests, 7/7 vectors, 0 warnings.