### PR TITLE
ORCHESTRATIONS: Recall Retrieves Knowledge

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -151,6 +151,8 @@ public class StandardAgentTests
         memoryBroker.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var knowledgeBroker = new Mock<IKnowledgeBroker>();
+        knowledgeBroker.Setup(b => b.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+
         var logBroker = new Mock<ILogBroker>();
 
         var agent = new StandardAgent()
@@ -225,7 +227,7 @@ public class StandardAgentTests
     .UseGate(gate.Object)
     .UseJudge(judge.Object)
     .UseMemory(memory.Object)
-    .UseKnowledge(new Mock<IKnowledgeBroker>().Object)
+    .UseKnowledge(EmptyKnowledgeBroker())
     .UseLog(new Mock<ILogBroker>().Object);
 
         // when
@@ -269,7 +271,7 @@ public class StandardAgentTests
             .UseGate(gate.Object)
             .UseJudge(judge.Object)
             .UseMemory(memory.Object)
-            .UseKnowledge(new Mock<IKnowledgeBroker>().Object)
+            .UseKnowledge(EmptyKnowledgeBroker())
             .UseLog(new Mock<ILogBroker>().Object);
 
         // when
@@ -382,6 +384,14 @@ public class StandardAgentTests
         capturedSystemPrompt.Should().Contain("calculator");
         capturedSystemPrompt.Should().NotContain("secret");
         capturedSystemPrompt.Should().NotContain("{{tools}}");
+    }
+
+    private static IKnowledgeBroker EmptyKnowledgeBroker()
+    {
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+        knowledgeBroker.Setup(b => b.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+
+        return knowledgeBroker.Object;
     }
 
     private static async IAsyncEnumerable<string> ToAsyncStream(params string[] tokens)

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Recall.cs
@@ -146,4 +146,35 @@ public partial class DataOrchestrationServiceTests
         actualContext.SystemPrompt.Should().Contain(ToolCatalog);
         actualContext.SystemPrompt.Should().NotContain("{{tools}}");
     }
+
+    [Fact]
+    public async Task ShouldSeedKnowledgeIntoObservationsOnRecallAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        List<string> randomKnowledge = [CreateRandomString(), CreateRandomString()];
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync())
+                .ReturnsAsync(CreateRandomString());
+
+        this.memoryServiceMock.Setup(service =>
+            service.RecallMemoriesAsync())
+                .ReturnsAsync([]);
+
+        this.knowledgeServiceMock.Setup(service =>
+            service.RetrieveKnowledgeAsync(It.IsAny<string>()))
+                .ReturnsAsync(randomKnowledge);
+
+        // when
+        AgentContext actualContext =
+            await this.dataOrchestrationService.RecallAsync(inputContext);
+
+        // then
+        actualContext.Observations.Should().Contain(randomKnowledge);
+
+        this.knowledgeServiceMock.Verify(service =>
+            service.RetrieveKnowledgeAsync(inputContext.Prompt),
+                Times.Once);
+    }
 }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.cs
@@ -34,6 +34,10 @@ public partial class DataOrchestrationServiceTests
         this.knowledgeServiceMock = new Mock<IKnowledgeService>();
         this.loggingBrokerMock = new Mock<ILoggingBroker>();
 
+        this.knowledgeServiceMock.Setup(service =>
+            service.RetrieveKnowledgeAsync(It.IsAny<string>()))
+                .ReturnsAsync([]);
+
         this.dataOrchestrationService = new DataOrchestrationService(
             skillService: this.skillServiceMock.Object,
             memoryService: this.memoryServiceMock.Object,

--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
@@ -16,6 +16,14 @@ public class AgentToolTests
     private static string CreateRandomString() =>
         new MnemonicString().GetValue();
 
+    private static Brokers.Knowledges.IKnowledgeBroker EmptyKnowledgeBroker()
+    {
+        var knowledgeBroker = new Mock<Brokers.Knowledges.IKnowledgeBroker>();
+        knowledgeBroker.Setup(b => b.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+
+        return knowledgeBroker.Object;
+    }
+
     [Fact]
     public async Task ShouldRunNestedAgentAsToolAsync()
     {
@@ -88,7 +96,7 @@ public class AgentToolTests
             .UseSkills(skills.Object)
             .UseGenerator(outerBrain.Object)
             .UseMemory(memory.Object)
-            .UseKnowledge(new Mock<Brokers.Knowledges.IKnowledgeBroker>().Object)
+            .UseKnowledge(EmptyKnowledgeBroker())
             .UseGate(gate.Object)
             .UseJudge(judge.Object)
             .UseMcp(new Mock<Brokers.Mcps.IMcpBroker>().Object)

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -42,13 +42,14 @@ public partial class DataOrchestrationService : IDataOrchestrationService
 
         string skills = await this.skillService.RetrieveSkillsAsync();
         IReadOnlyList<string> memories = await this.memoryService.RecallMemoriesAsync();
+        IReadOnlyList<string> knowledge = await this.knowledgeService.RetrieveKnowledgeAsync(context.Prompt);
 
         string systemPrompt = skills.Replace(ToolsMarker, this.toolCatalog);
 
         return context with
         {
             SystemPrompt = systemPrompt,
-            Observations = [.. context.Observations, .. memories]
+            Observations = [.. context.Observations, .. memories, .. knowledge]
         };
     });
 }


### PR DESCRIPTION
Closes #121. Recall now queries `KnowledgeService` with the prompt and seeds the hits into observations — previously `KnowledgeService` was composed but never called, so `.Knowledge(path)` did nothing. Implements the Data side of SPEC §8.2.

```csharp
IReadOnlyList<string> knowledge = await this.knowledgeService.RetrieveKnowledgeAsync(context.Prompt);
// ... Observations = [.. context.Observations, .. memories, .. knowledge]
```

## FAIL → PASS
- `ShouldSeedKnowledgeIntoObservationsOnRecallAsync -> FAIL` — knowledge never queried; observations empty.
- `ShouldSeedKnowledgeIntoObservationsOnRecallAsync -> PASS` — Recall queries and seeds. 220 tests, 7/7 vectors, 0 warnings.

(Test doubles that mocked `IKnowledgeBroker` unconfigured were returning null; configured them to `[]`, matching the real broker.)