### PR TITLE
ORCHESTRATIONS: Ask To Disambiguate On A Skill Conflict

### DIFF
--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -117,7 +117,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         .Tools(stubTools.Values)
         .LocalGate((rubric, prompt) =>
         {
-            gateRubric = rubric;
+            gateRubric ??= rubric;
 
             return new ValueTask<string>(vector.GateVerdict ?? "allow");
         })

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Conflict.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Conflict.Think.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldAwaitInputOnThinkIfSkillsConflictAsync()
+    {
+        // given
+        AgentContext inputContext =
+            CreateRandomAgentContext() with { SystemPrompt = CreateRandomString() };
+
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.gateServiceMock.Setup(service =>
+            service.DetectConflictAsync(inputContext.SystemPrompt))
+                .ReturnsAsync("CONFLICT: Arabic | answer in Arabic || English | answer in English");
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL: whatever");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("AwaitInput");
+        actualContext.Payload.Should().Contain("Arabic");
+        actualContext.Payload.Should().Contain("English");
+
+        this.brainServiceMock.Verify(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Logic.Act.cs
@@ -42,6 +42,35 @@ public partial class DirectionOrchestrationServiceTests
     }
 
     [Fact]
+    public async Task ShouldAwaitInputAndTerminateOnActIfDirectionTypeIsAwaitInputAsync()
+    {
+        // given
+        string question = CreateRandomString();
+
+        AgentContext inputContext =
+            CreateContextWithDirection("AwaitInput", question);
+
+        this.returnServiceMock.Setup(service =>
+            service.ReturnAsync(question))
+                .ReturnsAsync(question);
+
+        // when
+        AgentContext actualContext =
+            await this.directionOrchestrationService.ActAsync(inputContext);
+
+        // then
+        actualContext.Result.Should().Be(question);
+        actualContext.Status.Should().Be(AgentStatus.AwaitingInput);
+
+        this.returnServiceMock.Verify(service =>
+            service.ReturnAsync(question),
+                Times.Once);
+
+        this.internalToolServiceMock.VerifyNoOtherCalls();
+        this.externalToolServiceMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
     public async Task ShouldRefuseAndTerminateOnActIfDirectionTypeIsRefuseAsync()
     {
         // given

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -129,7 +129,9 @@ public partial class AgentCoordinationService : IAgentCoordinationService
                     $"{context.DirectionType}: {context.Result}");
             }
 
-            if (context.Status is AgentStatus.Responded or AgentStatus.Refused
+            if (context.Status is AgentStatus.Responded
+                or AgentStatus.Refused
+                or AgentStatus.AwaitingInput
                 && string.IsNullOrEmpty(context.Result) is false)
             {
                 yield return new AgentStreamEvent(

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Foundations.Gates;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Foundations.Brains;
 using Standard.Agents.Services.Foundations.Gates;
@@ -24,6 +25,10 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
     private const string RefuseDirection = "Refuse";
     private const string ReturnResponseDirection = "ReturnResponse";
     private const string RespondIntent = "Respond";
+    private const string AwaitInputDirection = "AwaitInput";
+    private const string ConflictPrefix = "CONFLICT:";
+    private const string ConflictOptionSeparator = "||";
+    private const string ConflictLabelSeparator = "|";
     private const string RefusalMessage = "I'm not able to help with that.";
 
     private const double MinimumAcceptableScore = 0.3;
@@ -62,6 +67,13 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
                 Payload = RefusalMessage,
                 RawReply = verdict
             };
+        }
+
+        AgentContext? clarification = await DetectSkillConflictAsync(context);
+
+        if (clarification is not null)
+        {
+            return clarification;
         }
 
         string reply =
@@ -133,6 +145,18 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
             yield return new AgentStreamEvent(
                 AgentStreamEventType.Status, "gate refused the request");
+
+            yield break;
+        }
+
+        AgentContext? clarification = await DetectSkillConflictAsync(context);
+
+        if (clarification is not null)
+        {
+            setResult(clarification);
+
+            yield return new AgentStreamEvent(
+                AgentStreamEventType.Status, "skills conflict; asking for clarification");
 
             yield break;
         }
@@ -210,6 +234,66 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
         segment.Type is AgentStreamEventType.Response
             ? segment with { Type = AgentStreamEventType.Thinking }
             : segment;
+
+    private async ValueTask<AgentContext?> DetectSkillConflictAsync(AgentContext context)
+    {
+        if (string.IsNullOrWhiteSpace(context.SystemPrompt))
+        {
+            return null;
+        }
+
+        string verdict = await this.gateService.DetectConflictAsync(context.SystemPrompt);
+        SkillConflict? conflict = ParseConflict(verdict);
+
+        if (conflict is null)
+        {
+            return null;
+        }
+
+        return context with
+        {
+            Intent = AwaitInputDirection,
+            DirectionType = AwaitInputDirection,
+            Payload = BuildClarificationQuestion(conflict),
+            RawReply = verdict
+        };
+    }
+
+    private static SkillConflict? ParseConflict(string verdict)
+    {
+        string trimmed = (verdict ?? string.Empty).Trim();
+
+        if (trimmed.StartsWith(ConflictPrefix, StringComparison.OrdinalIgnoreCase) is false)
+        {
+            return null;
+        }
+
+        List<SkillDirective> options = trimmed[ConflictPrefix.Length..]
+            .Split(
+                ConflictOptionSeparator,
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(ToDirective)
+            .ToList();
+
+        return options.Count >= 2 ? new SkillConflict(options) : null;
+    }
+
+    private static SkillDirective ToDirective(string option)
+    {
+        string[] parts = option.Split(
+            ConflictLabelSeparator, count: 2, StringSplitOptions.TrimEntries);
+
+        return parts.Length == 2
+            ? new SkillDirective(parts[0], parts[1])
+            : new SkillDirective(option, option);
+    }
+
+    private static string BuildClarificationQuestion(SkillConflict conflict)
+    {
+        string choices = string.Join(" or ", conflict.Options.Select(option => option.Skill));
+
+        return $"Your skills give conflicting instructions. Should I follow: {choices}?";
+    }
 
     private static bool IsRefusal(string verdict) =>
 verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase);

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -15,6 +15,7 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
 {
     private const string ReturnResponseDirection = "ReturnResponse";
     private const string RefuseDirection = "Refuse";
+    private const string AwaitInputDirection = "AwaitInput";
 
     private readonly IInternalToolService internalToolService;
     private readonly IExternalToolService externalToolService;
@@ -65,10 +66,21 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
 
     private static bool IsTerminal(string directionType) =>
         directionType.Equals(ReturnResponseDirection, StringComparison.OrdinalIgnoreCase)
-            || directionType.Equals(RefuseDirection, StringComparison.OrdinalIgnoreCase);
+            || directionType.Equals(RefuseDirection, StringComparison.OrdinalIgnoreCase)
+            || directionType.Equals(AwaitInputDirection, StringComparison.OrdinalIgnoreCase);
 
-    private static AgentStatus ToTerminalStatus(string directionType) =>
-        directionType.Equals(RefuseDirection, StringComparison.OrdinalIgnoreCase)
-            ? AgentStatus.Refused
-            : AgentStatus.Responded;
+    private static AgentStatus ToTerminalStatus(string directionType)
+    {
+        if (directionType.Equals(RefuseDirection, StringComparison.OrdinalIgnoreCase))
+        {
+            return AgentStatus.Refused;
+        }
+
+        if (directionType.Equals(AwaitInputDirection, StringComparison.OrdinalIgnoreCase))
+        {
+            return AgentStatus.AwaitingInput;
+        }
+
+        return AgentStatus.Responded;
+    }
 }


### PR DESCRIPTION
When the Gate detects a direct contradiction across the active skills, the Decision now stops before the brain and returns a clarifying question via a terminal AwaitInput direction (AgentStatus.AwaitingInput) instead of silently picking one skill. The Direction terminates AwaitInput to AwaitingInput; the coordinator surfaces the question on the Response channel. Honoring the user's answer (the round-trip) follows.