### PR TITLE
BROKERS: LLamaSharp Generator Adapter For Local In-Process Inference

### DIFF
--- a/Standard.Agents.LlamaSharp/LlamaSharpGeneratorBroker.cs
+++ b/Standard.Agents.LlamaSharp/LlamaSharpGeneratorBroker.cs
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Text;
+using LLama;
+using LLama.Common;
+using LLama.Sampling;
+using Standard.Agents.Brokers.Generators;
+
+namespace Standard.Agents.LlamaSharp;
+
+public sealed class LlamaSharpGeneratorBroker : IGeneratorBroker, IDisposable
+{
+    private const string AntiPrompt = "User:";
+
+    private readonly LLamaWeights weights;
+    private readonly StatelessExecutor executor;
+    private readonly int maxTokens;
+
+    public LlamaSharpGeneratorBroker(
+        string modelPath,
+        int contextSize = 4096,
+        int gpuLayerCount = 0,
+        int maxTokens = 1024)
+    {
+        var parameters = new ModelParams(modelPath)
+        {
+            ContextSize = (uint)contextSize,
+            GpuLayerCount = gpuLayerCount
+        };
+
+        this.weights = LLamaWeights.LoadFromFile(parameters);
+        this.executor = new StatelessExecutor(this.weights, parameters);
+        this.maxTokens = maxTokens;
+    }
+
+    public async ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt)
+    {
+        var reply = new StringBuilder();
+
+        await foreach (string token in GenerateStreamAsync(systemPrompt, userPrompt))
+        {
+            reply.Append(token);
+        }
+
+        return reply.ToString();
+    }
+
+    public async IAsyncEnumerable<string> GenerateStreamAsync(
+        string systemPrompt,
+        string userPrompt,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var inferenceParams = new InferenceParams
+        {
+            MaxTokens = this.maxTokens,
+            AntiPrompts = [AntiPrompt],
+            SamplingPipeline = new DefaultSamplingPipeline()
+        };
+
+        IAsyncEnumerable<string> tokens = this.executor.InferAsync(
+            BuildPrompt(systemPrompt, userPrompt),
+            inferenceParams,
+            cancellationToken);
+
+        await foreach (string token in tokens.WithCancellation(cancellationToken))
+        {
+            yield return token;
+        }
+    }
+
+    private static string BuildPrompt(string systemPrompt, string userPrompt)
+    {
+        var prompt = new StringBuilder();
+
+        if (string.IsNullOrWhiteSpace(systemPrompt) is false)
+        {
+            prompt.AppendLine(systemPrompt).AppendLine();
+        }
+
+        prompt.Append("User: ").AppendLine(userPrompt).Append("Assistant: ");
+
+        return prompt.ToString();
+    }
+
+    public void Dispose() =>
+        this.weights.Dispose();
+}

--- a/Standard.Agents.LlamaSharp/LlamaSharpGeneratorBroker.cs
+++ b/Standard.Agents.LlamaSharp/LlamaSharpGeneratorBroker.cs
@@ -14,17 +14,22 @@ namespace Standard.Agents.LlamaSharp;
 
 public sealed class LlamaSharpGeneratorBroker : IGeneratorBroker, IDisposable
 {
-    private const string AntiPrompt = "User:";
-
     private readonly LLamaWeights weights;
     private readonly StatelessExecutor executor;
     private readonly int maxTokens;
+    private readonly Func<string, string, string> formatPrompt;
 
+    // The prompt template is the thing to get right per model: an instruct model only
+    // generates when its own chat format is used. Defaults to ChatML (the most common
+    // modern format); pass PromptTemplates.Plain, or your own (system, user) => prompt,
+    // to match a different model. There is no hard-coded anti-prompt — generation stops
+    // at the model's own end-of-turn / EOS token.
     public LlamaSharpGeneratorBroker(
         string modelPath,
         int contextSize = 4096,
         int gpuLayerCount = 0,
-        int maxTokens = 1024)
+        int maxTokens = 1024,
+        Func<string, string, string>? promptTemplate = null)
     {
         var parameters = new ModelParams(modelPath)
         {
@@ -35,6 +40,7 @@ public sealed class LlamaSharpGeneratorBroker : IGeneratorBroker, IDisposable
         this.weights = LLamaWeights.LoadFromFile(parameters);
         this.executor = new StatelessExecutor(this.weights, parameters);
         this.maxTokens = maxTokens;
+        this.formatPrompt = promptTemplate ?? PromptTemplates.ChatML;
     }
 
     public async ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt)
