### PR TITLE
ORCHESTRATIONS: Learn And Apply A Skill-Conflict Preference

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
@@ -195,6 +195,35 @@ Times.Exactly(7));
     }
 
     [Fact]
+    public async Task ShouldRememberPreferenceOnProcessPromptWhenDecisionSetsRememberAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        string preference = CreateRandomString();
+
+        this.dataOrchestrationServiceMock.Setup(service =>
+            service.RecallAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) => context);
+
+        this.decisionOrchestrationServiceMock.Setup(service =>
+            service.ThinkAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) => context with { Remember = preference });
+
+        this.directionOrchestrationServiceMock.Setup(service =>
+            service.ActAsync(It.IsAny<AgentContext>()))
+                .ReturnsAsync((AgentContext context) =>
+                    context with { Result = "done", Status = AgentStatus.Responded });
+
+        // when
+        await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        this.dataOrchestrationServiceMock.Verify(service =>
+            service.RememberAsync(preference),
+                Times.Once);
+    }
+
+    [Fact]
     public async Task ShouldRecallEveryTurnOnProcessPromptAsync()
     {
         // given

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Conflict.Resolve.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Conflict.Resolve.cs
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldAutoResolveSkillConflictFromLearnedPreferenceOnThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext() with
+        {
+            SystemPrompt = CreateRandomString(),
+            Observations = ["SKILL_PREFERENCE::arabic|english::Arabic"]
+        };
+
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.gateServiceMock.Setup(service =>
+            service.DetectConflictAsync(It.IsAny<string>()))
+                .ReturnsAsync("CONFLICT: Arabic | answer in Arabic || English | answer in English");
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL: an answer");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("ReturnResponse");
+
+        this.brainServiceMock.Verify(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Once);
+    }
+
+    [Fact]
+    public async Task ShouldLearnPreferenceOnThinkIfPromptAnswersSkillConflictAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext() with
+        {
+            Prompt = "Arabic",
+            SystemPrompt = CreateRandomString()
+        };
+
+        SetupGateAllows();
+
+        this.gateServiceMock.Setup(service =>
+            service.DetectConflictAsync(It.IsAny<string>()))
+                .ReturnsAsync("CONFLICT: Arabic | answer in Arabic || English | answer in English");
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.DirectionType.Should().Be("ReturnResponse");
+        actualContext.Payload.Should().Contain("Arabic");
+        actualContext.Remember.Should().StartWith("SKILL_PREFERENCE::");
+        actualContext.Remember.Should().EndWith("Arabic");
+
+        this.brainServiceMock.Verify(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+    }
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -84,6 +84,11 @@ public partial class AgentCoordinationService : IAgentCoordinationService
             };
         }
 
+        if (string.IsNullOrEmpty(context.Remember) is false)
+        {
+            await this.dataOrchestrationService.RememberAsync(context.Remember);
+        }
+
         return context.Result;
     });
 
@@ -156,6 +161,11 @@ public partial class AgentCoordinationService : IAgentCoordinationService
             yield return new AgentStreamEvent(
                 AgentStreamEventType.Response,
                 RetriesExhaustedMessage);
+        }
+
+        if (string.IsNullOrEmpty(context.Remember) is false)
+        {
+            await this.dataOrchestrationService.RememberAsync(context.Remember);
         }
     }
 

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -29,6 +29,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
     private const string ConflictPrefix = "CONFLICT:";
     private const string ConflictOptionSeparator = "||";
     private const string ConflictLabelSeparator = "|";
+    private const string PreferencePrefix = "SKILL_PREFERENCE::";
     private const string RefusalMessage = "I'm not able to help with that.";
 
     private const double MinimumAcceptableScore = 0.3;
@@ -69,12 +70,15 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             };
         }
 
-        AgentContext? clarification = await DetectSkillConflictAsync(context);
+        (AgentContext resolvedContext, bool isTerminal) =
+            await ResolveSkillConflictAsync(context);
 
-        if (clarification is not null)
+        if (isTerminal)
         {
-            return clarification;
+            return resolvedContext;
         }
