### PR TITLE
CODE RUB: Meaningful Lambda Parameter Names Across Tests

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -24,24 +24,24 @@ public class StandardAgentTests
     private static StandardAgent CreateFullyStubbedAgent(string brainReply)
     {
         var skillBroker = new Mock<ISkillBroker>();
-        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("you are an agent");
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync("you are an agent");
 
         var generatorBroker = new Mock<IGeneratorBroker>();
-        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+        generatorBroker.Setup(broker => broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(brainReply);
 
         var memoryBroker = new Mock<IMemoryBroker>();
-        memoryBroker.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var knowledgeBroker = new Mock<IKnowledgeBroker>();
-        knowledgeBroker.Setup(b => b.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
 
         var classifierBroker = new Mock<IClassifierBroker>();
-        classifierBroker.Setup(b => b.ClassifyAsync(It.IsAny<string>()))
+        classifierBroker.Setup(broker => broker.ClassifyAsync(It.IsAny<string>()))
             .ReturnsAsync("allow");
 
         var verifierBroker = new Mock<IVerifierBroker>();
-        verifierBroker.Setup(b => b.VerifyAsync(It.IsAny<string>()))
+        verifierBroker.Setup(broker => broker.VerifyAsync(It.IsAny<string>()))
             .ReturnsAsync("1.0");
 
         var mcpBroker = new Mock<IMcpBroker>();
@@ -99,7 +99,7 @@ public class StandardAgentTests
         string firstResult = await agent.ProcessPromptAsync(prompt: "prompt");
 
         var newGenerator = new Mock<IGeneratorBroker>();
-        newGenerator.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+        newGenerator.Setup(broker => broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync("FINAL: second");
 
         // when
@@ -133,25 +133,25 @@ public class StandardAgentTests
     {
         // given
         var generatorBroker = new Mock<IGeneratorBroker>();
-        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+        generatorBroker.Setup(broker => broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync("FINAL: ok");
 
         var classifierBroker = new Mock<IClassifierBroker>();
-        classifierBroker.Setup(b => b.ClassifyAsync(It.IsAny<string>()))
+        classifierBroker.Setup(broker => broker.ClassifyAsync(It.IsAny<string>()))
             .ReturnsAsync("allow");
 
         var verifierBroker = new Mock<IVerifierBroker>();
-        verifierBroker.Setup(b => b.VerifyAsync(It.IsAny<string>()))
+        verifierBroker.Setup(broker => broker.VerifyAsync(It.IsAny<string>()))
             .ReturnsAsync("1.0");
 
         var skillBroker = new Mock<ISkillBroker>();
-        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("skills");
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync("skills");
 
         var memoryBroker = new Mock<IMemoryBroker>();
-        memoryBroker.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var knowledgeBroker = new Mock<IKnowledgeBroker>();
-        knowledgeBroker.Setup(b => b.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
 
         var logBroker = new Mock<ILogBroker>();
 
@@ -177,13 +177,13 @@ public class StandardAgentTests
     {
         // given
         var skillBroker = new Mock<ISkillBroker>();
-        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(string.Empty);
 
         var memory = new Mock<IMemoryBroker>();
-        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var generatorBroker = new Mock<IGeneratorBroker>();
-        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+        generatorBroker.Setup(broker => broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync("Hello there!");
 
         var agent = new StandardAgent()
@@ -204,22 +204,22 @@ public class StandardAgentTests
     {
         // given
         var skillBroker = new Mock<ISkillBroker>();
-        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("skills");
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync("skills");
 
         var generatorBroker = new Mock<IGeneratorBroker>();
-        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+        generatorBroker.Setup(broker => broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync("FINAL: composed");
 
         var gate = new Mock<IClassifierBroker>();
-        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>()))
+        gate.Setup(broker => broker.ClassifyAsync(It.IsAny<string>()))
             .ReturnsAsync("allow");
 
         var judge = new Mock<IVerifierBroker>();
-        judge.Setup(b => b.VerifyAsync(It.IsAny<string>()))
+        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>()))
             .ReturnsAsync("1.0");
 
         var memory = new Mock<IMemoryBroker>();
-        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var agent = new StandardAgent()
     .UseSkills(skillBroker.Object)
@@ -248,22 +248,22 @@ public class StandardAgentTests
         ]);
 
         var skillBroker = new Mock<ISkillBroker>();
-        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("skills");
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync("skills");
 
         var generatorBroker = new Mock<IGeneratorBroker>();
-        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+        generatorBroker.Setup(broker => broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(() => replies.Dequeue());
 
         var gate = new Mock<IClassifierBroker>();
-        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>()))
+        gate.Setup(broker => broker.ClassifyAsync(It.IsAny<string>()))
             .ReturnsAsync("allow");
 
         var judge = new Mock<IVerifierBroker>();
-        judge.Setup(b => b.VerifyAsync(It.IsAny<string>()))
+        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>()))
             .ReturnsAsync("1.0");
 
         var memory = new Mock<IMemoryBroker>();
-        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var agent = new StandardAgent()
             .UseSkills(skillBroker.Object)
@@ -286,13 +286,13 @@ public class StandardAgentTests
     {
         // given
         var skillBroker = new Mock<ISkillBroker>();
-        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(string.Empty);
 
         var memory = new Mock<IMemoryBroker>();
-        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var generatorBroker = new Mock<IGeneratorBroker>();
-        generatorBroker.Setup(b => b.GenerateStreamAsync(
+        generatorBroker.Setup(broker => broker.GenerateStreamAsync(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Returns(ToAsyncStream("Hi ", "there."));
 
@@ -325,10 +325,10 @@ public class StandardAgentTests
         string expectedAnswer = "answer from the local model";
 
         var skillBroker = new Mock<ISkillBroker>();
-        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(string.Empty);
 
         var memory = new Mock<IMemoryBroker>();
-        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var agent = new StandardAgent()
             .UseSkills(skillBroker.Object)
@@ -350,13 +350,13 @@ public class StandardAgentTests
         string capturedSystemPrompt = string.Empty;
 
         var skillBroker = new Mock<ISkillBroker>();
-        skillBroker.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("Tools:\n{{tools}}");
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync("Tools:\n{{tools}}");
 
         var memory = new Mock<IMemoryBroker>();
-        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var generatorBroker = new Mock<IGeneratorBroker>();
-        generatorBroker.Setup(b => b.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+        generatorBroker.Setup(broker => broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
             .Callback<string, string>((systemPrompt, userPrompt) => capturedSystemPrompt = systemPrompt)
             .ReturnsAsync("FINAL: done");
 
@@ -389,7 +389,7 @@ public class StandardAgentTests
     private static IKnowledgeBroker EmptyKnowledgeBroker()
     {
         var knowledgeBroker = new Mock<IKnowledgeBroker>();
-        knowledgeBroker.Setup(b => b.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
 
         return knowledgeBroker.Object;
     }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
@@ -87,7 +87,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // then
         actualContext.Status.Should().Be(AgentStatus.Working);
-        actualContext.Observations.Should().ContainSingle(o => o.Contains("2"));
+        actualContext.Observations.Should().ContainSingle(observation => observation.Contains("2"));
 
         this.externalToolServiceMock.Verify(service =>
             service.CallAsync(It.IsAny<string>(), It.IsAny<string>()),
@@ -115,7 +115,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // then
         actualContext.Status.Should().Be(AgentStatus.Working);
-        actualContext.Observations.Should().ContainSingle(o => o.Contains("weather"));
+        actualContext.Observations.Should().ContainSingle(observation => observation.Contains("weather"));
 
         this.externalToolServiceMock.Verify(service =>
             service.CallAsync("weather", "today"),
@@ -179,7 +179,7 @@ public partial class DirectionOrchestrationServiceTests
         // then
         actualContext.Status.Should().Be(AgentStatus.Working);
         actualContext.Observations.Should()
-            .ContainSingle(o => o.Contains("could not parse expression"));
+            .ContainSingle(observation => observation.Contains("could not parse expression"));
     }
 
     [Fact]
@@ -227,6 +227,6 @@ public partial class DirectionOrchestrationServiceTests
 
         // then
         actualContext.Observations.Should()
-            .ContainSingle(o => o.Contains("calculator") && o.Contains("2"));
+            .ContainSingle(observation => observation.Contains("calculator") && observation.Contains("2"));
     }
 }

--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
@@ -19,7 +19,7 @@ public class AgentToolTests
     private static Brokers.Knowledges.IKnowledgeBroker EmptyKnowledgeBroker()
     {
         var knowledgeBroker = new Mock<Brokers.Knowledges.IKnowledgeBroker>();
-        knowledgeBroker.Setup(b => b.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
 
         return knowledgeBroker.Object;
     }
@@ -79,17 +79,17 @@ public class AgentToolTests
                 .ReturnsAsync(() => replies.Dequeue());
 
         var skills = new Mock<Brokers.Skills.ISkillBroker>();
-        skills.Setup(b => b.SelectSkillsAsync()).ReturnsAsync("you are an agent");
+        skills.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync("you are an agent");
 
         var memory = new Mock<Brokers.Memorys.IMemoryBroker>();
-        memory.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
 
         var gate = new Mock<Brokers.Classifiers.IClassifierBroker>();
-        gate.Setup(b => b.ClassifyAsync(It.IsAny<string>()))
+        gate.Setup(broker => broker.ClassifyAsync(It.IsAny<string>()))
             .ReturnsAsync("allow");
 
         var judge = new Mock<Brokers.Verifiers.IVerifierBroker>();
-        judge.Setup(b => b.VerifyAsync(It.IsAny<string>()))
+        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>()))
             .ReturnsAsync("1.0");
 
         var outerAgent = new StandardAgent()


### PR DESCRIPTION
## What
Renames single-letter lambda parameters to meaningful names, per The Standard C# naming rule (0.0.0 — names must be representative, no single letters):

- Mock setups: `b => b.SelectSkillsAsync()` → `broker => broker.SelectSkillsAsync()`
- Observation assertions: `o => o.Contains(...)` → `observation => observation.Contains(...)`

Files swept:
- `StandardAgentTests.cs`
- `AgentToolTests.cs`
- `DirectionOrchestrationServiceTests.Logic.Act.cs`

Addresses the review feedback on #132 ("never use single letter for funcs … always use a meaningful name"), applied across the whole project. The lambda in #132's own new test was fixed there to keep that PR scoped; this PR handles the pre-existing ones everywhere else.

A project-wide grep for `\b[a-z] =>` now returns nothing.

## Verification
- 223 unit tests pass, 0 warnings

Category: CODE RUB (naming/style, no behavior change).