### PR TITLE
COORDINATIONS: Reserve The Response Stream For The Settled Answer

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.ThinkStream.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.ThinkStream.cs
@@ -15,7 +15,7 @@ namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
 public partial class DecisionOrchestrationServiceTests
 {
     [Fact]
-    public async Task ShouldStreamAnswerAsResponseOnThinkStreamAsync()
+    public async Task ShouldStreamAnswerDraftAsThinkingOnThinkStreamAsync()
     {
         // given
         AgentContext inputContext = CreateRandomAgentContext();
@@ -34,13 +34,15 @@ public partial class DecisionOrchestrationServiceTests
         List<AgentStreamEvent> actualEvents = await DrainAsync(decisionStream);
 
         // then
-        actualEvents.Should().OnlyContain(streamEvent =>
+        actualEvents.Should().NotContain(streamEvent =>
             streamEvent.Type == AgentStreamEventType.Response);
 
-        string streamedResponse =
-            string.Concat(actualEvents.Select(streamEvent => streamEvent.Content));
+        string streamedDraft =
+            string.Concat(actualEvents
+                .Where(streamEvent => streamEvent.Type == AgentStreamEventType.Thinking)
+                .Select(streamEvent => streamEvent.Content));
 
-        streamedResponse.Should().Be("Hello there!");
+        streamedDraft.Should().Be("Hello there!");
         decisionStream.Result.DirectionType.Should().Be("ReturnResponse");
         decisionStream.Result.Payload.Should().Be("Hello there!");
     }
@@ -79,7 +81,7 @@ public partial class DecisionOrchestrationServiceTests
     }
 
     [Fact]
-    public async Task ShouldSplitFinalPrefixIntoThinkingAndResponseOnThinkStreamAsync()
+    public async Task ShouldStreamFinalDraftAsThinkingOnThinkStreamAsync()
     {
         // given
         AgentContext inputContext = CreateRandomAgentContext();
@@ -101,16 +103,14 @@ public partial class DecisionOrchestrationServiceTests
         actualEvents.Should().Contain(streamEvent =>
             streamEvent.Type == AgentStreamEventType.Thinking);
 
-        string streamedResponse = string.Concat(actualEvents
-            .Where(streamEvent => streamEvent.Type == AgentStreamEventType.Response)
-            .Select(streamEvent => streamEvent.Content));
+        actualEvents.Should().NotContain(streamEvent =>
+            streamEvent.Type == AgentStreamEventType.Response);
 
-        streamedResponse.Should().Be("The answer is 42.");
         decisionStream.Result.Payload.Should().Be("The answer is 42.");
     }
 
     [Fact]
-    public async Task ShouldStreamRefusalAsResponseOnThinkStreamIfGateRefusesAsync()
+    public async Task ShouldNotStreamResponseOnThinkStreamIfGateRefusesAsync()
     {
         // given
         AgentContext inputContext = CreateRandomAgentContext();
@@ -127,8 +127,11 @@ public partial class DecisionOrchestrationServiceTests
 
         // then
         actualEvents.Should().Contain(streamEvent =>
-            streamEvent.Type == AgentStreamEventType.Response
-                && streamEvent.Content == "I'm not able to help with that.");
+            streamEvent.Type == AgentStreamEventType.Status
+                && streamEvent.Content == "gate refused the request");
+
+        actualEvents.Should().NotContain(streamEvent =>
+            streamEvent.Type == AgentStreamEventType.Response);
 
         decisionStream.Result.DirectionType.Should().Be("Refuse");
 

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -126,6 +126,14 @@ public partial class AgentCoordinationService : IAgentCoordinationService
                     $"{context.DirectionType}: {context.Result}");
             }
 
+            if (context.Status is AgentStatus.Responded or AgentStatus.Refused
+                && string.IsNullOrEmpty(context.Result) is false)
+            {
+                yield return new AgentStreamEvent(
+                    AgentStreamEventType.Response,
+                    context.Result);
+            }
+
             await LogTurnAsync(turn, context);
 
             if (context.Status is not AgentStatus.Working)

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -134,9 +134,6 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             yield return new AgentStreamEvent(
                 AgentStreamEventType.Status, "gate refused the request");
 
-            yield return new AgentStreamEvent(
-                AgentStreamEventType.Response, RefusalMessage);
-
             yield break;
         }
 
@@ -154,13 +151,13 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
             foreach (AgentStreamEvent segment in classifier.Classify(delta))
             {
-                yield return segment;
+                yield return AsUnsettledDraft(segment);
             }
         }
 
         foreach (AgentStreamEvent segment in classifier.Flush())
         {
-            yield return segment;
+            yield return AsUnsettledDraft(segment);
         }
 
         AgentContext decided = Interpret(context, reply.ToString().Trim());
@@ -208,6 +205,11 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         setResult(decided);
     }
+
+    private static AgentStreamEvent AsUnsettledDraft(AgentStreamEvent segment) =>
+        segment.Type is AgentStreamEventType.Response
+            ? segment with { Type = AgentStreamEventType.Thinking }
+            : segment;
 
     private static bool IsRefusal(string verdict) =>
 verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
Streaming emitted the brain's draft answer as Response tokens live, so a Judge-rejected draft leaked into the Response channel. The draft now streams as Thinking, and the coordinator emits one Response event from the settled result after Act — the same value ProcessPromptAsync returns. Filtering a stream to Response now equals ProcessPromptAsync; drafts, rejections, reasoning and tool calls live in Thinking/Status/Tool.