### PR TITLE
COORDINATIONS: Refuse Gracefully When Review Never Passes

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
@@ -132,6 +132,38 @@ Times.Exactly(7));
     }
 
     [Fact]
+    public async Task ShouldRefuseGracefullyWhenReviewNeverPassesOnProcessPromptAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        string expectedResult = "I can't help with that at the moment.";
+
+        this.dataOrchestrationServiceMock.Setup(service =>
+            service.RecallAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) => context);
+
+        this.decisionOrchestrationServiceMock.Setup(service =>
+            service.ThinkAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) =>
+                    context with { Status = AgentStatus.Revising });
+
+        // when
+        string actualResult =
+            await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        actualResult.Should().Be(expectedResult);
+
+        this.decisionOrchestrationServiceMock.Verify(service =>
+            service.ThinkAsync(It.IsAny<AgentContext>()),
+                Times.Exactly(7));
+
+        this.directionOrchestrationServiceMock.Verify(service =>
+            service.ActAsync(It.IsAny<AgentContext>()),
+                Times.Never);
+    }
+
+    [Fact]
     public async Task ShouldRecallEveryTurnOnProcessPromptAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
@@ -100,7 +100,7 @@ public partial class DecisionOrchestrationServiceTests
             await this.decisionOrchestrationService.ThinkAsync(inputContext);
 
         // then
-        actualContext.Status.Should().Be(AgentStatus.Working);
+        actualContext.Status.Should().Be(AgentStatus.Revising);
         actualContext.DirectionType.Should().NotBe("ReturnResponse");
     }
 

--- a/Standard.Agents/Models/Orchestrations/Agents/AgentStatus.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentStatus.cs
@@ -11,5 +11,6 @@ public enum AgentStatus
     Responded = 1,
     AwaitingInput = 2,
     Refused = 3,
-    Failed = 4
+    Failed = 4,
+    Revising = 5
 }

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -18,6 +18,9 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 {
     private const int MaxTurns = 7;
 
+    private const string RetriesExhaustedMessage =
+        "I can't help with that at the moment.";
+
     private readonly IDataOrchestrationService dataOrchestrationService;
     private readonly IDecisionOrchestrationService decisionOrchestrationService;
     private readonly IDirectionOrchestrationService directionOrchestrationService;
@@ -51,6 +54,14 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         {
             context = await this.dataOrchestrationService.RecallAsync(context);
             context = await this.decisionOrchestrationService.ThinkAsync(context);
+
+            if (context.Status is AgentStatus.Revising)
+            {
+                await LogTurnAsync(turn, context);
+
+                continue;
+            }
+
             context = await this.directionOrchestrationService.ActAsync(context);
 
             await LogTurnAsync(turn, context);
@@ -59,6 +70,15 @@ public partial class AgentCoordinationService : IAgentCoordinationService
             {
                 break;
             }
+        }
+
+        if (context.Status is AgentStatus.Revising)
+        {
+            context = context with
+            {
+                Result = RetriesExhaustedMessage,
+                Status = AgentStatus.Refused
+            };
         }
 
         return context.Result;
@@ -89,6 +109,13 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
             context = decisionStream.Result;
 
+            if (context.Status is AgentStatus.Revising)
+            {
+                await LogTurnAsync(turn, context);
+
+                continue;
+            }
+
             context = await this.directionOrchestrationService.ActAsync(context);
 
             if (context.Status is AgentStatus.Working
@@ -105,6 +132,17 @@ public partial class AgentCoordinationService : IAgentCoordinationService
             {
                 break;
             }
+        }
+
+        if (context.Status is AgentStatus.Revising)
+        {
+            yield return new AgentStreamEvent(
+                AgentStreamEventType.Status,
+                "unable to satisfy review after retries; refusing");
+
+            yield return new AgentStreamEvent(
+                AgentStreamEventType.Response,
+                RetriesExhaustedMessage);
         }
     }
 

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -101,7 +101,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
                     $"A previous draft was rejected on review: {decided.Payload}"
                 ],
 
-                Status = AgentStatus.Working
+                Status = AgentStatus.Revising
             };
         }
 
@@ -197,7 +197,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
                     $"A previous draft was rejected on review: {decided.Payload}"
                 ],
 
-                Status = AgentStatus.Working
+                Status = AgentStatus.Revising
             });
 
             yield return new AgentStreamEvent(


### PR DESCRIPTION
When the Judge rejected a draft, the coordination loop still ran `ActAsync` on a context whose `DirectionType` was empty, faulting with `InvalidInternalToolException`. Exhausting the turn budget while still rejected also returned an empty result.

**Fix**
- Added `AgentStatus.Revising`.
- `DecisionOrchestrationService` marks a rejected draft `Revising` (sync + stream) instead of the ambiguous `Working`.
- `AgentCoordinationService` re-thinks on `Revising` (skips `Act`), and after `MaxTurns` refuses gracefully: "I can't help with that at the moment."

236/236 unit tests pass; conformance 10/10.