### PR TITLE
MINOR ORCHESTRATIONS: Narrate Data Recall Processes

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Trace.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Trace.Recall.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Data;
+
+public partial class DataOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldNarrateProcessesToLoggingBrokerOnRecallAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync())
+                .ReturnsAsync(CreateRandomString());
+
+        this.memoryServiceMock.Setup(service =>
+            service.RecallMemoriesAsync())
+                .ReturnsAsync([]);
+
+        // when
+        await this.dataOrchestrationService.RecallAsync(inputContext);
+
+        // then
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Data",
+                It.Is<string>(message => message.Contains("memories")),
+                It.IsAny<bool>()),
+                    Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Data",
+                It.Is<string>(message => message.Contains("knowledge")),
+                It.IsAny<bool>()),
+                    Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -46,6 +46,12 @@ public partial class DataOrchestrationService : IDataOrchestrationService
 
         string systemPrompt = skills.Replace(ToolsMarker, this.toolCatalog);
 
+        await this.loggingBroker.LogProcessAsync("Data", $"Received prompt: \"{context.Prompt}\"");
+        await this.loggingBroker.LogProcessAsync("Data", $"Retrieved skills ({skills.Length} chars)", detail: true);
+        await this.loggingBroker.LogProcessAsync("Data", $"Recalled {memories.Count} memories");
+        await this.loggingBroker.LogProcessAsync("Data", $"Retrieved {knowledge.Count} knowledge matches");
+        await this.loggingBroker.LogProcessAsync("Data", $"Assembled system prompt ({systemPrompt.Length} chars)", detail: true);
+
         return context with
         {
             SystemPrompt = systemPrompt,


### PR DESCRIPTION
The Data orchestration now narrates its Process lines under the `Step 0: Data` header — prompt received, skills retrieved, memories recalled, knowledge matched, system prompt assembled.

- Emitted through `ILoggingBroker.LogProcessAsync` after the foundation calls complete, so any dependency/validation exception skips narration (the exception tests' `VerifyNoOtherCalls` stay valid).
- Char-count lines are `detail: true` (Full only); counts are key lines (visible at Natures).

FAIL→PASS: `ShouldNarrateProcessesToLoggingBrokerOnRecallAsync`. Category: MINOR ORCHESTRATIONS. Suite green (249).