### PR TITLE
RELEASES: Bump Package Version To 0.8.0

### DIFF
--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -12,13 +12,13 @@
     <!-- The Standard's release format is v1.2.3.4 — model . service/routine . fix/config
          . automated build. Deliberately NOT semver; the segments say what KIND of change
          happened, so a model change can never hide in the service segment.
-         0.7.0.0: developer-controlled tool advertisement (SPEC 6.1) — Recall expands a
-         '{{tools}}' marker in Data into the catalog of described tools; a description is
-         the opt-in, a description-less tool stays callable but hidden. New Recall routine
-         behaviour, the spec's core AgentContext model unchanged, so this is a
-         service/routine change: segment 2 advances, 3/4 reset. Still tracks SPEC.md v0.1
-         (draft): segment 1 goes to 1 when the spec settles. -->
-    <Version>0.7.0.0</Version>
+         0.8.0.0: memory and knowledge come alive — Recall now queries the knowledge store
+         and seeds hits into observations, and a built-in 'remember' tool lets the agent
+         write memory (persisting across restarts). New Recall + tool routines, the spec's
+         core AgentContext model unchanged, so this is a service/routine change: segment 2
+         advances, 3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1 goes to 1 when
+         the spec settles. -->
+    <Version>0.8.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>


### PR DESCRIPTION
Releases the memory + knowledge features the new how-to (#125) documents: knowledge retrieval (#122) and the built-in remember tool (#124). Service/routine change, segment 2: `0.7.0.0 → 0.8.0.0`. 222 tests, 7/7 vectors.