### PR TITLE
MINOR CLIENTS: Add Verbosity To LogTo And Wire Trace Sink

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -15,6 +15,7 @@ using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Clients.Agents.Exceptions;
+using Standard.Agents.Models.Loggings;
 using Xunit;
 
 namespace Standard.Agents.Tests.Unit.Clients;
@@ -109,6 +110,20 @@ public class StandardAgentTests
             .Knowledge(path: "Knowledge")
             .Mcp(endpointUrl: "https://mcp/")
             .LogTo(path: "log.txt");
+
+        // then
+        chained.Should().BeSameAs(agent);
+    }
+
+    [Fact]
+    public void ShouldChainLogToWithVerbosity()
+    {
+        // given
+        var agent = new StandardAgent();
+
+        // when
+        StandardAgent chained =
+            agent.LogTo(path: "log.txt", verbosity: TraceVerbosity.Natures);
 
         // then
         chained.Should().BeSameAs(agent);

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -17,6 +17,7 @@ using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Brokers.Tools;
 using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Loggings;
 using Standard.Agents.Prompts;
 using Standard.Agents.Services.Coordinations;
 using Standard.Agents.Services.Foundations.Brains;
@@ -43,6 +44,7 @@ public sealed partial class StandardAgent : IAgent
     private string constitutionPath = string.Empty;
     private string consumptionPath = string.Empty;
     private string logPath = "log.txt";
+    private TraceVerbosity traceVerbosity = TraceVerbosity.Full;
     private string memoryPath = "memory.txt";
     private int maxTurns = 7;
     private string knowledgePath = "Knowledge";
@@ -291,13 +293,22 @@ public sealed partial class StandardAgent : IAgent
         Set(() => this.tools.AddRange(tools));
 
     /// <summary>
-    /// Writes a turn-by-turn trace of the agent's run to a log file — useful for seeing which tools
-    /// were called and what the brain decided.
+    /// Writes a step-by-step trace of the agent's run to a log file, organised as
+    /// <c>Turn → Step → Process</c> (the Coordination → Orchestration → Foundation tiers).
     /// </summary>
     /// <param name="path">Path to the log file (created if it does not exist).</param>
+    /// <param name="verbosity">
+    /// How deep the trace goes: <see cref="TraceVerbosity.Summary"/> (Turn outcomes only),
+    /// <see cref="TraceVerbosity.Natures"/> (the three natures per Turn), or
+    /// <see cref="TraceVerbosity.Full"/> (every Process, the default).
+    /// </param>
     /// <returns>The same agent, so calls can be chained.</returns>
-    public StandardAgent LogTo(string path) =>
-        Set(() => this.logPath = path);
+    public StandardAgent LogTo(string path, TraceVerbosity verbosity = TraceVerbosity.Full) =>
+    Set(() =>
+    {
+        this.logPath = path;
+        this.traceVerbosity = verbosity;
+    });
 
     /// <summary>
     /// Caps how many Recall→Think→Act turns a single prompt may take before the agent stops —
@@ -474,7 +485,8 @@ public sealed partial class StandardAgent : IAgent
         IFileBroker file = new FileBroker();
 
         ILoggingBroker logging =
-            this.loggingBroker ?? new LoggingBroker(new NullLogger<LoggingBroker>());
+            this.loggingBroker ?? new LoggingBroker(
+                new NullLogger<LoggingBroker>(), this.traceVerbosity, this.logPath);
 
         IGeneratorBroker generator =
             this.generatorBroker ?? new GeneratorBroker(


### PR DESCRIPTION
Wires the step-by-step trace to `.LogTo` and lets the caller choose depth.

- `LogTo(path, TraceVerbosity verbosity = Full)` — new optional parameter; existing `.LogTo(path)` calls are unchanged.
- `Compose()` now builds the `LoggingBroker` with the chosen verbosity and the log path, so the trace lands in the `.LogTo` file.

Non-breaking. The coordination and orchestrations start emitting Turn/Step/Process into this sink in the following PRs. Category: MINOR CLIENTS (1 test). Suite green (248).