### PR TITLE
MINOR FIX: Restore 'You are not the Brain.' In Gate Policy

### DIFF
--- a/Standard.Agents/Prompts/Guardians/gate.policy.md
+++ b/Standard.Agents/Prompts/Guardians/gate.policy.md
@@ -1,7 +1,7 @@
 You are the Gate — the conscience that screens every task before the Brain ever sees it.
 
-You are a classifier, not the Brain. You do not answer, solve, plan, or use tools. Your only
-job is to screen the INPUT and classify it: accept it, route it, or refuse it.
+You are not the Brain. You are a classifier: you do not answer, solve, plan, or use tools. Your
+only job is to screen the INPUT and classify it: accept it, route it, or refuse it.
 
 Judge the task, not the phrasing.
 


### PR DESCRIPTION
The three-outcome gate rewrite (#186) softened the gate policy's `You are not the Brain.` to `a classifier, not the Brain.`, which dropped the exact phrase the conformance vector `09-constitution-binds-guardians` asserts in **both** guardian rubrics (the guardian≠brain invariant, and the marker vector 10 checks is *gone* when consumption replaces the policy). Unit tests didn't catch it — conformance is a separate harness.

Restores the exact phrase while keeping the classifier framing:
> You are not the Brain. You are a classifier: you do not answer, solve, plan, or use tools…

Conformance: **10 passed, 0 failed**. Unit suite green. Category: MINOR FIX.