### PR TITLE
ORCHESTRATIONS: Remember Through Data

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Remember.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Remember.cs
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Data;
+
+public partial class DataOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldRememberAsync()
+    {
+        // given
+        string randomMemory = CreateRandomString();
+
+        // when
+        await this.dataOrchestrationService.RememberAsync(randomMemory);
+
+        // then
+        this.memoryServiceMock.Verify(service =>
+            service.RememberAsync(randomMemory),
+                Times.Once);
+
+        this.memoryServiceMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -52,4 +52,7 @@ public partial class DataOrchestrationService : IDataOrchestrationService
             Observations = [.. context.Observations, .. memories, .. knowledge]
         };
     });
+
+    public ValueTask RememberAsync(string memory) =>
+        ValueTask.CompletedTask;
 }

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -54,5 +54,5 @@ public partial class DataOrchestrationService : IDataOrchestrationService
     });
 
     public ValueTask RememberAsync(string memory) =>
-        ValueTask.CompletedTask;
+        this.memoryService.RememberAsync(memory);
 }

--- a/Standard.Agents/Services/Orchestrations/Data/IDataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/IDataOrchestrationService.cs
@@ -10,4 +10,6 @@ namespace Standard.Agents.Services.Orchestrations.Data;
 public interface IDataOrchestrationService
 {
     ValueTask<AgentContext> RecallAsync(AgentContext context);
+
+    ValueTask RememberAsync(string memory);
 }


### PR DESCRIPTION
Data orchestration gains a RememberAsync write path (delegates to the memory foundation) so the coordinator can persist a learned skill-conflict preference after a turn.