### PR TITLE
MINOR COORDINATIONS: Constitution - Add .Constitution builder that binds the guardians

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -468,6 +468,56 @@ public class StandardAgentTests
         judgeInvoked.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task ShouldPrependConstitutionToGuardianRubricsOnProcessPromptAsync()
+    {
+        // given
+        string constitutionText = "CONSTITUTION: you must do no harm.";
+
+        string constitutionPath = Path.Combine(
+            Path.GetTempPath(), $"constitution-{Guid.NewGuid():N}.md");
+
+        await File.WriteAllTextAsync(constitutionPath, constitutionText);
+
+        string capturedGateRubric = string.Empty;
+        string capturedJudgeRubric = string.Empty;
+
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(EmptyKnowledgeBroker())
+            .LocalBrain(async (systemPrompt, userPrompt) => "FINAL: 42")
+            .Constitution(constitutionPath)
+            .LocalGate(async (gateRubric, prompt) =>
+            {
+                capturedGateRubric = gateRubric;
+
+                return "allow";
+            })
+            .LocalJudge(async (judgeRubric, draftAnswer) =>
+            {
+                capturedJudgeRubric = judgeRubric;
+
+                return "1.0";
+            })
+            .UseLog(new Mock<ILogBroker>().Object);
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "what is the answer?");
+
+        // then
+        capturedGateRubric.Should().Contain(constitutionText);
+        capturedJudgeRubric.Should().Contain(constitutionText);
+
+        File.Delete(constitutionPath);
+    }
+
     private static IKnowledgeBroker EmptyKnowledgeBroker()
     {
         var knowledgeBroker = new Mock<IKnowledgeBroker>();

--- a/Standard.Agents/Brokers/Files/FileBroker.cs
+++ b/Standard.Agents/Brokers/Files/FileBroker.cs
@@ -16,6 +16,9 @@ public sealed class FileBroker : IFileBroker
     public async ValueTask<string> ReadFileAsync(string path) =>
         await File.ReadAllTextAsync(path);
 
+    public string ReadFile(string path) =>
+        File.ReadAllText(path);
+
     public bool FileExists(string path) =>
         File.Exists(path);
 

--- a/Standard.Agents/Brokers/Files/IFileBroker.cs
+++ b/Standard.Agents/Brokers/Files/IFileBroker.cs
@@ -13,6 +13,8 @@ public interface IFileBroker
 
     ValueTask<string> ReadFileAsync(string path);
 
+    string ReadFile(string path);
+
     bool FileExists(string path);
 
     ValueTask<IReadOnlyList<string>> ReadAllLinesAsync(string path);

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -60,6 +60,8 @@ public sealed partial class StandardAgent : IAgent
     private IKnowledgeBroker? knowledgeBroker;
     private IClassifierBroker? classifierBroker;
     private IVerifierBroker? verifierBroker;
+    private Func<string, string, ValueTask<string>>? localGateScreen;
+    private Func<string, string, ValueTask<string>>? localJudgeEvaluate;
     private IMcpBroker? mcpBroker;
     private ILogBroker? logBroker;
     private ILoggingBroker? loggingBroker;
@@ -140,8 +142,7 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="screen">A <c>(gateRubric, prompt) =&gt; verdict</c> delegate.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent LocalGate(Func<string, string, ValueTask<string>> screen) =>
-        Set(() => this.classifierBroker =
-            new FunctionClassifierBroker(screen, GuardianPrompts.Gate));
+        Set(() => this.localGateScreen = screen);
 
     /// <summary>
     /// Turns on the Judge using an in-process model — the local counterpart to <see cref="Judge"/>,
@@ -152,8 +153,7 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="evaluate">A <c>(judgeRubric, draftAnswer) =&gt; score</c> delegate.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent LocalJudge(Func<string, string, ValueTask<string>> evaluate) =>
-        Set(() => this.verifierBroker =
-            new FunctionVerifierBroker(evaluate, GuardianPrompts.Judge));
+        Set(() => this.localJudgeEvaluate = evaluate);
 
     /// <summary>
     /// Turns on the Gate: an opt-in guardian that screens each prompt before the brain sees
@@ -426,20 +426,26 @@ public sealed partial class StandardAgent : IAgent
         List<ITool> allTools = [.. this.tools, new RememberTool(memoryService)];
 
         IClassifierBroker classifier =
-            this.classifierBroker ?? (this.gateSettings is null
-                ? new NotConfiguredClassifierBroker()
-                : new ClassifierBroker(
-                    this.gateSettings.ApiUrl, this.gateSettings.ApiKey, this.gateSettings.Model,
-                    this.gateSettings.Temperature, this.gateSettings.MaxTokens,
-                    this.gateSettings.TimeoutSeconds, GuardianPrompts.Gate));
+            this.classifierBroker
+                ?? (this.localGateScreen is not null
+                    ? new FunctionClassifierBroker(this.localGateScreen, GuardianPrompts.Gate)
+                    : this.gateSettings is null
+                        ? new NotConfiguredClassifierBroker()
+                        : new ClassifierBroker(
+                            this.gateSettings.ApiUrl, this.gateSettings.ApiKey, this.gateSettings.Model,
+                            this.gateSettings.Temperature, this.gateSettings.MaxTokens,
+                            this.gateSettings.TimeoutSeconds, GuardianPrompts.Gate));
 
         IVerifierBroker verifier =
-            this.verifierBroker ?? (this.judgeSettings is null
-                ? new NotConfiguredVerifierBroker()
-                : new VerifierBroker(
-                    this.judgeSettings.ApiUrl, this.judgeSettings.ApiKey, this.judgeSettings.Model,
-                    this.judgeSettings.Temperature, this.judgeSettings.MaxTokens,
-                    this.judgeSettings.TimeoutSeconds, GuardianPrompts.Judge));
+            this.verifierBroker
+                ?? (this.localJudgeEvaluate is not null
+                    ? new FunctionVerifierBroker(this.localJudgeEvaluate, GuardianPrompts.Judge)
+                    : this.judgeSettings is null
+                        ? new NotConfiguredVerifierBroker()
+                        : new VerifierBroker(
+                            this.judgeSettings.ApiUrl, this.judgeSettings.ApiKey, this.judgeSettings.Model,
+                            this.judgeSettings.Temperature, this.judgeSettings.MaxTokens,
+                            this.judgeSettings.TimeoutSeconds, GuardianPrompts.Judge));
 
         IToolBroker toolBroker = new ToolBroker(allTools);
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -40,6 +40,7 @@ public sealed partial class StandardAgent : IAgent
     private readonly List<ITool> tools = [];
 
     private string skillsPath = "Skills";
+    private string constitutionPath = string.Empty;
     private string logPath = "log.txt";
     private string memoryPath = "memory.txt";
     private string knowledgePath = "Knowledge";
@@ -97,6 +98,18 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent Skills(string path) =>
         Set(() => this.skillsPath = path);
+
+    /// <summary>
+    /// Points the agent at the ethical constitution: a markdown file whose text is prepended
+    /// to every guardian rubric (Gate and Judge), above the built-in policy, so the guardians
+    /// are bound by it. It takes effect only when a guardian is configured, and it never
+    /// replaces the built-in output contract. Omit it to run the built-in guardian policy
+    /// alone. The file must be copied to the build output.
+    /// </summary>
+    /// <param name="path">Path to the constitution <c>.md</c> file.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Constitution(string path) =>
+        Set(() => this.constitutionPath = path);
 
     /// <summary>
     /// Sets the brain: an external, OpenAI-compatible chat-completions endpoint that does the

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -416,6 +416,30 @@ public sealed partial class StandardAgent : IAgent
         return this;
     }
 
