### PR TITLE
MINOR ORCHESTRATIONS: Include Gate Verdict On Pass In Trace

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.GateVerdict.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.GateVerdict.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldNarrateGateVerdictOnPassOnThinkStreamAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupJudgeApproves();
+
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>()))
+                .ReturnsAsync("allow because the request is safe");
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(ToAsyncStream("FINAL: 42"));
+
+        // when
+        IDecisionStream decisionStream =
+            this.decisionOrchestrationService.ThinkStreamAsync(inputContext);
+
+        await DrainAsync(decisionStream);
+
+        // then
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Decision",
+                It.Is<string>(message =>
+                    message.Contains("PASS") && message.Contains("safe")),
+                It.IsAny<bool>()),
+                    Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -156,7 +156,8 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             yield break;
         }
 
-        await this.loggingBroker.LogProcessAsync("Decision", "Gate → PASS");
+        await this.loggingBroker.LogProcessAsync(
+            "Decision", $"Gate → PASS: {verdict.ReplaceLineEndings(" ").Trim()}");
 
         (AgentContext resolvedContext, bool isTerminal) =
             await ResolveSkillConflictAsync(context);


### PR DESCRIPTION
Symmetric guardian debuggability: the Gate's raw verdict is now shown on **pass** as well as refuse, so every gate decision reveals exactly what the model said.

```
Process 0: Decision: Gate → PASS: allow because the request is safe
...
Process 0: Decision: Gate → REFUSE: refuse: <the model's reason>
```

FAIL→PASS: `ShouldNarrateGateVerdictOnPassOnThinkStreamAsync`. Category: MINOR ORCHESTRATIONS. Suite green (256).