### PR TITLE
MINOR DATA: Add Route Label To AgentContext

### DIFF
--- a/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
@@ -13,6 +13,7 @@ public sealed record AgentContext
     public IReadOnlyList<string> Observations { get; init; } = [];
 
     public string Intent { get; init; } = "";
+    public string Route { get; init; } = "";
     public string DirectionType { get; init; } = "";
     public string Payload { get; init; } = "";
     public string RawReply { get; init; } = "";


### PR DESCRIPTION
The Gate's third outcome — `route in` — is a **classification label**, and per the doctrine (Invariant 1: every produced value is Data) that label lives in the context. Adds `Route` to `AgentContext`.

Settles `route in` as **A**: the Gate classifies (emits a label); it selects nothing and calls nothing. Acting on the label is a downstream nature's job (Data fan-in / Direction). This is the label's home; the Gate populates it next, a consumer reads it after.

Category: MINOR DATA (one property). Suite green.