### PR TITLE
MINOR FOUNDATIONS: Route Skills By File On A Route Label

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.Logic.RouteByFile.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Skills/SkillServiceTests.Logic.RouteByFile.cs
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Services.Foundations.Skills;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Skills;
+
+public partial class SkillServiceTests
+{
+    [Fact]
+    public async Task ShouldRetrieveOnlyRoutedSkillFileWhenRouteIsGivenAsync()
+    {
+        // given
+        string skillsPath = CreateRandomString();
+        string calculatorPath = "calculator-skill.md";
+        string identityPath = "identity-skill.md";
+        List<string> filePaths = [identityPath, calculatorPath];
+
+        string calculatorSkill = CreateRandomString();
+        string identitySkill = CreateRandomString();
+
+        var fileSkillService = new SkillService(
+            fileBroker: this.fileBrokerMock.Object,
+            skillsPath: skillsPath,
+            loggingBroker: this.loggingBrokerMock.Object);
+
+        this.fileBrokerMock.Setup(broker =>
+            broker.DirectoryExists(skillsPath))
+                .Returns(true);
+
+        this.fileBrokerMock.Setup(broker =>
+            broker.SelectFiles(skillsPath, "*.md", SearchOption.TopDirectoryOnly))
+                .Returns(filePaths);
+
+        this.fileBrokerMock.Setup(broker =>
+            broker.ReadFileAsync(calculatorPath))
+                .ReturnsAsync(calculatorSkill);
+
+        this.fileBrokerMock.Setup(broker =>
+            broker.ReadFileAsync(identityPath))
+                .ReturnsAsync(identitySkill);
+
+        // when
+        string actualSkills = await fileSkillService.RetrieveSkillsAsync(route: "calculator");
+
+        // then — only the file whose name matches the route label is fanned in
+        actualSkills.Should().Be(calculatorSkill);
+
+        this.fileBrokerMock.Verify(broker =>
+            broker.ReadFileAsync(calculatorPath),
+                Times.Once);
+
+        this.fileBrokerMock.Verify(broker =>
+            broker.ReadFileAsync(identityPath),
+                Times.Never);
+    }
+}

--- a/Standard.Agents/Services/Foundations/Skills/ISkillService.cs
+++ b/Standard.Agents/Services/Foundations/Skills/ISkillService.cs
@@ -7,5 +7,5 @@ namespace Standard.Agents.Services.Foundations.Skills;
 
 public interface ISkillService
 {
-    ValueTask<string> RetrieveSkillsAsync();
+    ValueTask<string> RetrieveSkillsAsync(string route = "");
 }

--- a/Standard.Agents/Services/Foundations/Skills/SkillService.cs
+++ b/Standard.Agents/Services/Foundations/Skills/SkillService.cs
@@ -57,6 +57,19 @@ public partial class SkillService : ISkillService
             fileBroker.SelectFiles(this.skillsPath, SkillFilePattern, SearchOption.TopDirectoryOnly)
                 .OrderBy(skillFilePath => skillFilePath, StringComparer.Ordinal);
 
+        if (string.IsNullOrWhiteSpace(route) is false)
+        {
+            List<string> routedFilePaths = skillFilePaths
+                .Where(skillFilePath => Path.GetFileNameWithoutExtension(skillFilePath)
+                    .Contains(route, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+
+            if (routedFilePaths.Count > 0)
+            {
+                skillFilePaths = routedFilePaths;
+            }
+        }
+
         List<string> skills = [];
 
         foreach (string skillFilePath in skillFilePaths)

--- a/Standard.Agents/Services/Foundations/Skills/SkillService.cs
+++ b/Standard.Agents/Services/Foundations/Skills/SkillService.cs
@@ -38,22 +38,22 @@ public partial class SkillService : ISkillService
         this.loggingBroker = loggingBroker;
     }
 
-    public ValueTask<string> RetrieveSkillsAsync() =>
+    public ValueTask<string> RetrieveSkillsAsync(string route = "") =>
     TryCatch(async () =>
     {
         return this.fileBroker is not null
-            ? await SelectSkillsFromFilesAsync(this.fileBroker)
+            ? await SelectSkillsFromFilesAsync(this.fileBroker, route)
             : await this.skillBroker!.SelectSkillsAsync();
     });
 
-    private async ValueTask<string> SelectSkillsFromFilesAsync(IFileBroker fileBroker)
+    private async ValueTask<string> SelectSkillsFromFilesAsync(IFileBroker fileBroker, string route)
     {
         if (fileBroker.DirectoryExists(this.skillsPath) is false)
         {
             return string.Empty;
         }
 
-        IOrderedEnumerable<string> skillFilePaths =
+        IEnumerable<string> skillFilePaths =
             fileBroker.SelectFiles(this.skillsPath, SkillFilePattern, SearchOption.TopDirectoryOnly)
                 .OrderBy(skillFilePath => skillFilePath, StringComparer.Ordinal);
 


### PR DESCRIPTION
`SkillService.RetrieveSkillsAsync` takes an optional `route` label and, when given, fans in only the skill files whose filename matches it (by-file, per the settled design) — otherwise all skills, unchanged.

- Match is on `Path.GetFileNameWithoutExtension` (case-insensitive contains), so `route: calculator` selects `calculator-skill.md`.
- **Safety fallback:** if the label matches no file, all skills are returned rather than stranding the Brain with none.
- The custom `ISkillBroker` path returns all skills (routing is a file-based capability); `route` defaults to `""`, so every existing caller and test is unchanged.

This is the Data-side consumer of the Gate's route label. FAIL→PASS: `ShouldRetrieveOnlyRoutedSkillFileWhenRouteIsGivenAsync`. Category: MINOR FOUNDATIONS. Suite green.