### PR TITLE
CODE RUB: Replace ValueTask.FromResult With async And Direct Return

### DIFF
--- a/Standard.Agents.Conformance/Brokers/AllowingClassifierBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/AllowingClassifierBroker.cs
@@ -9,6 +9,6 @@ namespace Standard.Agents.Conformance;
 
 public sealed class AllowingClassifierBroker : IClassifierBroker
 {
-    public ValueTask<string> ClassifyAsync(string input) =>
-        ValueTask.FromResult("allow");
+    public async ValueTask<string> ClassifyAsync(string input) =>
+        "allow";
 }

--- a/Standard.Agents.Conformance/Brokers/ApprovingVerifierBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/ApprovingVerifierBroker.cs
@@ -9,6 +9,6 @@ namespace Standard.Agents.Conformance;
 
 public sealed class ApprovingVerifierBroker : IVerifierBroker
 {
-    public ValueTask<string> VerifyAsync(string candidate) =>
-        ValueTask.FromResult("1.0");
+    public async ValueTask<string> VerifyAsync(string candidate) =>
+        "1.0";
 }

--- a/Standard.Agents.Conformance/Brokers/NotConfiguredMcpBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/NotConfiguredMcpBroker.cs
@@ -9,6 +9,6 @@ namespace Standard.Agents.Conformance;
 
 public sealed class NotConfiguredMcpBroker : IMcpBroker
 {
-    public ValueTask<string> CallAsync(string name, string input) =>
-        ValueTask.FromResult($"[external '{name}' not configured]");
+    public async ValueTask<string> CallAsync(string name, string input) =>
+        $"[external '{name}' not configured]";
 }

--- a/Standard.Agents.Conformance/Brokers/ScriptedGeneratorBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/ScriptedGeneratorBroker.cs
@@ -16,12 +16,12 @@ public sealed class ScriptedGeneratorBroker : IGeneratorBroker
     public ScriptedGeneratorBroker(IReadOnlyList<string> replies) =>
         this.replies = replies;
 
-    public ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt)
+    public async ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt)
     {
         string reply = this.replies[Math.Min(this.index, this.replies.Count - 1)];
         this.index++;
 
-        return ValueTask.FromResult(reply);
+        return reply;
     }
 
     public async IAsyncEnumerable<string> GenerateStreamAsync(

--- a/Standard.Agents.Conformance/Brokers/StubKnowledgeBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/StubKnowledgeBroker.cs
@@ -9,6 +9,6 @@ namespace Standard.Agents.Conformance;
 
 public sealed class StubKnowledgeBroker : IKnowledgeBroker
 {
-    public ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query) =>
-        ValueTask.FromResult<IReadOnlyList<string>>([]);
+    public async ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query) =>
+        [];
 }

--- a/Standard.Agents.Conformance/Brokers/StubMemoryBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/StubMemoryBroker.cs
@@ -9,8 +9,8 @@ namespace Standard.Agents.Conformance;
 
 public sealed class StubMemoryBroker : IMemoryBroker
 {
-    public ValueTask<IReadOnlyList<string>> SelectMemoriesAsync() =>
-        ValueTask.FromResult<IReadOnlyList<string>>([]);
+    public async ValueTask<IReadOnlyList<string>> SelectMemoriesAsync() =>
+        [];
 
     public ValueTask InsertMemoryAsync(string memory) =>
         ValueTask.CompletedTask;

--- a/Standard.Agents.Conformance/Brokers/StubSkillBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/StubSkillBroker.cs
@@ -9,6 +9,6 @@ namespace Standard.Agents.Conformance;
 
 public sealed class StubSkillBroker : ISkillBroker
 {
-    public ValueTask<string> SelectSkillsAsync() =>
-        ValueTask.FromResult("You are a test agent.");
+    public async ValueTask<string> SelectSkillsAsync() =>
+        "You are a test agent.";
 }

--- a/Standard.Agents.Conformance/Tools/StubTool.cs
+++ b/Standard.Agents.Conformance/Tools/StubTool.cs
@@ -26,10 +26,10 @@ public sealed class StubTool : ITool
         this.output = output;
     }
 
-    public ValueTask<string> ExecuteAsync(string input)
+    public async ValueTask<string> ExecuteAsync(string input)
     {
         this.receivedInputs.Add(input);
 
-        return ValueTask.FromResult(this.output);
+        return this.output;
     }
 }

