### PR TITLE
MINOR ORCHESTRATIONS: Include Gate Verdict In Refusal Trace

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.Refuse.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.Refuse.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldNarrateGateRefusalReasonOnThinkStreamAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>()))
+                .ReturnsAsync("refuse: asks for personal information");
+
+        // when
+        IDecisionStream decisionStream =
+            this.decisionOrchestrationService.ThinkStreamAsync(inputContext);
+
+        await DrainAsync(decisionStream);
+
+        // then
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Decision",
+                It.Is<string>(message =>
+                    message.Contains("REFUSE")
+                        && message.Contains("personal information")),
+                It.IsAny<bool>()),
+                    Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -139,7 +139,8 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         if (IsRefusal(verdict))
         {
-            await this.loggingBroker.LogProcessAsync("Decision", "Gate → REFUSE");
+            await this.loggingBroker.LogProcessAsync(
+                "Decision", $"Gate → REFUSE: {verdict.ReplaceLineEndings(" ").Trim()}");
 
             setResult(context with
             {


### PR DESCRIPTION
When the Gate refuses, the trace now shows **why** — the gate's verdict is appended to the refuse line instead of being dropped:

```
Process 0: Decision: Gate → REFUSE: refuse: asks for personal information
```

The verdict is the classifier's output (`IsRefusal` matches a leading `refuse`), so the text after it carries the model's reasoning. Line endings are collapsed to keep it one Process line.

FAIL→PASS: `ShouldNarrateGateRefusalReasonOnThinkStreamAsync`. Category: MINOR ORCHESTRATIONS. Suite green (255).