### PR TITLE
MINOR ORCHESTRATIONS: Recognize Gate Route And Narrate Three Outcomes

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.Route.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.Route.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using FluentAssertions;
 using Moq;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Orchestrations.Decision;
@@ -13,7 +14,7 @@ namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
 public partial class DecisionOrchestrationServiceTests
 {
     [Fact]
-    public async Task ShouldNarrateGateAcceptVerdictOnThinkStreamAsync()
+    public async Task ShouldNarrateGateRouteAndProceedOnThinkStreamAsync()
     {
         // given
         AgentContext inputContext = CreateRandomAgentContext();
@@ -21,7 +22,7 @@ public partial class DecisionOrchestrationServiceTests
 
         this.gateServiceMock.Setup(service =>
             service.ScreenAsync(It.IsAny<string>()))
-                .ReturnsAsync("allow because the request is safe");
+                .ReturnsAsync("route: arithmetic");
 
         this.brainServiceMock.Setup(service =>
             service.GenerateStreamAsync(
@@ -34,12 +35,14 @@ public partial class DecisionOrchestrationServiceTests
 
         await DrainAsync(decisionStream);
 
-        // then
+        // then a route proceeds to the Brain (not refused) and is narrated as ROUTE
+        decisionStream.Result.DirectionType.Should().Be("ReturnResponse");
+
         this.loggingBrokerMock.Verify(broker =>
             broker.LogProcessAsync(
                 "Decision",
                 It.Is<string>(message =>
-                    message.Contains("ACCEPT") && message.Contains("safe")),
+                    message.Contains("ROUTE") && message.Contains("arithmetic")),
                 It.IsAny<bool>()),
                     Times.Once);
     }

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -22,6 +22,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
     private const string ToolPrefix = "TOOL:";
     private const string FinalPrefix = "FINAL:";
     private const string RefuseVerdict = "refuse";
+    private const string RouteVerdict = "route";
     private const string RefuseDirection = "Refuse";
     private const string ReturnResponseDirection = "ReturnResponse";
     private const string RespondIntent = "Respond";
@@ -157,7 +158,10 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
         }
 
         await this.loggingBroker.LogProcessAsync(
-            "Decision", $"Gate → PASS: {verdict.ReplaceLineEndings(" ").Trim()}");
+            "Decision",
+            IsRoute(verdict)
+                ? $"Gate → ROUTE: {verdict.ReplaceLineEndings(" ").Trim()}"
+                : $"Gate → ACCEPT: {verdict.ReplaceLineEndings(" ").Trim()}");
 
         (AgentContext resolvedContext, bool isTerminal) =
             await ResolveSkillConflictAsync(context);
@@ -381,6 +385,9 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
     private static bool IsRefusal(string verdict) =>
 verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsRoute(string verdict) =>
+        verdict.TrimStart().StartsWith(RouteVerdict, StringComparison.OrdinalIgnoreCase);
 
     private static string BuildUserMessage(AgentContext context)
     {


### PR DESCRIPTION
The Decision orchestration now recognizes the Gate's three outcomes and narrates them faithfully:

- `refuse: …` → **REFUSE** (blocks — unchanged).
- `route: <label>` → **ROUTE** (proceeds to the Brain, tagged).
- anything else → **ACCEPT** (proceeds).

```
Process 0: Decision: Gate → ACCEPT: accept
Process 0: Decision: Gate → ROUTE: route: arithmetic
Process 0: Decision: Gate → REFUSE: refuse: <reason>
```

Only `refuse` blocks (as before); `route` and `accept` both flow through — so a routed input is no longer mislabeled as a plain pass. Renamed the former PASS narration to ACCEPT to match the doctrine (Gate = classifier of the INPUT). Route affecting downstream selection (actual routing) is a future step; today it classifies + proceeds.

FAIL→PASS: `ShouldNarrateGateRouteAndProceedOnThinkStreamAsync` (+ ACCEPT rename). Category: MINOR ORCHESTRATIONS. Suite green (260).