### PR TITLE
MINOR COORDINATIONS: Narrate Turn And Run Outcomes

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Trace.Outcome.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Trace.Outcome.cs
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Coordinations;
+
+public partial class AgentCoordinationServiceTests
+{
+    [Fact]
+    public async Task ShouldNarrateRunOutcomeOnProcessPromptAsync()
+    {
+        // given
+        string randomPrompt = CreateRandomString();
+        SetupOrchestrationsPassThrough();
+        SetupDirectionTerminates(CreateRandomString());
+
+        // when
+        await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
+
+        // then
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogOutcomeAsync(It.Is<string>(message => message.Contains("done"))),
+                Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -62,11 +62,15 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
             if (context.Status is AgentStatus.Revising)
             {
+                await this.loggingBroker.LogOutcomeAsync($"turn {turn}: revising");
+
                 continue;
             }
 
             await this.loggingBroker.LogStepAsync(AgentStep.Direction);
             context = await this.directionOrchestrationService.ActAsync(context);
+
+            await this.loggingBroker.LogOutcomeAsync($"turn {turn}: {context.Status}");
 
             if (context.Status != AgentStatus.Working)
             {
@@ -82,6 +86,8 @@ public partial class AgentCoordinationService : IAgentCoordinationService
                 Status = AgentStatus.Refused
             };
         }
+
+        await this.loggingBroker.LogOutcomeAsync($"done: {context.Status}");
 
         if (string.IsNullOrEmpty(context.Remember) is false)
         {
@@ -123,11 +129,15 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
             if (context.Status is AgentStatus.Revising)
             {
+                await this.loggingBroker.LogOutcomeAsync($"turn {turn}: revising");
+
                 continue;
             }
 
             await this.loggingBroker.LogStepAsync(AgentStep.Direction);
             context = await this.directionOrchestrationService.ActAsync(context);
+
+            await this.loggingBroker.LogOutcomeAsync($"turn {turn}: {context.Status}");
 
             if (context.Status is AgentStatus.Working
                 && string.IsNullOrEmpty(context.Result) is false)
@@ -163,6 +173,8 @@ public partial class AgentCoordinationService : IAgentCoordinationService
                 AgentStreamEventType.Response,
                 RetriesExhaustedMessage);
         }
+
+        await this.loggingBroker.LogOutcomeAsync($"done: {context.Status}");
 
         if (string.IsNullOrEmpty(context.Remember) is false)
         {


### PR DESCRIPTION
Audit spine, step 1. The coordination now narrates each turn's resolved status and the run's final outcome, in both `ProcessPromptAsync` and `ProcessPromptStreamAsync`:

```
  → turn 0: Responded
  → done: Responded
```

- Per-turn: `turn N: <status>` (Responded / Refused / **Failed** / Working / revising).
- Run: `done: <status>` — includes the retries-exhausted → Refused rewrite and the max-turns cap.

This surfaces `Failed`/`Refused` outcomes (start of trace-on-failure) and fills the **Summary** tier, which previously showed only `Turn N`. FAIL→PASS: `ShouldNarrateRunOutcomeOnProcessPromptAsync`. Category: MINOR COORDINATIONS. 264 unit + 10/10 conformance green.