--- a/Standard.Agents.Demo/Tools/CalculatorTool.cs
+++ b/Standard.Agents.Demo/Tools/CalculatorTool.cs
@@ -12,16 +12,15 @@ public sealed partial class CalculatorTool : ITool
 {
     public string Name => "calculator";
 
-    public ValueTask<string> ExecuteAsync(string input)
+    public async ValueTask<string> ExecuteAsync(string input)
     {
         try
         {
-            return ValueTask.FromResult(
-                new NCalc.Expression(PromoteNumbers(input)).Evaluate()!.ToString()!);
+            return new NCalc.Expression(PromoteNumbers(input)).Evaluate()!.ToString()!;
         }
         catch (Exception exception)
         {
-            return ValueTask.FromResult($"error: {exception.Message}");
+            return $"error: {exception.Message}";
         }
     }
 

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -357,7 +357,7 @@ public class StandardAgentTests
         var agent = new StandardAgent()
             .UseSkills(skillBroker.Object)
             .UseMemory(memory.Object)
-            .LocalBrain((systemPrompt, userPrompt) => ValueTask.FromResult(expectedAnswer))
+            .LocalBrain(async (systemPrompt, userPrompt) => expectedAnswer)
             .UseLog(new Mock<ILogBroker>().Object);
 
         // when
@@ -424,8 +424,8 @@ public class StandardAgentTests
             .UseSkills(skillBroker.Object)
             .UseMemory(memory.Object)
             .UseKnowledge(EmptyKnowledgeBroker())
-            .LocalBrain((systemPrompt, userPrompt) => ValueTask.FromResult("FINAL: hello"))
-            .LocalGate((gateRubric, prompt) => ValueTask.FromResult("refuse: not allowed"))
+            .LocalBrain(async (systemPrompt, userPrompt) => "FINAL: hello")
+            .LocalGate(async (gateRubric, prompt) => "refuse: not allowed")
             .UseLog(new Mock<ILogBroker>().Object);
 
         // when
@@ -451,12 +451,12 @@ public class StandardAgentTests
             .UseSkills(skillBroker.Object)
             .UseMemory(memory.Object)
             .UseKnowledge(EmptyKnowledgeBroker())
-            .LocalBrain((systemPrompt, userPrompt) => ValueTask.FromResult("FINAL: 42"))
-            .LocalJudge((judgeRubric, draftAnswer) =>
+            .LocalBrain(async (systemPrompt, userPrompt) => "FINAL: 42")
+            .LocalJudge(async (judgeRubric, draftAnswer) =>
             {
                 judgeInvoked = true;
 
-                return ValueTask.FromResult("1.0");
+                return "1.0";
             })
             .UseLog(new Mock<ILogBroker>().Object);
 

--- a/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
@@ -80,8 +80,8 @@ public sealed class ClassifierBroker : IClassifierBroker
             relativeUrl,
             content,
             mediaType: JsonMediaType,
-            serializationFunction: value =>
-                ValueTask.FromResult(JsonSerializer.Serialize(value, jsonOptions)),
-            deserializationFunction: json =>
-                ValueTask.FromResult(JsonSerializer.Deserialize<TResult>(json, jsonOptions)!));
+            serializationFunction: async value =>
+                JsonSerializer.Serialize(value, jsonOptions),
+            deserializationFunction: async json =>
+                JsonSerializer.Deserialize<TResult>(json, jsonOptions)!);
 }

--- a/Standard.Agents/Brokers/Classifiers/NotConfiguredClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/NotConfiguredClassifierBroker.cs
@@ -9,6 +9,6 @@ public sealed class NotConfiguredClassifierBroker : IClassifierBroker
 {
     private const string Allow = "allow";
 
-    public ValueTask<string> ClassifyAsync(string input) =>
-        ValueTask.FromResult(Allow);
+    public async ValueTask<string> ClassifyAsync(string input) =>
+        Allow;
 }

--- a/Standard.Agents/Brokers/Generators/GeneratorBroker.cs
+++ b/Standard.Agents/Brokers/Generators/GeneratorBroker.cs
@@ -155,8 +155,8 @@ public sealed class GeneratorBroker : IGeneratorBroker
             relativeUrl,
             content,
             mediaType: JsonMediaType,
-            serializationFunction: value =>
-                ValueTask.FromResult(JsonSerializer.Serialize(value, jsonOptions)),
-            deserializationFunction: json =>
-                ValueTask.FromResult(JsonSerializer.Deserialize<TResult>(json, jsonOptions)!));
+            serializationFunction: async value =>
+                JsonSerializer.Serialize(value, jsonOptions),
+            deserializationFunction: async json =>
+                JsonSerializer.Deserialize<TResult>(json, jsonOptions)!);
 }

--- a/Standard.Agents/Brokers/Mcps/McpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/McpBroker.cs
@@ -82,8 +82,8 @@ public sealed class McpBroker : IMcpBroker
             relativeUrl,
             content,
             mediaType: JsonMediaType,
