### PR TITLE
MINOR ORCHESTRATIONS: Show Full Brain Reply In Trace At Full

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.BrainReply.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.BrainReply.cs
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldNarrateBrainReplyContentOnThinkStreamAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(ToAsyncStream("FINAL: my-secret-answer"));
+
+        // when
+        IDecisionStream decisionStream =
+            this.decisionOrchestrationService.ThinkStreamAsync(inputContext);
+
+        await DrainAsync(decisionStream);
+
+        // then
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Decision",
+                It.Is<string>(message =>
+                    message.Contains("Brain") && message.Contains("my-secret-answer")),
+                It.IsAny<bool>()),
+                    Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -203,7 +203,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
         AgentContext decided = Interpret(context, reply.ToString().Trim());
 
         await this.loggingBroker.LogProcessAsync(
-            "Decision", $"Brain → replied ({reply.Length} chars)", detail: true);
+            "Decision", $"Brain replied →{Environment.NewLine}{reply.ToString().Trim()}", detail: true);
 
         await this.loggingBroker.LogProcessAsync(
             "Decision", $"Interpreted → {decided.DirectionType}");


### PR DESCRIPTION
Full now carries the Brain's **actual reply** — the reasoning behind the decision — instead of a char count. This is the 'why' for every turn: you see exactly what the model produced before it was interpreted.

```
Process 1: Decision: Brain replied →
      FINAL: My name is Michael.
```

Multi-line replies indent under the line (via the broker change). FAIL→PASS: `ShouldNarrateBrainReplyContentOnThinkStreamAsync`. Category: MINOR ORCHESTRATIONS. Suite green (257).