### PR TITLE
DATA: Add SkillConflict Model

### DIFF
--- a/Standard.Agents/Models/Foundations/Gates/SkillConflict.cs
+++ b/Standard.Agents/Models/Foundations/Gates/SkillConflict.cs
@@ -1,0 +1,8 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Foundations.Gates;
+
+public sealed record SkillConflict(IReadOnlyList<SkillDirective> Options);

--- a/Standard.Agents/Models/Foundations/Gates/SkillDirective.cs
+++ b/Standard.Agents/Models/Foundations/Gates/SkillDirective.cs
@@ -1,0 +1,8 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Foundations.Gates;
+
+public sealed record SkillDirective(string Skill, string Instruction);


### PR DESCRIPTION
First model for skill-conflict detection (v0.14.0): a SkillConflict holds the contradictory options the Gate found, each a SkillDirective (which skill said what). Used to phrase the AwaitingInput clarification question and to honor the user's choice on the follow-up turn.