### PR TITLE
MINOR ORCHESTRATIONS: Capture Gate Route Label As Data

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Route.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Route.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldCaptureGateRouteLabelAsDataOnThinkStreamAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupJudgeApproves();
+
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>()))
+                .ReturnsAsync("route: arithmetic");
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(ToAsyncStream("FINAL: 42"));
+
+        // when
+        IDecisionStream decisionStream =
+            this.decisionOrchestrationService.ThinkStreamAsync(inputContext);
+
+        await DrainAsync(decisionStream);
+
+        // then — the label rode through as Data on the resulting context
+        decisionStream.Result.Route.Should().Be("arithmetic");
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -163,6 +163,11 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
                 ? $"Gate → ROUTE: {verdict.ReplaceLineEndings(" ").Trim()}"
                 : $"Gate → ACCEPT: {verdict.ReplaceLineEndings(" ").Trim()}");
 
+        if (IsRoute(verdict))
+        {
+            context = context with { Route = ExtractRouteLabel(verdict) };
+        }
+
         (AgentContext resolvedContext, bool isTerminal) =
             await ResolveSkillConflictAsync(context);
 
@@ -388,6 +393,13 @@ verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase
 
     private static bool IsRoute(string verdict) =>
         verdict.TrimStart().StartsWith(RouteVerdict, StringComparison.OrdinalIgnoreCase);
+
+    private static string ExtractRouteLabel(string verdict)
+    {
+        string label = verdict.TrimStart()[RouteVerdict.Length..];
+
+        return label.TrimStart(':', ' ').ReplaceLineEndings(" ").Trim();
+    }
 
     private static string BuildUserMessage(AgentContext context)
     {


### PR DESCRIPTION
The Gate's `route: <label>` outcome now writes its label to `context.Route`, so the classification rides forward as Data (Invariant 1) for a downstream nature to act on. `accept`/`refuse` leave it empty. The Gate still only classifies — it selects no skills and calls nothing.

`ExtractRouteLabel` strips the `route:` prefix; the label flows through Interpret onto the decided context.

FAIL→PASS: `ShouldCaptureGateRouteLabelAsDataOnThinkStreamAsync`. Category: MINOR ORCHESTRATIONS. Suite green.