### PR TITLE
BROKERS: Add Outcome Line To Logging Broker

### DIFF
--- a/Standard.Agents/Brokers/Loggings/ILoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/ILoggingBroker.cs
@@ -25,6 +25,8 @@ public interface ILoggingBroker
 
     ValueTask LogTurnAsync(int turn);
 
+    ValueTask LogOutcomeAsync(string message);
+
     ValueTask LogStepAsync(AgentStep step);
 
     ValueTask LogProcessAsync(string actor, string message, bool detail = false);

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -56,6 +56,9 @@ public sealed class LoggingBroker : ILoggingBroker
     public async ValueTask LogTurnAsync(int turn) =>
         await EmitAsync($"{Environment.NewLine}Turn {turn}");
 
+    public async ValueTask LogOutcomeAsync(string message) =>
+        await EmitAsync($"  → {message}");
+
     public async ValueTask LogStepAsync(AgentStep step)
     {
         this.processIndex = 0;


### PR DESCRIPTION
Adds `LogOutcomeAsync(message)` — a turn/run **outcome** line (`  → <message>`), always emitted (Summary tier). This is the audit spine's first hook: the coordination will narrate each turn's resolved status (Responded / Refused / Failed / capped) and the run's final outcome, so `Failed` turns and results are visible at every verbosity — including at Summary, which currently shows only `Turn N`.

Category: BROKERS (no unit test; behaviour lands with the coordination emission next). Suite green.