### PR TITLE
MEDIUM BROKERS: Narrate Errors To The Trace

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/TraceFailureTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/TraceFailureTests.cs
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.IO;
+using FluentAssertions;
+using Moq;
+using Standard.Agents;
+using Standard.Agents.Brokers.Classifiers;
+using Standard.Agents.Brokers.Generators;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Brokers.Verifiers;
+using Standard.Agents.Models.Loggings;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+public class TraceFailureTests
+{
+    [Fact]
+    public async Task ShouldWriteFailureToTranscriptWhenBrainThrowsAsync()
+    {
+        // given
+        string logPath = Path.GetTempFileName();
+
+        var generator = new Mock<IGeneratorBroker>();
+
+        generator.Setup(broker => broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new Exception("brain exploded"));
+
+        var skills = new Mock<ISkillBroker>();
+        skills.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync("Answer directly.");
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+        var knowledge = new Mock<IKnowledgeBroker>();
+        knowledge.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+        var gate = new Mock<IClassifierBroker>();
+        gate.Setup(broker => broker.ClassifyAsync(It.IsAny<string>())).ReturnsAsync("accept");
+
+        var agent = new StandardAgent()
+            .UseGenerator(generator.Object)
+            .UseSkills(skills.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(knowledge.Object)
+            .UseGate(gate.Object)
+            .UseMcp(new Mock<IMcpBroker>().Object)
+            .LogTo(logPath, TraceVerbosity.Full);
+
+        // when
+        try
+        {
+            await agent.ProcessPromptAsync("what is the answer?");
+        }
+        catch
+        {
+            // the failure is expected; we are asserting it was traced
+        }
+
+        string transcript = await File.ReadAllTextAsync(logPath);
+        File.Delete(logPath);
+
+        // then — a thrown failure must appear in the audit trace, not vanish
+        transcript.Should().Contain("ERROR");
+    }
+}

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -37,11 +37,19 @@ public sealed class LoggingBroker : ILoggingBroker
     public async ValueTask LogWarningAsync(string message) =>
         this.logger.LogWarning(message);
 
-    public async ValueTask LogErrorAsync(Exception exception) =>
+    public async ValueTask LogErrorAsync(Exception exception)
+    {
         this.logger.LogError(exception, exception.Message);
 
-    public async ValueTask LogCriticalAsync(Exception exception) =>
+        await EmitAsync($"  → ERROR: {exception.Message.ReplaceLineEndings(" ")}");
+    }
+
+    public async ValueTask LogCriticalAsync(Exception exception)
+    {
         this.logger.LogCritical(exception, exception.Message);
+
+        await EmitAsync($"  → CRITICAL: {exception.Message.ReplaceLineEndings(" ")}");
+    }
 
     public async ValueTask LogResetAsync()
     {


### PR DESCRIPTION
Audit spine, step 2 — **trace-on-failure**. The logging broker's `LogErrorAsync`/`LogCriticalAsync` now also write to the trace sink:

```
  → ERROR: Agent coordination dependency error occurred, contact support.
  → CRITICAL: Brain dependency error occurred, contact support.
```

Because every layer logs its categorised exception before rethrowing (the Standard exception model), a failure now appears in the audit trail **at every layer it propagated through, in both paths** (stream and non-stream) — uniformly, without wrapping iterators in try/catch. The trace no longer goes dark exactly when you need it.

FAIL→PASS (acceptance): `ShouldWriteFailureToTranscriptWhenBrainThrowsAsync` — a throwing brain now appears in the transcript. Category: MEDIUM BROKERS. Unit + conformance green.