### PR TITLE
CODE RUB: Remove Flow Control From Skill, Knowledge And Mcp Brokers

### DIFF
--- a/Standard.Agents/Brokers/Knowledges/KnowledgeBroker.cs
+++ b/Standard.Agents/Brokers/Knowledges/KnowledgeBroker.cs
@@ -23,35 +23,17 @@ public sealed class KnowledgeBroker : IKnowledgeBroker
 
     public async ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query)
     {
-        if (Directory.Exists(this.knowledgePath) is false)
-        {
-            return [];
-        }
+        string[] documents = Directory.Exists(this.knowledgePath)
+            ? await Task.WhenAll(
+                Directory.EnumerateFiles(
+                    this.knowledgePath, this.searchPattern, SearchOption.AllDirectories)
+                        .OrderBy(documentPath => documentPath, StringComparer.Ordinal)
+                        .Select(path => File.ReadAllTextAsync(path)))
+            : [];
 
-        List<string> matches = [];
-
-        IOrderedEnumerable<string> documentPaths =
-            Directory.EnumerateFiles(
-                this.knowledgePath,
-                this.searchPattern,
-                SearchOption.AllDirectories)
-                    .OrderBy(documentPath => documentPath, StringComparer.Ordinal);
-
-        foreach (string documentPath in documentPaths)
-        {
-            string document = await File.ReadAllTextAsync(documentPath);
-
-            if (document.Contains(query, StringComparison.OrdinalIgnoreCase))
-            {
-                matches.Add(document);
-            }
-
-            if (matches.Count == this.maxResults)
-            {
-                break;
-            }
-        }
-
-        return matches;
+        return documents
+            .Where(document => document.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .Take(this.maxResults)
+            .ToList();
     }
 }

--- a/Standard.Agents/Brokers/Mcps/McpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/McpBroker.cs
@@ -66,13 +66,9 @@ public sealed class McpBroker : IMcpBroker
 
     private static string ToText(JsonRpcResponse jsonRpcResponse)
     {
-        if (jsonRpcResponse.Error is not null)
-        {
-            throw new HttpRequestException(jsonRpcResponse.Error.Message);
-        }
-
-        return string.Concat(
-            jsonRpcResponse.Result!.Content.Select(content => content.Text));
+        return jsonRpcResponse.Error is not null
+            ? throw new HttpRequestException(jsonRpcResponse.Error.Message)
+            : string.Concat(jsonRpcResponse.Result!.Content.Select(content => content.Text));
     }
 
     private async ValueTask<TResult> PostAsync<TContent, TResult>(

--- a/Standard.Agents/Brokers/Skills/SkillBroker.cs
+++ b/Standard.Agents/Brokers/Skills/SkillBroker.cs
@@ -17,21 +17,12 @@ public sealed class SkillBroker : ISkillBroker
 
     public async ValueTask<string> SelectSkillsAsync()
     {
-        if (Directory.Exists(this.skillsPath) is false)
-        {
-            return string.Empty;
-        }
-
-        List<string> skills = [];
-
-        IOrderedEnumerable<string> skillFilePaths =
-    Directory.EnumerateFiles(this.skillsPath, SkillFilePattern)
-        .OrderBy(skillFilePath => skillFilePath, StringComparer.Ordinal);
-
-        foreach (string skillFilePath in skillFilePaths)
-        {
-            skills.Add(await File.ReadAllTextAsync(skillFilePath));
-        }
+        string[] skills = Directory.Exists(this.skillsPath)
+            ? await Task.WhenAll(
+                Directory.EnumerateFiles(this.skillsPath, SkillFilePattern)
+                    .OrderBy(skillFilePath => skillFilePath, StringComparer.Ordinal)
+                    .Select(path => File.ReadAllTextAsync(path)))
+            : [];
 
         return string.Join(SkillSeparator, skills);
     }


### PR DESCRIPTION
Brokers must hold no flow control. This removes the `if`/`foreach` from the three core brokers that had it:

- **SkillBroker** — `if Directory.Exists` + `foreach` read → ternary guard + `Task.WhenAll` over ordered `EnumerateFiles().Select(...)`.
- **KnowledgeBroker** — same, then `.Where(Contains).Take(maxResults)` instead of a `foreach` with an `if`-match and an `if`-break. Result is identical (first `maxResults` matches in path order); it now reads the matched-pattern files then filters, which is fine for the small-scale file default (DB adapters do server-side search at scale).
- **McpBroker.ToText** — `if (Error is not null) throw` → ternary throw.

### Verification
- Build — 0 warnings, 0 errors
- 226 unit tests pass · 7/7 conformance vectors pass

No behavior change. Category: CODE RUB.

---
**Left in place (flagging for your call):** `GeneratorBroker`'s SSE `while` loop is server-sent-events wire parsing; the LlamaSharp `await foreach` (token stream) and Postgres/MsSql `while(reader.ReadAsync())` (ADO.NET rows) in the adapter repos are data-reader iteration. These are transport mechanics — 'the broker speaks its technology's language' — not business flow control, so under The Standard's "no flow control *for business decisions*" they're arguably compliant, and removing them is hard/uglier. Say the word if you want them refactored too.