@@ -57,12 +63,11 @@ public sealed class LlamaSharpGeneratorBroker : IGeneratorBroker, IDisposable
         var inferenceParams = new InferenceParams
         {
             MaxTokens = this.maxTokens,
-            AntiPrompts = [AntiPrompt],
             SamplingPipeline = new DefaultSamplingPipeline()
         };
 
         IAsyncEnumerable<string> tokens = this.executor.InferAsync(
-            BuildPrompt(systemPrompt, userPrompt),
+            this.formatPrompt(systemPrompt, userPrompt),
             inferenceParams,
             cancellationToken);
 
@@ -70,20 +75,6 @@ public sealed class LlamaSharpGeneratorBroker : IGeneratorBroker, IDisposable
         {
             yield return token;
         }
-    }
-
-    private static string BuildPrompt(string systemPrompt, string userPrompt)
-    {
-        var prompt = new StringBuilder();
-
-        if (string.IsNullOrWhiteSpace(systemPrompt) is false)
-        {
-            prompt.AppendLine(systemPrompt).AppendLine();
-        }
-
-        prompt.Append("User: ").AppendLine(userPrompt).Append("Assistant: ");
-
-        return prompt.ToString();
     }
 
     public void Dispose() =>

--- a/Standard.Agents.LlamaSharp/PromptTemplates.cs
+++ b/Standard.Agents.LlamaSharp/PromptTemplates.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.LlamaSharp;
+
+public static class PromptTemplates
+{
+    // ChatML — Qwen and many modern instruct GGUFs. A good first guess.
+    public static string ChatML(string systemPrompt, string userPrompt)
+    {
+        string system = string.IsNullOrWhiteSpace(systemPrompt)
+            ? string.Empty
+            : $"<|im_start|>system\n{systemPrompt}<|im_end|>\n";
+
+        return $"{system}<|im_start|>user\n{userPrompt}<|im_end|>\n<|im_start|>assistant\n";
+    }
+
+    // Llama 3 instruct.
+    public static string Llama3(string systemPrompt, string userPrompt)
+    {
+        string system = string.IsNullOrWhiteSpace(systemPrompt)
+            ? string.Empty
+            : $"<|start_header_id|>system<|end_header_id|>\n\n{systemPrompt}<|eot_id|>";
+
+        return "<|begin_of_text|>" + system
+            + $"<|start_header_id|>user<|end_header_id|>\n\n{userPrompt}<|eot_id|>"
+            + "<|start_header_id|>assistant<|end_header_id|>\n\n";
+    }
+
+    // Plain — base / completion models with no chat format.
+    public static string Plain(string systemPrompt, string userPrompt)
+    {
+        string system = string.IsNullOrWhiteSpace(systemPrompt)
+            ? string.Empty
+            : systemPrompt + "\n\n";
+
+        return $"{system}User: {userPrompt}\nAssistant: ";
+    }
+}

--- a/Standard.Agents.LlamaSharp/PromptTemplates.cs
+++ b/Standard.Agents.LlamaSharp/PromptTemplates.cs
@@ -29,6 +29,11 @@ public static class PromptTemplates
             + "<|start_header_id|>assistant<|end_header_id|>\n\n";
     }
 
