### PR TITLE
COORDINATIONS: Make Max Turns Configurable

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
@@ -6,6 +6,7 @@
 using FluentAssertions;
 using Moq;
 using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Coordinations;
 using Xunit;
 
 namespace Standard.Agents.Tests.Unit.Services.Coordinations;
@@ -129,6 +130,36 @@ Times.Exactly(7));
         this.decisionOrchestrationServiceMock.Verify(service =>
             service.ThinkAsync(It.IsAny<AgentContext>()),
                 Times.Exactly(7));
+    }
+
+    [Fact]
+    public async Task ShouldCapTurnsAtConfiguredMaximumOnProcessPromptAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        int configuredMaxTurns = 3;
+
+        var boundedCoordinationService = new AgentCoordinationService(
+            dataOrchestrationService: this.dataOrchestrationServiceMock.Object,
+            decisionOrchestrationService: this.decisionOrchestrationServiceMock.Object,
+            directionOrchestrationService: this.directionOrchestrationServiceMock.Object,
+            logBroker: this.logBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object,
+            maxTurns: configuredMaxTurns);
+
+        SetupOrchestrationsPassThrough();
+        SetupDirectionNeverTerminates("again");
+
+        // when
+        string actualResult =
+            await boundedCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        actualResult.Should().Be("again");
+
+        this.dataOrchestrationServiceMock.Verify(service =>
+            service.RecallAsync(It.IsAny<AgentContext>()),
+                Times.Exactly(configuredMaxTurns));
     }
 
     [Fact]

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -53,7 +53,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
         AgentContext context = new() { Prompt = prompt };
 
-        for (int turn = 1; turn <= DefaultMaxTurns; turn++)
+        for (int turn = 1; turn <= this.maxTurns; turn++)
         {
             context = await this.dataOrchestrationService.RecallAsync(context);
             context = await this.decisionOrchestrationService.ThinkAsync(context);
@@ -97,7 +97,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
         AgentContext context = new() { Prompt = prompt };
 
-        for (int turn = 1; turn <= DefaultMaxTurns; turn++)
+        for (int turn = 1; turn <= this.maxTurns; turn++)
         {
             context = await this.dataOrchestrationService.RecallAsync(context);
 

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -16,7 +16,7 @@ namespace Standard.Agents.Services.Coordinations;
 
 public partial class AgentCoordinationService : IAgentCoordinationService
 {
-    private const int MaxTurns = 7;
+    private const int DefaultMaxTurns = 7;
 
     private const string RetriesExhaustedMessage =
         "I can't help with that at the moment.";
@@ -26,19 +26,22 @@ public partial class AgentCoordinationService : IAgentCoordinationService
     private readonly IDirectionOrchestrationService directionOrchestrationService;
     private readonly ILogBroker logBroker;
     private readonly ILoggingBroker loggingBroker;
+    private readonly int maxTurns;
 
     public AgentCoordinationService(
         IDataOrchestrationService dataOrchestrationService,
         IDecisionOrchestrationService decisionOrchestrationService,
         IDirectionOrchestrationService directionOrchestrationService,
         ILogBroker logBroker,
-        ILoggingBroker loggingBroker)
+        ILoggingBroker loggingBroker,
+        int maxTurns = DefaultMaxTurns)
     {
         this.dataOrchestrationService = dataOrchestrationService;
         this.decisionOrchestrationService = decisionOrchestrationService;
         this.directionOrchestrationService = directionOrchestrationService;
         this.logBroker = logBroker;
         this.loggingBroker = loggingBroker;
+        this.maxTurns = maxTurns;
     }
 
     public ValueTask<string> ProcessPromptAsync(string prompt) =>
@@ -50,7 +53,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
         AgentContext context = new() { Prompt = prompt };
 
-        for (int turn = 1; turn <= MaxTurns; turn++)
+        for (int turn = 1; turn <= DefaultMaxTurns; turn++)
         {
             context = await this.dataOrchestrationService.RecallAsync(context);
             context = await this.decisionOrchestrationService.ThinkAsync(context);
@@ -94,7 +97,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
         AgentContext context = new() { Prompt = prompt };
 
-        for (int turn = 1; turn <= MaxTurns; turn++)
+        for (int turn = 1; turn <= DefaultMaxTurns; turn++)
         {
             context = await this.dataOrchestrationService.RecallAsync(context);
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -44,6 +44,7 @@ public sealed partial class StandardAgent : IAgent
     private string consumptionPath = string.Empty;
     private string logPath = "log.txt";
     private string memoryPath = "memory.txt";
+    private int maxTurns = 7;
     private string knowledgePath = "Knowledge";
     private string knowledgePattern = "*.md";
     private int knowledgeMaxResults = 3;
@@ -297,6 +298,16 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent LogTo(string path) =>
         Set(() => this.logPath = path);
+
+    /// <summary>
+    /// Caps how many Recall→Think→Act turns a single prompt may take before the agent stops —
+    /// the shared budget across tool calls and Judge revisions. Defaults to 7. A value below 1
+    /// is treated as 1.
+    /// </summary>
+    /// <param name="turns">Maximum turns per prompt.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent MaxTurns(int turns) =>
+        Set(() => this.maxTurns = turns < 1 ? 1 : turns);
 
     /// <summary>
     /// Swaps in a custom skill broker, replacing the default file-backed one. For advanced hosts
@@ -557,7 +568,7 @@ public sealed partial class StandardAgent : IAgent
             new ReturnService(logging),
             logging);
 
-        return new AgentCoordinationService(data, decision, direction, log, logging);
+        return new AgentCoordinationService(data, decision, direction, log, logging, this.maxTurns);
     }
 
     // The catalog a "{{tools}}" marker in the agent's Data expands into. Only tools that


### PR DESCRIPTION
The Recall→Think→Act turn cap was a hardcoded 7. AgentCoordinationService now takes an optional maxTurns (default 7), and StandardAgent exposes it via .MaxTurns(n) so callers can tune the shared budget across tool calls and Judge revisions.