### PR TITLE
RELEASES: Standard.Agents 0.12.0.0

### DIFF
--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -43,7 +43,7 @@
          3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1 goes to 1 when the spec settles.
          (0.8.0.0: memory and knowledge came alive — knowledge retrieval in Recall + a built-in
          'remember' tool.) -->
-    <Version>0.11.0.0</Version>
+    <Version>0.12.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>


### PR DESCRIPTION
Bumps the package version to 0.12.0.0 for release. Includes the graceful-refusal fix for the guardian review loop (PR #157).