### PR TITLE
CLIENTS: Built-In Remember Tool (Agent Writes Memory)

### DIFF
--- a/Standard.Agents.Tests.Unit/Tools/RememberToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/RememberToolTests.cs
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Tools;
+
+public class RememberToolTests
+{
+    [Fact]
+    public async Task ShouldWriteToMemoryOnExecuteAsync()
+    {
+        // given
+        string fact = "Hassan works on PeerLLM";
+        var memoryBroker = new Mock<IMemoryBroker>();
+        var rememberTool = new RememberTool(memoryBroker.Object);
+
+        // when
+        string actualResult = await rememberTool.ExecuteAsync(fact);
+
+        // then
+        actualResult.Should().Contain(fact);
+
+        memoryBroker.Verify(broker =>
+            broker.InsertMemoryAsync(fact),
+                Times.Once);
+    }
+
+    [Fact]
+    public async Task ShouldExtractFactFromStructuredArgumentsOnExecuteAsync()
+    {
+        // given
+        var memoryBroker = new Mock<IMemoryBroker>();
+        var rememberTool = new RememberTool(memoryBroker.Object);
+
+        // when
+        await rememberTool.ExecuteAsync("{\"fact\":\"Paris is the capital of France\"}");
+
+        // then
+        memoryBroker.Verify(broker =>
+            broker.InsertMemoryAsync("Paris is the capital of France"),
+                Times.Once);
+    }
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -222,6 +222,8 @@ public sealed partial class StandardAgent : IAgent
         IMemoryBroker memory =
             this.memoryBroker ?? new MemoryBroker(this.memoryPath);
 
+        List<ITool> allTools = [.. this.tools, new RememberTool(memory)];
+
         IKnowledgeBroker knowledge =
             this.knowledgeBroker ?? new KnowledgeBroker(
                 this.knowledgePath, this.knowledgePattern, this.knowledgeMaxResults);
@@ -242,7 +244,7 @@ public sealed partial class StandardAgent : IAgent
                     this.judgeSettings.Temperature, this.judgeSettings.MaxTokens,
                     this.judgeSettings.TimeoutSeconds, GuardianPrompts.Judge));
 
-        IToolBroker toolBroker = new ToolBroker(this.tools);
+        IToolBroker toolBroker = new ToolBroker(allTools);
 
         IMcpBroker mcp =
             this.mcpBroker ?? (string.IsNullOrWhiteSpace(this.mcpEndpointUrl)
@@ -259,7 +261,7 @@ public sealed partial class StandardAgent : IAgent
             new SkillService(skill, logging),
             new MemoryService(memory, logging),
             new KnowledgeService(knowledge, logging),
-            RenderToolCatalog(),
+            RenderToolCatalog(allTools),
             logging);
 
         DecisionOrchestrationService decision = new(
@@ -281,9 +283,9 @@ public sealed partial class StandardAgent : IAgent
     // carry a description are listed — a description is the opt-in (SPEC 6.1); a tool with
     // none is callable but not advertised. Derived from the registered tools, so it never
     // drifts from what is actually there.
-    private string RenderToolCatalog()
+    private static string RenderToolCatalog(IEnumerable<ITool> tools)
     {
-        IEnumerable<string> describedTools = this.tools
+        IEnumerable<string> describedTools = tools
             .Where(tool => string.IsNullOrWhiteSpace(tool.Description) is false)
             .Select(tool => $"- {tool.Name} — {tool.Description} parameters: {tool.Parameters}");
 

--- a/Standard.Agents/Tools/RememberTool.cs
+++ b/Standard.Agents/Tools/RememberTool.cs
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.Json;
+using Standard.Agents.Brokers.Memorys;
+
+namespace Standard.Agents.Tools;
+
+public sealed class RememberTool : ITool
+{
+    private readonly IMemoryBroker memoryBroker;
+
+    public string Name => "remember";
+
+    public string Description =>
+        "Store a fact to remember across sessions. Use it when the user tells you "
+            + "something worth keeping — their name, where they are, their preferences.";
+
+    public string Parameters => "{ \"fact\": \"the fact to remember\" }";
+
+    public RememberTool(IMemoryBroker memoryBroker) =>
+        this.memoryBroker = memoryBroker;
+
+    public async ValueTask<string> ExecuteAsync(string input)
+    {
+        string fact = ExtractFact(input);
+
+        await Task.CompletedTask;
+
+        return $"Remembered: {fact}";
+    }
+
+    private static string ExtractFact(string input)
+    {
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(input);
+
+            if (document.RootElement.ValueKind is JsonValueKind.Object
+                && document.RootElement.TryGetProperty("fact", out JsonElement factElement)
+                && factElement.ValueKind is JsonValueKind.String)
+            {
+                return factElement.GetString() ?? input;
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return input;
+    }
+}

--- a/Standard.Agents/Tools/RememberTool.cs
+++ b/Standard.Agents/Tools/RememberTool.cs
@@ -27,7 +27,7 @@ public sealed class RememberTool : ITool
     {
         string fact = ExtractFact(input);
 
-        await Task.CompletedTask;
+        await this.memoryBroker.InsertMemoryAsync(fact);
 
         return $"Remembered: {fact}";
     }


### PR DESCRIPTION
Closes #123. A built-in `remember` tool the agent calls to persist a fact — the write side of memory (SPEC §7.4: memory is written by Direction; a tool run through Direction is exactly that). Previously `RememberAsync` was never invoked, so the agent never remembered.

- `RememberTool` writes the fact via the memory broker; accepts a raw fact (`ACTION: remember: …`) or structured arguments (`{"fact":"…"}`).
- `Compose` wires it into every agent's tools, so it advertises like any other — **only when you surface it** (via `{{tools}}` or a skill). No advertisement, no remembering.
- On the next run, Recall reads the store back into observations.

## FAIL → PASS
- `ShouldWriteToMemoryOnExecuteAsync -> FAIL` — tool returned a confirmation without writing.
- `ShouldWriteToMemoryOnExecuteAsync -> PASS` — it writes via `InsertMemoryAsync`; plus structured-argument extraction. 221 tests, 7/7 vectors, 0 warnings.

**Verified live:** session 1 tells the agent "My name is Hassan and I work on PeerLLM" → it calls `remember` → a brand-new agent in session 2 (same memory file) answers "Your name is Hassan and you work on PeerLLM."