### PR TITLE
DATA: Add Remember To AgentContext Model

### DIFF
--- a/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
@@ -18,5 +18,6 @@ public sealed record AgentContext
     public string RawReply { get; init; } = "";
 
     public string Result { get; init; } = "";
+    public string Remember { get; init; } = "";
     public AgentStatus Status { get; init; }
 }


### PR DESCRIPTION
Adds a Remember field to AgentContext. The Decision sets it when a skill-conflict answer should be learned as a durable preference; the Coordinator flushes it to memory after the turn.