-            serializationFunction: value =>
-                ValueTask.FromResult(JsonSerializer.Serialize(value, jsonOptions)),
-            deserializationFunction: json =>
-                ValueTask.FromResult(JsonSerializer.Deserialize<TResult>(json, jsonOptions)!));
+            serializationFunction: async value =>
+                JsonSerializer.Serialize(value, jsonOptions),
+            deserializationFunction: async json =>
+                JsonSerializer.Deserialize<TResult>(json, jsonOptions)!);
 }

--- a/Standard.Agents/Brokers/Mcps/NotConfiguredMcpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/NotConfiguredMcpBroker.cs
@@ -7,6 +7,6 @@ namespace Standard.Agents.Brokers.Mcps;
 
 public sealed class NotConfiguredMcpBroker : IMcpBroker
 {
-    public ValueTask<string> CallAsync(string name, string input) =>
-        ValueTask.FromResult($"[external '{name}' not configured]");
+    public async ValueTask<string> CallAsync(string name, string input) =>
+        $"[external '{name}' not configured]";
 }

--- a/Standard.Agents/Brokers/Tools/ToolBroker.cs
+++ b/Standard.Agents/Brokers/Tools/ToolBroker.cs
@@ -16,8 +16,8 @@ public sealed class ToolBroker : IToolBroker
         tool => tool.Name,
         StringComparer.OrdinalIgnoreCase);
 
-    public ValueTask<bool> HasAsync(string name) =>
-        ValueTask.FromResult(this.tools.ContainsKey(name));
+    public async ValueTask<bool> HasAsync(string name) =>
+        this.tools.ContainsKey(name);
 
     public async ValueTask<string> RunAsync(string name, string input) =>
         await this.tools[name].ExecuteAsync(input);

--- a/Standard.Agents/Brokers/Verifiers/NotConfiguredVerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/NotConfiguredVerifierBroker.cs
@@ -12,6 +12,6 @@ public sealed class NotConfiguredVerifierBroker : IVerifierBroker
     private static readonly string PassingScore =
         (1.0).ToString(CultureInfo.InvariantCulture);
 
-    public ValueTask<string> VerifyAsync(string candidate) =>
-        ValueTask.FromResult(PassingScore);
+    public async ValueTask<string> VerifyAsync(string candidate) =>
+        PassingScore;
 }

--- a/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
@@ -80,8 +80,8 @@ public sealed class VerifierBroker : IVerifierBroker
             relativeUrl,
             content,
             mediaType: JsonMediaType,
-            serializationFunction: value =>
-                ValueTask.FromResult(JsonSerializer.Serialize(value, jsonOptions)),
-            deserializationFunction: json =>
-                ValueTask.FromResult(JsonSerializer.Deserialize<TResult>(json, jsonOptions)!));
+            serializationFunction: async value =>
+                JsonSerializer.Serialize(value, jsonOptions),
+            deserializationFunction: async json =>
+                JsonSerializer.Deserialize<TResult>(json, jsonOptions)!);
 }

--- a/Standard.Agents/Services/Foundations/Returns/ReturnService.cs
+++ b/Standard.Agents/Services/Foundations/Returns/ReturnService.cs
@@ -15,10 +15,10 @@ public partial class ReturnService : IReturnService
         this.loggingBroker = loggingBroker;
 
     public ValueTask<string> ReturnAsync(string payload) =>
-    TryCatch(() =>
+    TryCatch(async () =>
     {
         ValidatePayload(payload);
 
-        return ValueTask.FromResult(payload);
+        return payload;
     });
 }


### PR DESCRIPTION
Applies the async-abstraction rule (now normative in `the-standard-architecture` §1.5.1): **never `ValueTask.FromResult`** — mark the method or lambda `async` and return the value directly.

### Swept (19 files)
- **Not-configured / stub brokers** (core + conformance): `=> ValueTask.FromResult(x)` → `async … => x`
- **HTTP brokers** (Classifier / Generator / Mcp / Verifier): serialization/deserialization callbacks → `async value => …` / `async json => …`
- **ReturnService**: the `TryCatch` lambda → `async () => { …; return payload; }`
- **Conformance** `ScriptedGeneratorBroker`, `StubTool`; **Demo** `CalculatorTool`; **test** `LocalBrain`/`LocalGate`/`LocalJudge` delegates

### No warnings
C# 13 / .NET 10 compiles the async-direct-return form **cleanly — no CS1998** (verified with `-warnaserror:CS1998`), so no suppression was needed.

### Verification
- 226 unit tests pass
- 7/7 conformance vectors pass
- `dotnet build` — 0 warnings, 0 errors

No behavior change. Category: CODE RUB.