+
+        context = resolvedContext;
 
         string reply =
             (await this.brainService.GenerateAsync(
@@ -149,17 +153,23 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             yield break;
         }
 
-        AgentContext? clarification = await DetectSkillConflictAsync(context);
+        (AgentContext resolvedContext, bool isTerminal) =
+            await ResolveSkillConflictAsync(context);
 
-        if (clarification is not null)
+        if (isTerminal)
         {
-            setResult(clarification);
+            setResult(resolvedContext);
 
             yield return new AgentStreamEvent(
-                AgentStreamEventType.Status, "skills conflict; asking for clarification");
+                AgentStreamEventType.Status,
+                resolvedContext.DirectionType == AwaitInputDirection
+                    ? "skills conflict; asking for clarification"
+                    : "learned your skill preference");
 
             yield break;
         }
+
+        context = resolvedContext;
 
         var classifier = new ReplyStreamClassifier();
         var reply = new StringBuilder();
@@ -235,11 +245,12 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             ? segment with { Type = AgentStreamEventType.Thinking }
             : segment;
 
-    private async ValueTask<AgentContext?> DetectSkillConflictAsync(AgentContext context)
+    private async ValueTask<(AgentContext Context, bool IsTerminal)> ResolveSkillConflictAsync(
+        AgentContext context)
     {
         if (string.IsNullOrWhiteSpace(context.SystemPrompt))
         {
-            return null;
+            return (context, false);
         }
 
         string verdict = await this.gateService.DetectConflictAsync(context.SystemPrompt);
@@ -247,17 +258,74 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         if (conflict is null)
         {
-            return null;
+            return (context, false);
         }
 
-        return context with
+        string key = ConflictKey(conflict);
+        string? preferred = FindPreference(context.Observations, key);
+
+        if (preferred is not null)
+        {
+            AgentContext resolvedContext = context with
+            {
+                Observations =
+                [
+                    .. context.Observations,
+                    $"The user resolved a skill conflict in favor of '{preferred}'; "
+                        + "follow it and ignore the conflicting instruction."
+                ]
+            };
+
+            return (resolvedContext, false);
+        }
+
+        SkillDirective? chosen = MatchChoice(context.Prompt, conflict);
+
+        if (chosen is not null)
+        {
+            AgentContext learnedContext = context with
+            {
+                Intent = RespondIntent,
+                DirectionType = ReturnResponseDirection,
+                Payload = $"Understood — I'll follow '{chosen.Skill}' for that from now on.",
+                Remember = $"{PreferencePrefix}{key}::{chosen.Skill}",
+                RawReply = verdict
+            };
+
+            return (learnedContext, true);
+        }
+
+        AgentContext questionContext = context with
         {
             Intent = AwaitInputDirection,
             DirectionType = AwaitInputDirection,
             Payload = BuildClarificationQuestion(conflict),
             RawReply = verdict
         };
+
+        return (questionContext, true);
     }
+
+    private static string ConflictKey(SkillConflict conflict) =>
+        string.Join(
+            "|",
+            conflict.Options
+                .Select(option => option.Skill.Trim().ToLowerInvariant())
+                .OrderBy(label => label));
+
+    private static string? FindPreference(IReadOnlyList<string> observations, string key)
+    {
+        string prefix = $"{PreferencePrefix}{key}::";
+
+        string? record = observations.LastOrDefault(observation =>
+            observation.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+
+        return record?[prefix.Length..];
+    }
+
+    private static SkillDirective? MatchChoice(string prompt, SkillConflict conflict) =>
+        conflict.Options.FirstOrDefault(option =>
+            prompt.Contains(option.Skill, StringComparison.OrdinalIgnoreCase));
 
     private static SkillConflict? ParseConflict(string verdict)
     {


### PR DESCRIPTION
Honors the user's disambiguation (learn-the-preference design). On a detected conflict the Decision now: (1) auto-resolves silently when a matching SKILL_PREFERENCE is already in memory (adds a resolution note and proceeds to the brain); (2) learns the preference when the current prompt answers the conflict (confirms and flags AgentContext.Remember); (3) otherwise asks. The coordinator flushes context.Remember via Data.RememberAsync after the turn, so the choice persists and future identical conflicts resolve without asking.