### PR TITLE
BROKERS: Add Turn, Step And Process Trace Methods To Logging Broker

### DIFF
--- a/Standard.Agents/Brokers/Loggings/ILoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/ILoggingBroker.cs
@@ -3,6 +3,8 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using Standard.Agents.Models.Loggings;
+
 namespace Standard.Agents.Brokers.Loggings;
 
 public interface ILoggingBroker
@@ -18,4 +20,10 @@ public interface ILoggingBroker
     ValueTask LogErrorAsync(Exception exception);
 
     ValueTask LogCriticalAsync(Exception exception);
+
+    ValueTask LogTurnAsync(int turn);
+
+    ValueTask LogStepAsync(AgentStep step);
+
+    ValueTask LogProcessAsync(string actor, string message, bool detail = false);
 }

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -4,15 +4,23 @@
 // ---------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using Standard.Agents.Models.Loggings;
 
 namespace Standard.Agents.Brokers.Loggings;
 
 public sealed class LoggingBroker : ILoggingBroker
 {
     private readonly ILogger<LoggingBroker> logger;
+    private readonly TraceVerbosity verbosity;
+    private int processIndex;
 
-    public LoggingBroker(ILogger<LoggingBroker> logger) =>
+    public LoggingBroker(
+        ILogger<LoggingBroker> logger,
+        TraceVerbosity verbosity = TraceVerbosity.Full)
+    {
         this.logger = logger;
+        this.verbosity = verbosity;
+    }
 
     public async ValueTask LogInformationAsync(string message) =>
         this.logger.LogInformation(message);
@@ -31,4 +39,27 @@ public sealed class LoggingBroker : ILoggingBroker
 
     public async ValueTask LogCriticalAsync(Exception exception) =>
         this.logger.LogCritical(exception, exception.Message);
+
+    public async ValueTask LogTurnAsync(int turn) =>
+        this.logger.LogInformation($"{Environment.NewLine}Turn {turn}");
+
+    public async ValueTask LogStepAsync(AgentStep step)
+    {
+        this.processIndex = 0;
+
+        if (TraceVerbosity.Natures <= this.verbosity)
+        {
+            this.logger.LogInformation($"  Step {(int)step}: {step}");
+        }
+    }
+
+    public async ValueTask LogProcessAsync(string actor, string message, bool detail = false)
+    {
+        TraceVerbosity level = detail ? TraceVerbosity.Full : TraceVerbosity.Natures;
+
+        if (level <= this.verbosity)
+        {
+            this.logger.LogInformation($"    Process {this.processIndex++}: {actor}: {message}");
+        }
+    }
 }


### PR DESCRIPTION
Extends `ILoggingBroker` — the cross-cutting logging support broker already injected into every service — with the step-by-step trace vocabulary, rather than introducing a parallel broker:

- `LogTurnAsync(int turn)` — Summary tier, always emitted.
- `LogStepAsync(AgentStep step)` — Natures tier; resets the process counter.
- `LogProcessAsync(actor, message, detail)` — Natures tier for key lines, Full tier for `detail: true`.

Verbosity filtering and process numbering live in the broker per the maintainer's direction — this is intrinsic logging behaviour (equivalent to `ILogger` level filtering), not business logic. Rendering is positional indentation (Turn/Step/Process), so lower verbosities simply omit deeper lines. The `verbosity` constructor parameter defaults to `Full`, keeping the existing `new LoggingBroker(logger)` call compatible.

Category: BROKERS (support-broker capability). No unit tests — broker; behaviour is covered by the acceptance golden-trace test at the end of this series. Full suite green (247).