### PR TITLE
MINOR ORCHESTRATIONS: Show Returned Result Content In Trace

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Trace.Return.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Trace.Return.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+
+public partial class DirectionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldNarrateReturnedResultContentOnActAsync()
+    {
+        // given
+        AgentContext inputContext = new()
+        {
+            Prompt = "prompt",
+            DirectionType = "ReturnResponse",
+            Payload = "RESULT-MARKER"
+        };
+
+        this.returnServiceMock.Setup(service =>
+            service.ReturnAsync("RESULT-MARKER"))
+                .ReturnsAsync("RESULT-MARKER");
+
+        // when
+        await this.directionOrchestrationService.ActAsync(inputContext);
+
+        // then
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Direction",
+                It.Is<string>(message =>
+                    message.Contains("returned") && message.Contains("RESULT-MARKER")),
+                It.IsAny<bool>()),
+                    Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -44,7 +44,7 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
             string result = await this.returnService.ReturnAsync(context.Payload);
 
             await this.loggingBroker.LogProcessAsync(
-                "Direction", $"{context.DirectionType} → returned ({result.Length} chars)");
+                "Direction", $"{context.DirectionType} → returned: {result}");
 
             return context with
             {


### PR DESCRIPTION
Full now shows the **actual returned answer** (`ReturnResponse`/`Refuse` → returned: <text>) instead of a char count. Together with the already-full tool call/response lines, the Direction step now shows exactly what it produced and what any tool returned.

FAIL→PASS: `ShouldNarrateReturnedResultContentOnActAsync`. Category: MINOR ORCHESTRATIONS. Suite green (259).