### PR TITLE
MINOR COORDINATIONS: Consumption - Add .Consumption builder that replaces the guardian policy

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -518,6 +518,61 @@ public class StandardAgentTests
         File.Delete(constitutionPath);
     }
 
+    [Fact]
+    public async Task ShouldReplaceGuardianPolicyWithConsumptionOnProcessPromptAsync()
+    {
+        // given
+        string consumptionText = "CONSUMPTION: screen and score by these house rules only.";
+
+        string consumptionPath = Path.Combine(
+            Path.GetTempPath(), $"consumption-{Guid.NewGuid():N}.md");
+
+        await File.WriteAllTextAsync(consumptionPath, consumptionText);
+
+        string capturedGateRubric = string.Empty;
+        string capturedJudgeRubric = string.Empty;
+
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(EmptyKnowledgeBroker())
+            .LocalBrain(async (systemPrompt, userPrompt) => "FINAL: 42")
+            .Consumption(consumptionPath)
+            .LocalGate(async (gateRubric, prompt) =>
+            {
+                capturedGateRubric = gateRubric;
+
+                return "allow";
+            })
+            .LocalJudge(async (judgeRubric, draftAnswer) =>
+            {
+                capturedJudgeRubric = judgeRubric;
+
+                return "1.0";
+            })
+            .UseLog(new Mock<ILogBroker>().Object);
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "what is the answer?");
+
+        // then
+        capturedGateRubric.Should().Contain(consumptionText);
+        capturedGateRubric.Should().Contain("refuse");
+        capturedGateRubric.Should().NotContain("conscience that screens");
+
+        capturedJudgeRubric.Should().Contain(consumptionText);
+        capturedJudgeRubric.Should().Contain("decimal number");
+        capturedJudgeRubric.Should().NotContain("reviews the Brain");
+
+        File.Delete(consumptionPath);
+    }
+
     private static IKnowledgeBroker EmptyKnowledgeBroker()
     {
         var knowledgeBroker = new Mock<IKnowledgeBroker>();

--- a/Standard.Agents/Prompts/GuardianPrompts.cs
+++ b/Standard.Agents/Prompts/GuardianPrompts.cs
@@ -9,12 +9,21 @@ namespace Standard.Agents.Prompts;
 
 internal static class GuardianPrompts
 {
-    private const string GateResourceName = "Standard.Agents.Prompts.Guardians.gate.md";
-    private const string JudgeResourceName = "Standard.Agents.Prompts.Guardians.judge.md";
+    private const string GatePolicyResourceName = "Standard.Agents.Prompts.Guardians.gate.policy.md";
+    private const string GateContractResourceName = "Standard.Agents.Prompts.Guardians.gate.contract.md";
+    private const string JudgePolicyResourceName = "Standard.Agents.Prompts.Guardians.judge.policy.md";
+    private const string JudgeContractResourceName = "Standard.Agents.Prompts.Guardians.judge.contract.md";
 
-    internal static string Gate => Read(GateResourceName);
+    // The policy is the replaceable part (what to screen or score); a consumption skill
+    // can supply its own. The contract is the output protocol (allow/refuse, the score) the
+    // broker parses, so it is framework-owned and always appended, never replaced.
+    internal static string GatePolicy => Read(GatePolicyResourceName);
 
-    internal static string Judge => Read(JudgeResourceName);
+    internal static string GateContract => Read(GateContractResourceName);
+
+    internal static string JudgePolicy => Read(JudgePolicyResourceName);
+
+    internal static string JudgeContract => Read(JudgeContractResourceName);
 
     private static string Read(string resourceName)
     {

--- a/Standard.Agents/Prompts/Guardians/gate.contract.md
+++ b/Standard.Agents/Prompts/Guardians/gate.contract.md
@@ -1,0 +1,6 @@
+Reply with exactly one line and nothing else:
+
+- `allow` — if the task may proceed.
+- `refuse: <short reason>` — if it must not.
+
+Do not explain an allow. Do not add anything before or after the single line.

--- a/Standard.Agents/Prompts/Guardians/gate.policy.md
+++ b/Standard.Agents/Prompts/Guardians/gate.policy.md
@@ -6,10 +6,3 @@ decide whether the task in front of you is safe and permissible to attempt.
 Judge the task, not the phrasing. Refuse only when attempting it would cause real harm:
 requests for credentials, secrets, or private data; instructions to damage systems or data;
 clearly illegal or dangerous acts.
-
-Reply with exactly one line and nothing else:
-
-- `allow` — if the task may proceed.
-- `refuse: <short reason>` — if it must not.
-
-Do not explain an allow. Do not add anything before or after the single line.

--- a/Standard.Agents/Prompts/Guardians/judge.contract.md
+++ b/Standard.Agents/Prompts/Guardians/judge.contract.md
@@ -1,0 +1,2 @@
+Reply with exactly one decimal number between 0.0 and 1.0 and nothing else — no words, no
+punctuation, no explanation. Just the number.

--- a/Standard.Agents/Prompts/Guardians/judge.policy.md
+++ b/Standard.Agents/Prompts/Guardians/judge.policy.md
@@ -4,6 +4,3 @@ You are not the Brain. You do not rewrite, improve, or continue the answer. Your
 to score how well the candidate answer addresses the task it was given.
 
 Consider correctness, completeness, and relevance. A confident but wrong answer scores low.
-
-Reply with exactly one decimal number between 0.0 and 1.0 and nothing else — no words, no
-punctuation, no explanation. Just the number.

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -63,8 +63,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Prompts\Guardians\gate.md" />
-    <EmbeddedResource Include="Prompts\Guardians\judge.md" />
+    <EmbeddedResource Include="Prompts\Guardians\gate.policy.md" />
+    <EmbeddedResource Include="Prompts\Guardians\gate.contract.md" />
+    <EmbeddedResource Include="Prompts\Guardians\judge.policy.md" />
+    <EmbeddedResource Include="Prompts\Guardians\judge.contract.md" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -41,6 +41,7 @@ public sealed partial class StandardAgent : IAgent
 
     private string skillsPath = "Skills";
     private string constitutionPath = string.Empty;
+    private string consumptionPath = string.Empty;
     private string logPath = "log.txt";
     private string memoryPath = "memory.txt";
     private string knowledgePath = "Knowledge";
@@ -110,6 +111,19 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent Constitution(string path) =>
         Set(() => this.constitutionPath = path);
+
+    /// <summary>
+    /// Points the agent at the consumption skill: a markdown file whose text replaces the
+    /// built-in guardian policy (what the Gate screens for and what the Judge scores). The
+    /// built-in output contract is always kept, so a replacement policy cannot break the
+    /// guardian's wiring. It sits below the constitution and above the contract, and takes
+    /// effect only when a guardian is configured. Omit it to use the built-in policy. The
+    /// file must be copied to the build output.
+    /// </summary>
+    /// <param name="path">Path to the consumption skill <c>.md</c> file.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Consumption(string path) =>
+        Set(() => this.consumptionPath = path);
 
     /// <summary>
     /// Sets the brain: an external, OpenAI-compatible chat-completions endpoint that does the

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -433,12 +433,12 @@ public sealed partial class StandardAgent : IAgent
             : string.Empty;
     }
 
-    // Prepends the constitution above a guardian's built-in policy. The built-in policy stays
-    // last so its output contract (allow/refuse, the 0.0-1.0 score) is never displaced.
-    private static string ComposeGuardianRubric(string constitution, string policy) =>
-        string.IsNullOrWhiteSpace(constitution)
-            ? policy
-            : $"{constitution}\n\n{policy}";
+    // Assembles a guardian rubric from its parts in order, skipping any that are empty:
+    // constitution first (the law), then the policy (what to screen or score), then the
+    // contract (the output protocol the broker parses). The contract stays last so it is
+    // never displaced, whatever the policy above it.
+    private static string ComposeGuardianRubric(params string[] parts) =>
+        string.Join("\n\n", parts.Where(part => string.IsNullOrWhiteSpace(part) is false));
 
     private IAgentCoordinationService Compose()
     {
@@ -463,8 +463,11 @@ public sealed partial class StandardAgent : IAgent
         List<ITool> allTools = [.. this.tools, new RememberTool(memoryService)];
 
         string constitution = ReadConstitution(file);
-        string gateRubric = ComposeGuardianRubric(constitution, GuardianPrompts.Gate);
-        string judgeRubric = ComposeGuardianRubric(constitution, GuardianPrompts.Judge);
+        string gateRubric = ComposeGuardianRubric(
+            constitution, GuardianPrompts.GatePolicy, GuardianPrompts.GateContract);
+
+        string judgeRubric = ComposeGuardianRubric(
+            constitution, GuardianPrompts.JudgePolicy, GuardianPrompts.JudgeContract);
 
         IClassifierBroker classifier =
             this.classifierBroker

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -430,17 +430,17 @@ public sealed partial class StandardAgent : IAgent
         return this;
     }
 
-    // Reads the constitution file if one was configured, resolved against the build output
-    // like skills. A missing file yields no constitution rather than an error, so a stale
-    // path degrades to the built-in guardian policy instead of bricking composition.
-    private string ReadConstitution(IFileBroker file)
+    // Reads an optional prompt file (constitution, consumption) resolved against the build
+    // output like skills. A missing file yields empty rather than an error, so a stale path
+    // degrades to the built-in guardian policy instead of bricking composition.
+    private static string ReadOptionalFile(IFileBroker file, string path)
     {
-        if (string.IsNullOrWhiteSpace(this.constitutionPath))
+        if (string.IsNullOrWhiteSpace(path))
         {
             return string.Empty;
         }
 
-        string fullPath = Path.Combine(AppContext.BaseDirectory, this.constitutionPath);
+        string fullPath = Path.Combine(AppContext.BaseDirectory, path);
 
         return file.FileExists(fullPath)
             ? file.ReadFile(fullPath)
@@ -476,12 +476,22 @@ public sealed partial class StandardAgent : IAgent
 
         List<ITool> allTools = [.. this.tools, new RememberTool(memoryService)];
 
-        string constitution = ReadConstitution(file);
+        string constitution = ReadOptionalFile(file, this.constitutionPath);
+        string consumption = ReadOptionalFile(file, this.consumptionPath);
+
+        string gatePolicy = string.IsNullOrWhiteSpace(consumption)
+            ? GuardianPrompts.GatePolicy
+            : consumption;
+
+        string judgePolicy = string.IsNullOrWhiteSpace(consumption)
+            ? GuardianPrompts.JudgePolicy
+            : consumption;
+
         string gateRubric = ComposeGuardianRubric(
-            constitution, GuardianPrompts.GatePolicy, GuardianPrompts.GateContract);
+            constitution, gatePolicy, GuardianPrompts.GateContract);
 
         string judgeRubric = ComposeGuardianRubric(
-            constitution, GuardianPrompts.JudgePolicy, GuardianPrompts.JudgeContract);
+            constitution, judgePolicy, GuardianPrompts.JudgeContract);
 
         IClassifierBroker classifier =
             this.classifierBroker

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -292,6 +292,24 @@ It is prepended, never a replacement: the built-in output contract (the gate's `
 guardian's wiring. It only takes effect when a guardian is on, and the file must be copied to the
 build output, the same as your skills.
 
+**Replacing the policy.** The Gate and Judge each ship with a built-in policy for what to screen
+and how to score. To replace that policy with your own, point the agent at a consumption skill with
+`.Consumption(...)`. Its text takes the place of the built-in policy, while the built-in output
+contract is always kept, so a replacement can never break the guardian's wiring.
+
+```csharp
+var agent = new StandardAgent(url, key, "LLooMA2.0")
+    .Skills("Skills")
+    .Constitution("Constitution/ethics.md")           // the law, prepended
+    .Consumption("Constitution/consuming-skills.md")   // ← replaces the guardian policy
+    .Gate(apiUrl: url, apiKey: key, model: "LLooMA2.0")
+    .Judge(apiUrl: url, apiKey: key, model: "LLooMA2.0");
+```
+
+The assembled rubric is the constitution, then your consumption policy (or the built-in one when
+omitted), then the built-in contract, always in that order. Like the constitution, it takes effect
+only when a guardian is on, and the file must be copied to the build output.
+
 ---
 
 ## 6 · Memory — it remembers you across restarts


### PR DESCRIPTION
## What

Adds a `.Consumption(path)` builder to `StandardAgent`. It points the agent at a consumption skill (the SKILL of all SKILLs) whose text **replaces the built-in guardian policy** for both Gate and Judge, while the framework-owned output contract is always kept.

Stacked on #152 (`.Constitution`); review that first. Base will retarget to `main` once #152 merges.

## The output-contract split

Previously `gate.md` / `judge.md` fused two things: the policy (what to screen or score) and the output contract (`allow`/`refuse`, the `0.0`-`1.0` score the broker parses). This PR splits each into a `*.policy.md` and a `*.contract.md`. Now:

```
gateRubric  = constitution + (consumption OR built-in gate policy)  + gate contract
judgeRubric = constitution + (consumption OR built-in judge policy) + judge contract
```

The contract is always appended last, so a replacement policy can never break the guardian's wiring. This is what makes `.Consumption` safe to fully replace the policy.

## Design

- **Replace the policy, keep the contract.** Consumption substitutes the policy; the contract is framework-owned and immovable.
- **One skill, both guardians.** The consumption skill governs Gate and Judge; each applies its own section.
- **Opt-in and defaulting, fail-soft.** Omit it for the built-in policy; a stale path degrades to the built-in policy.

## Commits (The Standard practice)

- `GUARDIANS: Split gate/judge prompts into policy and contract`
- `ShouldReplaceGuardianPolicyWithConsumptionOnProcessPromptAsync -> FAIL` then `-> PASS`
- `DOCUMENTATION: Document .Consumption in the how-to`

## Tests

235 passing (was 234). New test asserts the consumption text replaces the default policy in both rubrics while the contract survives. Size: MINOR (1 test).

## Follow-up

The SPEC contract for constitution + consumption loading will be added in The-Standard-Agent-Specs.