### PR TITLE
CLIENTS: Simplest-Start Constructor On StandardAgent

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -76,10 +76,10 @@ public class StandardAgentTests
     {
         // given
         var skillBroker = new Mock<ISkillBroker>();
-        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(string.Empty);
 
         var memory = new Mock<IMemoryBroker>();
-        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var agent = new StandardAgent(apiUrl: "invalid-url", apiKey: "key", model: "model")
             .UseSkills(skillBroker.Object)

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -72,6 +72,30 @@ public class StandardAgentTests
     }
 
     [Fact]
+    public async Task ShouldConfigureBrainFromConstructorArgumentsAsync()
+    {
+        // given
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var agent = new StandardAgent(apiUrl: "invalid-url", apiKey: "key", model: "model")
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(EmptyKnowledgeBroker())
+            .UseLog(new Mock<ILogBroker>().Object);
+
+        // when
+        Exception actualException = await Record.ExceptionAsync(() =>
+            agent.ProcessPromptAsync(prompt: "what is the answer?").AsTask());
+
+        // then
+        actualException.Should().NotBeOfType<InvalidAgentCompositionException>();
+    }
+
+    [Fact]
     public void ShouldReturnSameInstanceOnEachBuilderMethod()
     {
         // given

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -65,6 +65,27 @@ public sealed partial class StandardAgent : IAgent
 
     private IAgentCoordinationService? agent;
 
+    /// <summary>
+    /// Creates an agent with nothing configured yet — set it up with the builder methods
+    /// (<see cref="Brain"/>, <see cref="LocalBrain"/>, <see cref="Skills"/>, and the rest)
+    /// before processing a prompt.
+    /// </summary>
+    public StandardAgent()
+    {
+    }
+
+    /// <summary>
+    /// Creates a ready-to-run agent against an OpenAI-compatible endpoint — the simplest start,
+    /// the same as <c>new StandardAgent().Brain(apiUrl, apiKey, model)</c>. Chain further builder
+    /// methods afterward to add skills, tools, guardians, memory or knowledge.
+    /// </summary>
+    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint.</param>
+    /// <param name="apiKey">API key for the endpoint (empty string if none is needed).</param>
+    /// <param name="model">Model name to request from the endpoint.</param>
+    public StandardAgent(string apiUrl, string apiKey, string model)
+    {
+    }
+
     public StandardAgent Skills(string path) =>
         Set(() => this.skillsPath = path);
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -82,9 +82,8 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint.</param>
     /// <param name="apiKey">API key for the endpoint (empty string if none is needed).</param>
     /// <param name="model">Model name to request from the endpoint.</param>
-    public StandardAgent(string apiUrl, string apiKey, string model)
-    {
-    }
+    public StandardAgent(string apiUrl, string apiKey, string model) =>
+        Brain(apiUrl, apiKey, model);
 
     public StandardAgent Skills(string path) =>
         Set(() => this.skillsPath = path);


### PR DESCRIPTION
## What
Adds a three-argument constructor to `StandardAgent` so the simplest possible start is a single line:

```csharp
var agent = new StandardAgent(url, key, llm);
string answer = await agent.ProcessPromptAsync("...");
```

It is exactly `new StandardAgent().Brain(apiUrl, apiKey, model)` — no new type, just an overload. The existing parameterless constructor is kept (now explicit, since adding any constructor removes the implicit one), so `new StandardAgent()` and the full fluent builder keep working unchanged. Chain more builder methods after the constructor to add skills, tools, guardians, memory or knowledge.

## Test (FAIL → PASS)
`ShouldConfigureBrainFromConstructorArgumentsAsync` proves the constructor wires the brain: `ValidateComposition` throws `InvalidAgentCompositionException` **only** for the no-brain case, so the test asserts that path is *not* taken. The FAIL commit left the constructor body empty (brain unwired → composition exception); the PASS commit calls `Brain(...)`. Deterministic and offline — the only outward-facing broker (the generator, built from the constructor's settings) is pointed at an invalid URL; every other dependency is mocked.

## Verification
- `dotnet build` — 0 warnings, 0 errors
- 224 unit tests pass (was 223)
- 7/7 conformance vectors pass

Category: CLIENTS (exposure layer).