### PR TITLE
FOUNDATIONS: Detect Skill Conflict

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.DetectConflict.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.DetectConflict.cs
@@ -1,0 +1,79 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Gates.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Gates;
+
+public partial class GateServiceTests
+{
+    [Fact]
+    public async Task ShouldDetectConflictAsync()
+    {
+        // given
+        string randomInstructions = CreateRandomString();
+        string randomVerdict = CreateRandomString();
+
+        this.classifierBrokerMock.Setup(broker =>
+            broker.AssessAsync(It.IsAny<string>(), randomInstructions))
+                .ReturnsAsync(randomVerdict);
+
+        // when
+        string actualVerdict =
+            await this.gateService.DetectConflictAsync(randomInstructions);
+
+        // then
+        actualVerdict.Should().BeEquivalentTo(randomVerdict);
+
+        this.classifierBrokerMock.Verify(broker =>
+            broker.AssessAsync(It.IsAny<string>(), randomInstructions),
+                Times.Once);
+
+        this.classifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ShouldThrowValidationExceptionOnDetectConflictIfInstructionsInvalidAndLogItAsync(
+        string invalidInstructions)
+    {
+        // given
+        var invalidGateException =
+            new InvalidGateException(
+                message: "Invalid gate input. Please correct the error and try again.");
+
+        var expectedGateValidationException =
+            new GateValidationException(
+                message: "Gate validation error occurred, fix the error and try again.",
+                innerException: invalidGateException);
+
+        // when
+        ValueTask<string> detectConflictTask =
+            this.gateService.DetectConflictAsync(invalidInstructions);
+
+        GateValidationException actualGateValidationException =
+            await Assert.ThrowsAsync<GateValidationException>(detectConflictTask.AsTask);
+
+        // then
+        actualGateValidationException.Should().BeEquivalentTo(expectedGateValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(expectedGateValidationException))),
+                Times.Once);
+
+        this.classifierBrokerMock.Verify(broker =>
+            broker.AssessAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        this.classifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/ClassifierBroker.cs
@@ -52,13 +52,16 @@ public sealed class ClassifierBroker : IClassifierBroker
         this.systemPrompt = systemPrompt;
     }
 
-    public async ValueTask<string> ClassifyAsync(string input)
+    public ValueTask<string> ClassifyAsync(string input) =>
+        AssessAsync(this.systemPrompt, input);
+
+    public async ValueTask<string> AssessAsync(string systemPrompt, string input)
     {
         ChatCompletionRequest chatCompletionRequest = new(
             Model: this.model,
             Messages:
             [
-                new ChatMessage(Role: "system", Content: this.systemPrompt),
+                new ChatMessage(Role: "system", Content: systemPrompt),
                 new ChatMessage(Role: "user", Content: input)
             ],
             Stream: false,

--- a/Standard.Agents/Brokers/Classifiers/FunctionClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/FunctionClassifierBroker.cs
@@ -18,6 +18,9 @@ public sealed class FunctionClassifierBroker : IClassifierBroker
         this.systemPrompt = systemPrompt;
     }
 
-    public async ValueTask<string> ClassifyAsync(string input) =>
-        await this.screen(this.systemPrompt, input);
+    public ValueTask<string> ClassifyAsync(string input) =>
+        AssessAsync(this.systemPrompt, input);
+
+    public async ValueTask<string> AssessAsync(string systemPrompt, string input) =>
+        await this.screen(systemPrompt, input);
 }

--- a/Standard.Agents/Brokers/Classifiers/IClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/IClassifierBroker.cs
@@ -8,4 +8,6 @@ namespace Standard.Agents.Brokers.Classifiers;
 public interface IClassifierBroker
 {
     ValueTask<string> ClassifyAsync(string input);
+
+    ValueTask<string> AssessAsync(string systemPrompt, string input);
 }

--- a/Standard.Agents/Brokers/Classifiers/NotConfiguredClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/NotConfiguredClassifierBroker.cs
@@ -8,7 +8,11 @@ namespace Standard.Agents.Brokers.Classifiers;
 public sealed class NotConfiguredClassifierBroker : IClassifierBroker
 {
     private const string Allow = "allow";
+    private const string NoConflict = "NONE";
 
     public async ValueTask<string> ClassifyAsync(string input) =>
         Allow;
+
+    public async ValueTask<string> AssessAsync(string systemPrompt, string input) =>
+        NoConflict;
 }

--- a/Standard.Agents/Services/Foundations/Gates/GateService.cs
+++ b/Standard.Agents/Services/Foundations/Gates/GateService.cs
@@ -28,4 +28,7 @@ public partial class GateService : IGateService
 
         return await this.classifierBroker.ClassifyAsync(input);
     });
+
+    public ValueTask<string> DetectConflictAsync(string instructions) =>
+        ValueTask.FromResult(string.Empty);
 }

--- a/Standard.Agents/Services/Foundations/Gates/GateService.cs
+++ b/Standard.Agents/Services/Foundations/Gates/GateService.cs
@@ -10,6 +10,13 @@ namespace Standard.Agents.Services.Foundations.Gates;
 
 public partial class GateService : IGateService
 {
+    private const string ConflictRubric =
+        "You review an AI agent's active skill instructions for a DIRECT CONTRADICTION — two " +
+        "instructions that cannot both be obeyed at once, for example 'answer in Arabic' versus " +
+        "'answer in English'. If such a contradiction exists, reply with a single line in the " +
+        "form: CONFLICT: <short label> | <instruction> || <short label> | <instruction>. If there " +
+        "is no contradiction, reply with a single word: NONE.";
+
     private readonly IClassifierBroker classifierBroker;
     private readonly ILoggingBroker loggingBroker;
 
@@ -30,5 +37,10 @@ public partial class GateService : IGateService
     });
 
     public ValueTask<string> DetectConflictAsync(string instructions) =>
-        ValueTask.FromResult(string.Empty);
+    TryCatch(async () =>
+    {
+        ValidateScreen(instructions);
+
+        return await this.classifierBroker.AssessAsync(ConflictRubric, instructions);
+    });
 }

--- a/Standard.Agents/Services/Foundations/Gates/IGateService.cs
+++ b/Standard.Agents/Services/Foundations/Gates/IGateService.cs
@@ -8,4 +8,6 @@ namespace Standard.Agents.Services.Foundations.Gates;
 public interface IGateService
 {
     ValueTask<string> ScreenAsync(string input);
+
+    ValueTask<string> DetectConflictAsync(string instructions);
 }


### PR DESCRIPTION
The Gate can now detect a direct contradiction across the agent's active skill instructions. DetectConflictAsync runs the guardian model against a conflict rubric (via the new classifier AssessAsync) and returns the verdict verbatim (CONFLICT: label | instruction || label | instruction, or NONE) for the orchestration to parse into a SkillConflict. Reuses the Screen exception/validation path.