### PR TITLE
MINOR ORCHESTRATIONS: Show System Prompt Sent To Decision At Full

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Trace.SystemPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Trace.SystemPrompt.cs
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Data;
+
+public partial class DataOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldNarrateSystemPromptSentToDecisionOnRecallAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync())
+                .ReturnsAsync("SKILL-MARKER-XYZ");
+
+        this.memoryServiceMock.Setup(service =>
+            service.RecallMemoriesAsync())
+                .ReturnsAsync([]);
+
+        // when
+        await this.dataOrchestrationService.RecallAsync(inputContext);
+
+        // then
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Data",
+                It.Is<string>(message =>
+                    message.Contains("System prompt") && message.Contains("SKILL-MARKER-XYZ")),
+                It.IsAny<bool>()),
+                    Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -47,10 +47,10 @@ public partial class DataOrchestrationService : IDataOrchestrationService
         string systemPrompt = skills.Replace(ToolsMarker, this.toolCatalog);
 
         await this.loggingBroker.LogProcessAsync("Data", $"Received prompt: \"{context.Prompt}\"");
-        await this.loggingBroker.LogProcessAsync("Data", $"Retrieved skills ({skills.Length} chars)", detail: true);
         await this.loggingBroker.LogProcessAsync("Data", $"Recalled {memories.Count} memories");
         await this.loggingBroker.LogProcessAsync("Data", $"Retrieved {knowledge.Count} knowledge matches");
-        await this.loggingBroker.LogProcessAsync("Data", $"Assembled system prompt ({systemPrompt.Length} chars)", detail: true);
+        await this.loggingBroker.LogProcessAsync(
+            "Data", $"System prompt sent to Decision →{Environment.NewLine}{systemPrompt}", detail: true);
 
         return context with
         {


### PR DESCRIPTION
Full now shows the **actual system prompt Data hands to Decision** — what was sent from one layer to the next — instead of a char count. This is the assembled skills+tools payload the Brain reasons over.

Replaces the two char-count detail lines (skills, assembled prompt) with the content itself. Counts for memories/knowledge stay as key lines for Natures. FAIL→PASS: `ShouldNarrateSystemPromptSentToDecisionOnRecallAsync`. Category: MINOR ORCHESTRATIONS. Suite green (258).