### PR TITLE
CONFORMANCE: Vector 03 Verifies Tool Input, Catching First-Line Parsing Bugs

### DIFF
--- a/Standard.Agents.Conformance/Models/Expectation.cs
+++ b/Standard.Agents.Conformance/Models/Expectation.cs
@@ -7,4 +7,5 @@ namespace Standard.Agents.Conformance;
 
 public sealed record Expectation(
     string? Result,
-    string? ResultContains);
+    string? ResultContains,
+    Dictionary<string, string>? ToolInput);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -29,14 +29,19 @@ foreach (string vectorFile in
     Vector vector =
         JsonSerializer.Deserialize<Vector>(await File.ReadAllTextAsync(vectorFile), jsonOptions)!;
 
-    string actualResult = await RunVectorAsync(vector);
+    (string actualResult, Dictionary<string, StubTool> stubTools) = await RunVectorAsync(vector);
 
-    bool isConformant = vector.Expect.Result is not null
+    bool resultConformant = vector.Expect.Result is not null
         ? actualResult == vector.Expect.Result
         : vector.Expect.ResultContains is not null
             && actualResult.Contains(vector.Expect.ResultContains, StringComparison.Ordinal);
 
-    if (isConformant)
+    bool toolInputConformant = vector.Expect.ToolInput is null
+        || vector.Expect.ToolInput.All(expected =>
+            stubTools.TryGetValue(expected.Key, out StubTool? tool)
+                && tool.ReceivedInputs.Contains(expected.Value));
+
+    if (resultConformant && toolInputConformant)
     {
         passed++;
         Console.WriteLine($"PASS  {vector.Name}");
@@ -44,14 +49,30 @@ foreach (string vectorFile in
     else
     {
         failed++;
-
-        string expectation = vector.Expect.Result is not null
-            ? vector.Expect.Result
-            : $"contains: {vector.Expect.ResultContains}";
-
         Console.WriteLine($"FAIL  {vector.Name}");
-        Console.WriteLine($"        expected: {Show(expectation)}");
-        Console.WriteLine($"        actual:   {Show(actualResult)}");
+
+        if (resultConformant is false)
+        {
+            string expectation = vector.Expect.Result is not null
+                ? vector.Expect.Result
+                : $"contains: {vector.Expect.ResultContains}";
+
+            Console.WriteLine($"        expected result: {Show(expectation)}");
+            Console.WriteLine($"        actual result:   {Show(actualResult)}");
+        }
+
+        if (toolInputConformant is false)
+        {
+            foreach (KeyValuePair<string, string> expected in vector.Expect.ToolInput!)
+            {
+                string actualInputs = stubTools.TryGetValue(expected.Key, out StubTool? tool)
+                    ? string.Join(" | ", tool.ReceivedInputs.Select(Show))
+                    : "(tool never called)";
+
+                Console.WriteLine($"        tool '{expected.Key}' expected input: {Show(expected.Value)}");
+                Console.WriteLine($"        tool '{expected.Key}' actual inputs:  {actualInputs}");
+            }
+        }
     }
 }
 
@@ -60,10 +81,12 @@ Console.WriteLine($"{passed} passed, {failed} failed");
 
 return failed == 0 ? 0 : 1;
 
-async Task<string> RunVectorAsync(Vector vector)
+async Task<(string Result, Dictionary<string, StubTool> Tools)> RunVectorAsync(Vector vector)
 {
-    IEnumerable<ITool> tools =
-        (vector.Tools ?? []).Select(pair => (ITool)new StubTool(name: pair.Key, output: pair.Value));
+    Dictionary<string, StubTool> stubTools =
+        (vector.Tools ?? []).ToDictionary(
+            pair => pair.Key,
+            pair => new StubTool(name: pair.Key, output: pair.Value));
 
     IAgent agent = new StandardAgent()
         .UseSkills(new StubSkillBroker())
@@ -74,9 +97,11 @@ async Task<string> RunVectorAsync(Vector vector)
         .UseJudge(new ApprovingVerifierBroker())
         .UseMcp(new NotConfiguredMcpBroker())
         .UseLog(new NullLogBroker())
-        .Tools(tools);
+        .Tools(stubTools.Values);
 
-    return await agent.ProcessPromptAsync(vector.Prompt);
+    string result = await agent.ProcessPromptAsync(vector.Prompt);
+
+    return (result, stubTools);
 }
 
 static string Show(string value) =>

--- a/Standard.Agents.Conformance/Tools/StubTool.cs
+++ b/Standard.Agents.Conformance/Tools/StubTool.cs
@@ -10,8 +10,15 @@ namespace Standard.Agents.Conformance;
 public sealed class StubTool : ITool
 {
     private readonly string output;
+    private readonly List<string> receivedInputs = [];
 
     public string Name { get; }
+
+    // A stub returns a fixed output, but it records every input it was handed — so a vector
+    // can assert what the tool was actually called with. Without this, a tool that ignores
+    // its input hides parsing bugs: corrupted input produces the same output, and the vector
+    // still passes (conformance issue #78).
+    public IReadOnlyList<string> ReceivedInputs => this.receivedInputs;
 
     public StubTool(string name, string output)
     {
@@ -19,6 +26,10 @@ public sealed class StubTool : ITool
         this.output = output;
     }
 
-    public ValueTask<string> ExecuteAsync(string input) =>
-        ValueTask.FromResult(this.output);
+    public ValueTask<string> ExecuteAsync(string input)
+    {
+        this.receivedInputs.Add(input);
+
+        return ValueTask.FromResult(this.output);
+    }
 }

--- a/conformance/vectors/03-first-line-action-only.json
+++ b/conformance/vectors/03-first-line-action-only.json
@@ -1,8 +1,8 @@
 {
   "name": "first-line-action-only",
-  "description": "When the model emits extra lines, only the first-line ACTION is parsed; the stray FINAL on line two is ignored.",
+  "description": "When the model emits extra lines, only the first-line ACTION is parsed; the stray FINAL on line two is ignored. The tool MUST receive only the first line's input ('1+1'), never the trailing 'FINAL: wrong'.",
   "generatorReplies": ["ACTION: calculator: 1+1\nFINAL: wrong", "FINAL: 2"],
   "tools": { "calculator": "2" },
   "prompt": "what is 1+1",
-  "expect": { "result": "2" }
+  "expect": { "result": "2", "toolInput": { "calculator": "1+1" } }
 }


### PR DESCRIPTION
Closes #78.

## The gap
`03-first-line-action-only` passed even when first-line parsing was removed entirely — the stub tool returned a fixed output regardless of input, so corrupted tool input was never observed. The vector didn't verify its own claim.

## The fix
- `StubTool` records every input it receives (`ReceivedInputs`).
- `Expectation` gains an optional `toolInput` map.
- The runner asserts each named tool received the expected input (and reports mismatches clearly).
- Vector 03 now asserts `toolInput: { "calculator": "1+1" }` — the tool must get **only** the first line, never the trailing `FINAL: wrong`.

## Verified by mutation (the issue's own repro)
| | `firstLine = reply.Split('\n')[0]` (clean) | `firstLine = reply.Trim()` (mutated) |
|---|---|---|
| Vector 03 | **PASS** | **FAIL** — `actual input '1+1\nFINAL: wrong' != '1+1'` |
| Suite | 7 passed | 6 passed, 1 failed |

Before this change the mutated suite reported 7/7 — the exact bug #78 describes. Unit tests: 226 pass.

Category: CONFORMANCE.