### PR TITLE
RELEASES: Standard.Agents 0.9.0.0

### DIFF
--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -20,13 +20,15 @@
     <!-- The Standard's release format is v1.2.3.4 — model . service/routine . fix/config
          . automated build. Deliberately NOT semver; the segments say what KIND of change
          happened, so a model change can never hide in the service segment.
-         0.8.0.0: memory and knowledge come alive — Recall now queries the knowledge store
-         and seeds hits into observations, and a built-in 'remember' tool lets the agent
-         write memory (persisting across restarts). New Recall + tool routines, the spec's
-         core AgentContext model unchanged, so this is a service/routine change: segment 2
-         advances, 3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1 goes to 1 when
-         the spec settles. -->
-    <Version>0.8.0.0</Version>
+         0.9.0.0: a simplest-start constructor (new StandardAgent(url, key, model)) and
+         in-process guardians (LocalGate / LocalJudge) — so a single local model can back the
+         brain, gate and judge with no HTTP — plus XML doc comments across the builder API that
+         now ship in the package. New public routines on the client, the spec's core
+         AgentContext model unchanged, so this is a service/routine change: segment 2 advances,
+         3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1 goes to 1 when the spec settles.
+         (0.8.0.0: memory and knowledge came alive — knowledge retrieval in Recall + a built-in
+         'remember' tool.) -->
+    <Version>0.9.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>


### PR DESCRIPTION
Bumps the core package `0.8.0.0 → 0.9.0.0` — a **service/routine** change (segment 2), gathering the public-API additions since 0.8.0.0:

- `new StandardAgent(url, key, model)` — the simplest-start constructor (#132)
- `.LocalGate(...)` / `.LocalJudge(...)` — in-process guardians, so one local model can back the brain, gate and judge with no HTTP (#137)
- XML doc comments across the builder API, now shipped in the package for IntelliSense (#131)

The spec's core `AgentContext` model is unchanged, so segment 1 stays 0 (still tracking SPEC.md v0.1 draft).

Category: RELEASES.