### PR TITLE
MINOR ORCHESTRATIONS: Narrate Decision Processes On Stream

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.ThinkStream.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.ThinkStream.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldNarrateProcessesToLoggingBrokerOnThinkStreamAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(ToAsyncStream("FINAL: 42"));
+
+        // when
+        IDecisionStream decisionStream =
+            this.decisionOrchestrationService.ThinkStreamAsync(inputContext);
+
+        await DrainAsync(decisionStream);
+
+        // then
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Decision",
+                It.Is<string>(message => message.Contains("Gate")),
+                It.IsAny<bool>()),
+                    Times.Once);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Decision",
+                It.Is<string>(message => message.Contains("Judge")),
+                It.IsAny<bool>()),
+                    Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -139,6 +139,8 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         if (IsRefusal(verdict))
         {
+            await this.loggingBroker.LogProcessAsync("Decision", "Gate → REFUSE");
+
             setResult(context with
             {
                 Intent = RefuseDirection,
@@ -152,6 +154,8 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
             yield break;
         }
+
+        await this.loggingBroker.LogProcessAsync("Decision", "Gate → PASS");
 
         (AgentContext resolvedContext, bool isTerminal) =
             await ResolveSkillConflictAsync(context);
@@ -196,6 +200,12 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         AgentContext decided = Interpret(context, reply.ToString().Trim());
 
+        await this.loggingBroker.LogProcessAsync(
+            "Decision", $"Brain → replied ({reply.Length} chars)", detail: true);
+
+        await this.loggingBroker.LogProcessAsync(
+            "Decision", $"Interpreted → {decided.DirectionType}");
+
         bool isFinalAnswer = decided.DirectionType.Equals(
             ReturnResponseDirection, StringComparison.OrdinalIgnoreCase);
 
@@ -217,6 +227,10 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
         }
 
         double score = await this.judgeService.EvaluateAsync(candidate: decided.Payload);
+
+        await this.loggingBroker.LogProcessAsync(
+            "Decision",
+            $"Judge → scored {score:F2} → {(score < MinimumAcceptableScore ? "REJECT" : "ACCEPT")}");
 
         if (score < MinimumAcceptableScore)
         {


### PR DESCRIPTION
The Decision orchestration narrates its Process lines under `Step 1: Decision` on the streaming path (`StreamThinkAsync`, the path `StreamPromptAsync` drives): Gate verdict (PASS/REFUSE), Brain reply, interpreted direction, Judge score (ACCEPT/REJECT).

- Emitted through `ILoggingBroker.LogProcessAsync` at each resolved point; the streaming path isn't covered by the `ThinkAsync` exception tests, and no stream test locks the logging broker, so no existing test changes.
- Brain char-count is `detail: true` (Full only); gate/judge/interpret are key lines (Natures).
- `ThinkAsync` (non-stream) parity is a deliberate follow-up — its exception tests `VerifyNoOtherCalls` on the logging broker, so narration there needs the return-point bundling pattern; kept out of this focused PR.

FAIL→PASS: `ShouldNarrateProcessesToLoggingBrokerOnThinkStreamAsync`. Category: MINOR ORCHESTRATIONS. Suite green (250).