+    // NVIDIA Nemotron — the <extra_id_0>/<extra_id_1> sentinel format.
+    public static string Nemotron(string systemPrompt, string userPrompt) =>
+        $"<extra_id_0>System\n{systemPrompt}\n"
+            + $"<extra_id_1>User\n{userPrompt}\n<extra_id_1>Assistant\n";
+
     // Plain — base / completion models with no chat format.
     public static string Plain(string systemPrompt, string userPrompt)
     {

--- a/Standard.Agents.LlamaSharp/README.md
+++ b/Standard.Agents.LlamaSharp/README.md
@@ -43,6 +43,9 @@ new LlamaSharpGeneratorBroker("model.gguf");
 // Llama 3 instruct
 new LlamaSharpGeneratorBroker("model.gguf", promptTemplate: PromptTemplates.Llama3);
 
+// NVIDIA Nemotron
+new LlamaSharpGeneratorBroker("model.gguf", promptTemplate: PromptTemplates.Nemotron);
+
 // Base / completion model
 new LlamaSharpGeneratorBroker("model.gguf", promptTemplate: PromptTemplates.Plain);
 

--- a/Standard.Agents.LlamaSharp/README.md
+++ b/Standard.Agents.LlamaSharp/README.md
@@ -1,0 +1,29 @@
+# Standard.Agents.LlamaSharp
+
+An optional **in-process local-inference brain** for [Standard.Agents](https://www.nuget.org/packages/Standard.Agents),
+backed by [LLamaSharp](https://github.com/SciSharp/LLamaSharp) (llama.cpp). Run GGUF models locally
+— no HTTP, no API key. The core `Standard.Agents` package stays dependency-free; the native weight
+lives only here.
+
+```bash
+dotnet add package Standard.Agents.LlamaSharp
+dotnet add package LLamaSharp.Backend.Cpu     # or .Cuda12 / .Vulkan for GPU
+```
+
+```csharp
+using Standard.Agents;
+using Standard.Agents.LlamaSharp;
+
+var agent = new StandardAgent()
+    .UseGenerator(new LlamaSharpGeneratorBroker("path/to/model.gguf"));
+
+string answer = await agent.ProcessPromptAsync("What is 47 * 89?");
+```
+
+`LlamaSharpGeneratorBroker` implements the brain's `IGeneratorBroker` (both `GenerateAsync` and
+streaming `GenerateStreamAsync`), so everything else — skills, tools, guardians, memory, knowledge,
+streaming — works exactly as with a hosted brain. Constructor options: `contextSize`,
+`gpuLayerCount` (0 = CPU), `maxTokens`.
+
+You supply the `.gguf` model and a backend package; llama.cpp does the rest, entirely on your
+machine.

--- a/Standard.Agents.LlamaSharp/README.md
+++ b/Standard.Agents.LlamaSharp/README.md
@@ -27,3 +27,44 @@ streaming — works exactly as with a hosted brain. Constructor options: `contex
 
 You supply the `.gguf` model and a backend package; llama.cpp does the rest, entirely on your
 machine.
+
+## Choosing the prompt template (important)
+
+An instruct model only generates when it's given **its own chat format**. If generation comes
+back **empty**, the template is almost always the reason. The default is `ChatML` (Qwen and many
+modern GGUFs); switch it to match your model:
+
+```csharp
+using Standard.Agents.LlamaSharp;
+
+// ChatML (default) — Qwen, many modern instruct models
+new LlamaSharpGeneratorBroker("model.gguf");
+
+// Llama 3 instruct
+new LlamaSharpGeneratorBroker("model.gguf", promptTemplate: PromptTemplates.Llama3);
+
+// Base / completion model
+new LlamaSharpGeneratorBroker("model.gguf", promptTemplate: PromptTemplates.Plain);
+
+// Your own — any (systemPrompt, userPrompt) => prompt
+new LlamaSharpGeneratorBroker("model.gguf",
+    promptTemplate: (system, user) => $"<s>[INST] {system}\n{user} [/INST]");   // Mistral
+```
+
+## Backend setup & troubleshooting
+
+`RuntimeError: The native library cannot be correctly loaded` is a **backend** problem, not a
+model or adapter one:
+
+- **Exactly one backend** — never install `LLamaSharp.Backend.Cpu` *and* `.Cuda12` together; they
+  fight over the native `llama` library. CPU-only box → keep only `.Cpu`.
+- **Put the backend in the app that runs**, not just a class library — a `Backend.*` reference on
+  a library doesn't reliably copy its native DLLs into the executable's output. Verify `llama.dll`
+  / `ggml*.dll` sit next to your `.exe`.
+- **Match versions** — `LLamaSharp` and the `Backend` must be the same version.
+- Force CPU and see the load attempts, at the top of `Main`:
+  ```csharp
+  LLama.Native.NativeLibraryConfig.All
+      .WithCuda(false)
+      .WithLogCallback((level, msg) => Console.Write(msg));
+  ```

--- a/Standard.Agents.LlamaSharp/Standard.Agents.LlamaSharp.csproj
+++ b/Standard.Agents.LlamaSharp/Standard.Agents.LlamaSharp.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>Standard.Agents.LlamaSharp</PackageId>
+    <Version>0.1.0.0</Version>
+    <Authors>Hassan Habib</Authors>
+    <Company>Hassan Habib</Company>
+    <Product>The Standard for Agents — LLamaSharp Adapter</Product>
+    <Title>The Standard for Agents — LLamaSharp Adapter</Title>
+    <Description>
+      An optional in-process local-inference brain for Standard.Agents, backed by LLamaSharp
+      (llama.cpp). Runs GGUF models locally with no HTTP and no API key. The core
+      Standard.Agents package stays dependency-free; add a LLamaSharp backend package
+      (LLamaSharp.Backend.Cpu, .Cuda12, .Vulkan, …) to run.
+    </Description>
+    <PackageTags>agent;ai;llm;local;llamasharp;llama-cpp;gguf;the-standard;standard-agents</PackageTags>
+    <Copyright>Copyright (c) Hassan Habib. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/hassanhabib/The-Standard-Agent</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/hassanhabib/The-Standard-Agent</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Standard.Agents\Standard.Agents.csproj" />
+    <PackageReference Include="LLamaSharp" Version="0.27.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE.txt" Pack="true" PackagePath="\" Visible="false" />
+    <None Include="README.md" Pack="true" PackagePath="\" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/Standard.Agents.slnx
+++ b/Standard.Agents.slnx
@@ -2,5 +2,6 @@
   <Project Path="Standard.Agents/Standard.Agents.csproj" />
   <Project Path="Standard.Agents.Conformance/Standard.Agents.Conformance.csproj" />
   <Project Path="Standard.Agents.Demo/Standard.Agents.Demo.csproj" />
+  <Project Path="Standard.Agents.LlamaSharp/Standard.Agents.LlamaSharp.csproj" />
   <Project Path="Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj" />
 </Solution>


### PR DESCRIPTION
Closes #127. The mature route to true in-process local inference in C#, kept **out of core**.

New opt-in package **`Standard.Agents.LlamaSharp`** — an `IGeneratorBroker` backed by [LLamaSharp](https://github.com/SciSharp/LLamaSharp) (llama.cpp):

```csharp
var agent = new StandardAgent()
    .UseGenerator(new LlamaSharpGeneratorBroker("model.gguf"));
```

- **Core stays dependency-free** — `Standard.Agents` references nothing new; the native weight lives only in this adapter. Consumer adds a backend (`LLamaSharp.Backend.Cpu` / `.Cuda12` / `.Vulkan`).
- Implements both `GenerateAsync` and streaming `GenerateStreamAsync` (via `StatelessExecutor` — each brain call is independent, matching the ephemeral agent), so skills, tools, guardians, memory, knowledge, and streaming all work unchanged.
- Separate NuGet package with its own version (0.1.0), README, and license.

## Verification honesty
- **Compiles** against the real LLamaSharp 0.27.0 API (types, `StatelessExecutor`, `InferAsync`, `DefaultSamplingPipeline`).
- **Packs** as `Standard.Agents.LlamaSharp.0.1.0.nupkg`; full solution builds, 222 core tests + 7/7 vectors unaffected.
- **Not run against a real model** — I have no `.gguf` + native backend on this box. The prompt template (`User:`/`Assistant:` with an `AntiPrompt`) is generic and may want the model's own chat template for best results.

**So this merges the code, but I'm not publishing the NuGet package** until you run it locally with a model. Once you confirm generation works on your machine, we cut `Standard.Agents.LlamaSharp 0.1.0`.
