### PR TITLE
MINOR ORCHESTRATIONS: Data Fans In Routed Skills On The Gate Label

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Route.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/DataOrchestrationServiceTests.Logic.Route.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Data;
+
+public partial class DataOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldFanInRoutedSkillsUsingContextRouteOnRecallAsync()
+    {
+        // given
+        string routeLabel = CreateRandomString();
+        AgentContext inputContext = CreateRandomAgentContext() with { Route = routeLabel };
+
+        this.skillServiceMock.Setup(service =>
+            service.RetrieveSkillsAsync(It.IsAny<string>()))
+                .ReturnsAsync(CreateRandomString());
+
+        this.memoryServiceMock.Setup(service =>
+            service.RecallMemoriesAsync())
+                .ReturnsAsync([]);
+
+        // when
+        await this.dataOrchestrationService.RecallAsync(inputContext);
+
+        // then — Data fans skills in on the Gate's route label (carried by the loop)
+        this.skillServiceMock.Verify(service =>
+            service.RetrieveSkillsAsync(routeLabel),
+                Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -40,7 +40,7 @@ public partial class DataOrchestrationService : IDataOrchestrationService
     {
         ValidateContext(context);
 
-        string skills = await this.skillService.RetrieveSkillsAsync();
+        string skills = await this.skillService.RetrieveSkillsAsync(context.Route);
         IReadOnlyList<string> memories = await this.memoryService.RecallMemoriesAsync();
         IReadOnlyList<string> knowledge = await this.knowledgeService.RetrieveKnowledgeAsync(context.Prompt);
 


### PR DESCRIPTION
Closes the loop on `route in` (A): Data now passes `context.Route` to `RetrieveSkillsAsync`, so it fans in only the routed skill file(s). The label is produced by the Gate in one turn's Decision and consumed by Data on the **next** recall — the loop is the coupling, exactly as the doctrine says. No route ⇒ all skills (unchanged).

End-to-end: **Gate classifies (emits label as Data) → Data routes skills on the label → Brain reasons over the minimal set.** Every nature does its one job; nothing crosses a boundary it shouldn't. The framework now reflects the settled doctrine for the Gate's third outcome.

FAIL→PASS: `ShouldFanInRoutedSkillsUsingContextRouteOnRecallAsync`. Category: MINOR ORCHESTRATIONS. Suite green.