### PR TITLE
INFRA: Publish To NuGet On Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Standard.Agents Release
+
+# Publishes the package to NuGet when a release is cut (a GitHub Release is
+# published) or triggered manually. The API key is never in the repo — it is
+# read from the NUGET_API_KEY repository secret at run time.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Pulling Code
+      uses: actions/checkout@v4
+
+    - name: Installing .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Restoring Packages
+      run: dotnet restore
+
+    - name: Building Solution
+      run: dotnet build --no-restore --configuration Release
+
+    - name: Running Tests
+      run: dotnet test --no-build --configuration Release --verbosity normal
+
+    # Same gate the build workflow enforces — never publish a package that no
+    # longer conforms to the spec's vectors.
+    - name: Certifying Conformance
+      run: dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
+
+    - name: Packing Package
+      run: >
+        dotnet pack Standard.Agents/Standard.Agents.csproj
+        --no-build
+        --configuration Release
+        --output ${{ github.workspace }}/artifacts
+
+    - name: Publishing To NuGet
+      run: >
+        dotnet nuget push "${{ github.workspace }}/artifacts/*.nupkg"
+        --source https://api.nuget.org/v3/index.json
+        --api-key ${{ secrets.NUGET_API_KEY }}
+        --skip-duplicate


### PR DESCRIPTION
Adds a release pipeline that publishes `Standard.Agents` to NuGet automatically.

## Trigger
- **`release: published`** — when you cut a GitHub Release (your existing flow — v0.9.0 etc. are Release objects), and
- **`workflow_dispatch`** — a manual "Run workflow" button to trigger a publish on demand.

## What it does
`checkout → setup .NET 10 → restore → build (Release) → test → certify conformance → pack → push`. It runs the same test + conformance gate as `dotnet.yml`, so a build that no longer conforms never reaches NuGet. Push uses `--skip-duplicate` so re-runs on an already-published version are a no-op instead of a failure.

## Security — the API key
The key is **not** in the repo. The workflow reads it from a repository secret:

```yaml
--api-key ${{ secrets.NUGET_API_KEY }}
```

**Before the first run, add the secret** (the key value never enters the codebase, the logs, or a PR):

- GitHub UI: **Settings → Secrets and variables → Actions → New repository secret**, name `NUGET_API_KEY`.
- or, from your machine: `gh secret set NUGET_API_KEY --repo hassanhabib/The-Standard-Agent` (paste the key when prompted).

It packs whatever `<Version>` is in `Standard.Agents.csproj` at the checked-out ref, so keep bumping the version before cutting the release (as with 0.10.0.0).

Category: INFRA.