### PR TITLE
BROKERS: Indent Multi-Line Process Content In Logging Broker

### DIFF
--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -72,7 +72,9 @@ public sealed class LoggingBroker : ILoggingBroker
 
         if (level <= this.verbosity)
         {
-            await EmitAsync($"    Process {this.processIndex++}: {actor}: {message}");
+            string indented = message.ReplaceLineEndings($"{Environment.NewLine}      ");
+
+            await EmitAsync($"    Process {this.processIndex++}: {actor}: {indented}");
         }
     }
 


### PR DESCRIPTION
Prepares the trace to carry real payloads (system prompts, brain replies, tool IO) at Full: when a Process message spans multiple lines, continuation lines are indented under it so the block stays readable instead of breaking the Turn/Step/Process layout.

Single-line messages are unaffected. Category: BROKERS (no unit test; covered by the acceptance transcript). Suite green (256).