### PR TITLE
MINOR CLIENTS: Local Gate And Judge (In-Process Guardians)

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -435,6 +435,39 @@ public class StandardAgentTests
         actualResult.Should().Be("I'm not able to help with that.");
     }
 
+    [Fact]
+    public async Task ShouldUseLocalJudgeToScoreOnProcessPromptAsync()
+    {
+        // given
+        bool judgeInvoked = false;
+
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(EmptyKnowledgeBroker())
+            .LocalBrain((systemPrompt, userPrompt) => ValueTask.FromResult("FINAL: 42"))
+            .LocalJudge((judgeRubric, draftAnswer) =>
+            {
+                judgeInvoked = true;
+
+                return ValueTask.FromResult("1.0");
+            })
+            .UseLog(new Mock<ILogBroker>().Object);
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "what is the answer?");
+
+        // then
+        actualResult.Should().Be("42");
+        judgeInvoked.Should().BeTrue();
+    }
+
     private static IKnowledgeBroker EmptyKnowledgeBroker()
     {
         var knowledgeBroker = new Mock<IKnowledgeBroker>();

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -410,6 +410,31 @@ public class StandardAgentTests
         capturedSystemPrompt.Should().NotContain("{{tools}}");
     }
 
+    [Fact]
+    public async Task ShouldUseLocalGateToRefuseOnProcessPromptAsync()
+    {
+        // given
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(EmptyKnowledgeBroker())
+            .LocalBrain((systemPrompt, userPrompt) => ValueTask.FromResult("FINAL: hello"))
+            .LocalGate((gateRubric, prompt) => ValueTask.FromResult("refuse: not allowed"))
+            .UseLog(new Mock<ILogBroker>().Object);
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "do something bad");
+
+        // then
+        actualResult.Should().Be("I'm not able to help with that.");
+    }
+
     private static IKnowledgeBroker EmptyKnowledgeBroker()
     {
         var knowledgeBroker = new Mock<IKnowledgeBroker>();

--- a/Standard.Agents/Brokers/Classifiers/FunctionClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/FunctionClassifierBroker.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Classifiers;
+
+public sealed class FunctionClassifierBroker : IClassifierBroker
+{
+    private readonly Func<string, string, ValueTask<string>> screen;
+    private readonly string systemPrompt;
+
+    public FunctionClassifierBroker(
+        Func<string, string, ValueTask<string>> screen,
+        string systemPrompt)
+    {
+        this.screen = screen;
+        this.systemPrompt = systemPrompt;
+    }
+
+    public async ValueTask<string> ClassifyAsync(string input) =>
+        await this.screen(this.systemPrompt, input);
+}

--- a/Standard.Agents/Brokers/Verifiers/FunctionVerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/FunctionVerifierBroker.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Verifiers;
+
+public sealed class FunctionVerifierBroker : IVerifierBroker
+{
+    private readonly Func<string, string, ValueTask<string>> evaluate;
+    private readonly string systemPrompt;
+
+    public FunctionVerifierBroker(
+        Func<string, string, ValueTask<string>> evaluate,
+        string systemPrompt)
+    {
+        this.evaluate = evaluate;
+        this.systemPrompt = systemPrompt;
+    }
+
+    public async ValueTask<string> VerifyAsync(string candidate) =>
+        await this.evaluate(this.systemPrompt, candidate);
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -151,7 +151,8 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="evaluate">A <c>(judgeRubric, draftAnswer) =&gt; score</c> delegate.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent LocalJudge(Func<string, string, ValueTask<string>> evaluate) =>
-        this;
+        Set(() => this.verifierBroker =
+            new FunctionVerifierBroker(evaluate, GuardianPrompts.Judge));
 
     /// <summary>
     /// Turns on the Gate: an opt-in guardian that screens each prompt before the brain sees

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -139,7 +139,8 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="screen">A <c>(gateRubric, prompt) =&gt; verdict</c> delegate.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent LocalGate(Func<string, string, ValueTask<string>> screen) =>
-        this;
+        Set(() => this.classifierBroker =
+            new FunctionClassifierBroker(screen, GuardianPrompts.Gate));
 
     /// <summary>
     /// Turns on the Gate: an opt-in guardian that screens each prompt before the brain sees

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -143,6 +143,17 @@ public sealed partial class StandardAgent : IAgent
             new FunctionClassifierBroker(screen, GuardianPrompts.Gate));
 
     /// <summary>
+    /// Turns on the Judge using an in-process model — the local counterpart to <see cref="Judge"/>,
+    /// with no API calls. The delegate receives the built-in judge rubric as the system prompt and
+    /// the draft answer as the user prompt, and returns the score. Pass a local brain's GenerateAsync
+    /// to let one local model serve as both brain and judge.
+    /// </summary>
+    /// <param name="evaluate">A <c>(judgeRubric, draftAnswer) =&gt; score</c> delegate.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent LocalJudge(Func<string, string, ValueTask<string>> evaluate) =>
+        this;
+
+    /// <summary>
     /// Turns on the Gate: an opt-in guardian that screens each prompt before the brain sees
     /// it and can refuse. A bare agent runs no gate (SPEC.md §8.1 leaves it pass-through in the
     /// Core profile). It may reuse the brain's endpoint or point at a different model; either

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -131,6 +131,17 @@ public sealed partial class StandardAgent : IAgent
         Set(() => this.generatorBroker = new FunctionGeneratorBroker(generate));
 
     /// <summary>
+    /// Turns on the Gate using an in-process model — the local counterpart to <see cref="Gate"/>,
+    /// with no API calls. The delegate receives the built-in gate rubric as the system prompt and
+    /// the prompt to screen as the user prompt, and returns the verdict. Pass a local brain's
+    /// GenerateAsync to let one local model serve as both brain and gate.
+    /// </summary>
+    /// <param name="screen">A <c>(gateRubric, prompt) =&gt; verdict</c> delegate.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent LocalGate(Func<string, string, ValueTask<string>> screen) =>
+        this;
+
+    /// <summary>
     /// Turns on the Gate: an opt-in guardian that screens each prompt before the brain sees
     /// it and can refuse. A bare agent runs no gate (SPEC.md §8.1 leaves it pass-through in the
     /// Core profile). It may reuse the brain's endpoint or point at a different model; either


### PR DESCRIPTION
## What
Gives the **Gate** and **Judge** the same local-model path the brain already has via `.LocalBrain`. Two new client methods on `StandardAgent`:

```csharp
.LocalGate((gateRubric, prompt)     => RunMyModelAsync(gateRubric, prompt))
.LocalJudge((judgeRubric, draft)    => RunMyModelAsync(judgeRubric, draft))
```

The delegate receives the **built-in guardian rubric** as the system prompt (the core supplies `GuardianPrompts.Gate`/`.Judge` automatically) and the input as the user prompt — the exact contract the HTTP `ClassifierBroker`/`VerifierBroker` use. No API calls.

## One model, three natures
Because the delegate is `(system, user) => result`, a local brain's `GenerateAsync` method group slots straight in — so one local GGUF model can back the brain **and** both guardians, fully offline:

```csharp
var llama = new LlamaSharpGeneratorBroker("model.gguf");
var agent = new StandardAgent()
    .UseGenerator(llama)
    .LocalGate(llama.GenerateAsync)
    .LocalJudge(llama.GenerateAsync);
```

This is SPEC.md §9's collapsible substrate — one engine, three rubrics — realized locally.

## The Standard
- `BROKERS`: `FunctionClassifierBroker` + `FunctionVerifierBroker` — the guardian counterparts of `FunctionGeneratorBroker`, thin, no tests.
- FAIL→PASS per client method:
  - `ShouldUseLocalGateToRefuseOnProcessPromptAsync` (local gate refuses → agent declines)
  - `ShouldUseLocalJudgeToScoreOnProcessPromptAsync` (local judge runs and scores the draft)
- Guardian rubric prompts stay `internal` — the core wires them; consumers just pass their model.

## Verification
- `dotnet build` — 0 warnings
- 226 unit tests pass (was 224)
- 7/7 conformance vectors pass

Category: MINOR CLIENTS (exposure layer, 2 tests).