### PR TITLE
CODE RUB: Scope The Multi-Line PostAsync Instead Of Fat-Arrowing It

### DIFF
--- a/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
@@ -75,8 +75,9 @@ public sealed class ClassifierBroker : IClassifierBroker
 
     private async ValueTask<TResult> PostAsync<TContent, TResult>(
         string relativeUrl,
-        TContent content) =>
-        await this.apiClient.PostContentAsync<TContent, TResult>(
+        TContent content)
+    {
+        return await this.apiClient.PostContentAsync<TContent, TResult>(
             relativeUrl,
             content,
             mediaType: JsonMediaType,
@@ -84,4 +85,5 @@ public sealed class ClassifierBroker : IClassifierBroker
                 JsonSerializer.Serialize(value, jsonOptions),
             deserializationFunction: async json =>
                 JsonSerializer.Deserialize<TResult>(json, jsonOptions)!);
+    }
 }

--- a/Standard.Agents/Brokers/Generators/GeneratorBroker.cs
+++ b/Standard.Agents/Brokers/Generators/GeneratorBroker.cs
@@ -150,8 +150,9 @@ public sealed class GeneratorBroker : IGeneratorBroker
 
     private async ValueTask<TResult> PostAsync<TContent, TResult>(
         string relativeUrl,
-        TContent content) =>
-        await this.apiClient.PostContentAsync<TContent, TResult>(
+        TContent content)
+    {
+        return await this.apiClient.PostContentAsync<TContent, TResult>(
             relativeUrl,
             content,
             mediaType: JsonMediaType,
@@ -159,4 +160,5 @@ public sealed class GeneratorBroker : IGeneratorBroker
                 JsonSerializer.Serialize(value, jsonOptions),
             deserializationFunction: async json =>
                 JsonSerializer.Deserialize<TResult>(json, jsonOptions)!);
+    }
 }

--- a/Standard.Agents/Brokers/Mcps/McpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/McpBroker.cs
@@ -77,8 +77,9 @@ public sealed class McpBroker : IMcpBroker
 
     private async ValueTask<TResult> PostAsync<TContent, TResult>(
         string relativeUrl,
-        TContent content) =>
-        await this.apiClient.PostContentAsync<TContent, TResult>(
+        TContent content)
+    {
+        return await this.apiClient.PostContentAsync<TContent, TResult>(
             relativeUrl,
             content,
             mediaType: JsonMediaType,
@@ -86,4 +87,5 @@ public sealed class McpBroker : IMcpBroker
                 JsonSerializer.Serialize(value, jsonOptions),
             deserializationFunction: async json =>
                 JsonSerializer.Deserialize<TResult>(json, jsonOptions)!);
+    }
 }

--- a/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
@@ -75,8 +75,9 @@ public sealed class VerifierBroker : IVerifierBroker
 
     private async ValueTask<TResult> PostAsync<TContent, TResult>(
         string relativeUrl,
-        TContent content) =>
-        await this.apiClient.PostContentAsync<TContent, TResult>(
+        TContent content)
+    {
+        return await this.apiClient.PostContentAsync<TContent, TResult>(
             relativeUrl,
             content,
             mediaType: JsonMediaType,
@@ -84,4 +85,5 @@ public sealed class VerifierBroker : IVerifierBroker
                 JsonSerializer.Serialize(value, jsonOptions),
             deserializationFunction: async json =>
                 JsonSerializer.Deserialize<TResult>(json, jsonOptions)!);
+    }
 }


### PR DESCRIPTION
Applies the fat-arrow rule (now explicit in `the-standard-code-csharp` 1.1.0.1): an expression-bodied method's body must be **one line**; a multi-line body must use a scoped `{ }` with an explicit `return`.

`PostAsync` in the four HTTP brokers (Classifier / Generator / Mcp / Verifier) was a fat arrow whose body — a `PostContentAsync` call with named args and two async lambdas — wrapped across ~8 lines. 'Crazy to read.' Now scoped:

```csharp
private async ValueTask<TResult> PostAsync<TContent, TResult>(
    string relativeUrl,
    TContent content)
{
    return await this.apiClient.PostContentAsync<TContent, TResult>( … );
}
```

### Scope
- Fixed: `PostAsync` ×4.
- Left as-is (correctly): `LogBroker.WriteAsync` (its body is a single line); the `TryCatch` service methods and `.Knowledge`/`.Mcp` `Set(() => { … })` builders — a fat arrow whose body is a single call taking a **braced lambda** keeps the lambda's own scope (the one documented exception).

### Verification
- Build — 0 warnings, 0 errors
- 226 unit tests pass · 7/7 conformance vectors pass

No behavior change. Category: CODE RUB.