### PR TITLE
MINOR FIX: An Empty Brain Answer Must Not Crash The Judge

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
@@ -253,4 +253,28 @@ public partial class DecisionOrchestrationServiceTests
         // then
         actualContext.DirectionType.Should().Be("ReturnResponse");
     }
+
+    [Fact]
+    public async Task ShouldReturnEmptyAnswerWithoutJudgingOnThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL:");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("ReturnResponse");
+        actualContext.Payload.Should().BeEmpty();
+
+        this.judgeServiceMock.Verify(service =>
+            service.EvaluateAsync(It.IsAny<string>()),
+                Times.Never);
+    }
 }

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -81,6 +81,13 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             return decided;
         }
 
+        // An empty answer is nothing to judge — a judge would (rightly) reject blank input,
+        // which would crash the turn. Return it as-is; the brain simply had nothing to say.
+        if (string.IsNullOrWhiteSpace(decided.Payload))
+        {
+            return decided;
+        }
+
         double score =
             await this.judgeService.EvaluateAsync(candidate: decided.Payload);
 
@@ -167,6 +174,13 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
             yield return new AgentStreamEvent(
                 AgentStreamEventType.Status, $"using tool: {decided.DirectionType}");
+
+            yield break;
+        }
+
+        if (string.IsNullOrWhiteSpace(decided.Payload))
+        {
+            setResult(decided);
 
             yield break;
         }


### PR DESCRIPTION
Closes #129. Surfaced by a local (LLamaSharp) model returning an empty reply.

When the brain returns an empty/whitespace **final answer**, `DecisionOrchestrationService` handed it to `judgeService.EvaluateAsync`, whose `ValidateEvaluate` rejects blank input — bubbling up as:

```
AgentCoordinationDependencyValidationException: Invalid judge input.
```

This fired **even with no judge configured**, because `JudgeService`'s validation runs before the pass-through broker. So any agent whose brain says nothing crashed.

Fix: an empty final answer is nothing to judge — return it as-is (both the sync and streaming paths). The brain simply had nothing to say; the agent yields an empty answer instead of faulting.

## FAIL → PASS
- `ShouldReturnEmptyAnswerWithoutJudgingOnThinkAsync -> FAIL` — empty answer went to the judge, got rejected, looped; `DirectionType` wasn't `ReturnResponse`.
- `ShouldReturnEmptyAnswerWithoutJudgingOnThinkAsync -> PASS` — empty answer skips the judge and returns. 223 tests, 7/7 vectors, 0 warnings.