+    // Reads the constitution file if one was configured, resolved against the build output
+    // like skills. A missing file yields no constitution rather than an error, so a stale
+    // path degrades to the built-in guardian policy instead of bricking composition.
+    private string ReadConstitution(IFileBroker file)
+    {
+        if (string.IsNullOrWhiteSpace(this.constitutionPath))
+        {
+            return string.Empty;
+        }
+
+        string fullPath = Path.Combine(AppContext.BaseDirectory, this.constitutionPath);
+
+        return file.FileExists(fullPath)
+            ? file.ReadFile(fullPath)
+            : string.Empty;
+    }
+
+    // Prepends the constitution above a guardian's built-in policy. The built-in policy stays
+    // last so its output contract (allow/refuse, the 0.0-1.0 score) is never displaced.
+    private static string ComposeGuardianRubric(string constitution, string policy) =>
+        string.IsNullOrWhiteSpace(constitution)
+            ? policy
+            : $"{constitution}\n\n{policy}";
+
     private IAgentCoordinationService Compose()
     {
         ValidateComposition();
@@ -438,27 +462,31 @@ public sealed partial class StandardAgent : IAgent
 
         List<ITool> allTools = [.. this.tools, new RememberTool(memoryService)];
 
+        string constitution = ReadConstitution(file);
+        string gateRubric = ComposeGuardianRubric(constitution, GuardianPrompts.Gate);
+        string judgeRubric = ComposeGuardianRubric(constitution, GuardianPrompts.Judge);
+
         IClassifierBroker classifier =
             this.classifierBroker
                 ?? (this.localGateScreen is not null
-                    ? new FunctionClassifierBroker(this.localGateScreen, GuardianPrompts.Gate)
+                    ? new FunctionClassifierBroker(this.localGateScreen, gateRubric)
                     : this.gateSettings is null
                         ? new NotConfiguredClassifierBroker()
                         : new ClassifierBroker(
                             this.gateSettings.ApiUrl, this.gateSettings.ApiKey, this.gateSettings.Model,
                             this.gateSettings.Temperature, this.gateSettings.MaxTokens,
-                            this.gateSettings.TimeoutSeconds, GuardianPrompts.Gate));
+                            this.gateSettings.TimeoutSeconds, gateRubric));
 
         IVerifierBroker verifier =
             this.verifierBroker
                 ?? (this.localJudgeEvaluate is not null
-                    ? new FunctionVerifierBroker(this.localJudgeEvaluate, GuardianPrompts.Judge)
+                    ? new FunctionVerifierBroker(this.localJudgeEvaluate, judgeRubric)
                     : this.judgeSettings is null
                         ? new NotConfiguredVerifierBroker()
                         : new VerifierBroker(
                             this.judgeSettings.ApiUrl, this.judgeSettings.ApiKey, this.judgeSettings.Model,
                             this.judgeSettings.Temperature, this.judgeSettings.MaxTokens,
-                            this.judgeSettings.TimeoutSeconds, GuardianPrompts.Judge));
+                            this.judgeSettings.TimeoutSeconds, judgeRubric));
 
         IToolBroker toolBroker = new ToolBroker(allTools);
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -274,6 +274,24 @@ var agent = new StandardAgent()
     .LocalJudge(llama.GenerateAsync);
 ```
 
+**One law above both.** The Gate and Judge each ship with a built-in policy. To bind them to
+your own rules, point the agent at an ethical constitution with `.Constitution(...)`, a markdown
+file whose text is prepended above *both* guardian rubrics, so one law governs what is screened
+and what is scored.
+
+```csharp
+var agent = new StandardAgent(url, key, "LLooMA2.0")
+    .Skills("Skills")
+    .Constitution("Constitution/ethics.md")   // ← prepended above the gate and judge policy
+    .Gate(apiUrl: url, apiKey: key, model: "LLooMA2.0")
+    .Judge(apiUrl: url, apiKey: key, model: "LLooMA2.0");
+```
+
+It is prepended, never a replacement: the built-in output contract (the gate's `allow` or
+`refuse`, the judge's score) always stays in place, so a constitution cannot accidentally break a
+guardian's wiring. It only takes effect when a guardian is on, and the file must be copied to the
+build output, the same as your skills.
+
 ---
 
 ## 6 · Memory — it remembers you across restarts


### PR DESCRIPTION
## What

Adds a `.Constitution(path)` builder to `StandardAgent`. It points the agent at an ethical constitution (a markdown file) whose text is **prepended above both guardian rubrics** (Gate and Judge), so one authored law governs what is screened and what is scored.

## Why

The guardian rules are baked into `GuardianPrompts` (embedded `gate.md` / `judge.md`) with no way for a user to supply their own. This lets an operator bind the guardians to their own ethical rules without editing the framework.

## Design

- **Prepend, never replace.** The built-in policy stays last, so its output contract (the gate's `allow` / `refuse`, the judge's `0.0`-`1.0` score) is never displaced. A user's constitution cannot brick a guardian.
- **Opt-in and defaulting.** Omit `.Constitution(...)` and the built-in policy runs alone, unchanged. Takes effect only when a Gate or Judge is configured.
- **Fail-soft on a missing file.** A stale path degrades to the built-in policy rather than throwing at composition.

## Commits (The Standard practice)

- `BROKERS:` add a synchronous `ReadFile` to `IFileBroker` for composition-time reads.
- `COMPOSITION:` build the local guardian brokers at composition time.
- `ShouldPrependConstitutionToGuardianRubricsOnProcessPromptAsync -> FAIL` then `-> PASS`.
- `DOCUMENTATION:` document `.Constitution` in the how-to.

## Tests

234 passing (was 233). New test asserts the constitution reaches both the gate and judge rubrics. Size: MINOR (1 test).

## Notes

Supersedes the earlier PR that used a non-Standard branch name. Branch and title now follow the-standard-practices (prac-010, prac-040).

Follow-ups: `.Consumption` (with the output-contract split) and the SPEC contract in The-Standard-Agent-Specs.