### PR TITLE
MINOR ORCHESTRATIONS: Narrate Direction Processes On Act

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Trace.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Trace.Act.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+
+public partial class DirectionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldNarrateProcessesToLoggingBrokerOnActAsync()
+    {
+        // given
+        AgentContext inputContext = new()
+        {
+            Prompt = "prompt",
+            DirectionType = "calculator",
+            Payload = "1+1"
+        };
+
+        this.internalToolServiceMock.Setup(service =>
+            service.HandlesAsync("calculator"))
+                .ReturnsAsync(true);
+
+        this.internalToolServiceMock.Setup(service =>
+            service.RunAsync("calculator", "1+1"))
+                .ReturnsAsync("2");
+
+        // when
+        await this.directionOrchestrationService.ActAsync(inputContext);
+
+        // then
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Direction",
+                It.Is<string>(message => message.Contains("Tool") && message.Contains("2")),
+                It.IsAny<bool>()),
+                    Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -43,6 +43,9 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
         {
             string result = await this.returnService.ReturnAsync(context.Payload);
 
+            await this.loggingBroker.LogProcessAsync(
+                "Direction", $"{context.DirectionType} → returned ({result.Length} chars)");
+
             return context with
             {
                 Result = result,
@@ -55,6 +58,12 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
         string output = isLocalTool
 ? await this.internalToolService.RunAsync(context.DirectionType, context.Payload)
 : await this.externalToolService.CallAsync(context.DirectionType, context.Payload);
+
+        await this.loggingBroker.LogProcessAsync(
+            "Direction", $"Tool '{context.DirectionType}' ← {context.Payload}", detail: true);
+
+        await this.loggingBroker.LogProcessAsync(
+            "Direction", $"Tool '{context.DirectionType}' → {output}");
 
         return context with
         {


### PR DESCRIPTION
The Direction orchestration narrates its Process lines under `Step 2: Direction`: the terminal return (`ReturnResponse`/`Refuse` → returned) and tool execution (input → output).

- Emitted through `ILoggingBroker.LogProcessAsync` after the fallible call (`ReturnAsync`/`RunAsync`/`CallAsync`) succeeds, so any exception skips narration and the exception tests' `VerifyNoOtherCalls` stay valid.
- Tool input is `detail: true` (Full only); the tool output / return line is key (Natures).

FAIL→PASS: `ShouldNarrateProcessesToLoggingBrokerOnActAsync`. Category: MINOR ORCHESTRATIONS. Suite green (251).