### PR TITLE
BROKERS: Add Time Broker

### DIFF
--- a/Standard.Agents/Brokers/Times/ITimeBroker.cs
+++ b/Standard.Agents/Brokers/Times/ITimeBroker.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Times;
+
+public interface ITimeBroker
+{
+    DateTimeOffset GetCurrentDateTimeOffset();
+}

--- a/Standard.Agents/Brokers/Times/TimeBroker.cs
+++ b/Standard.Agents/Brokers/Times/TimeBroker.cs
@@ -1,0 +1,12 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Times;
+
+public sealed class TimeBroker : ITimeBroker
+{
+    public DateTimeOffset GetCurrentDateTimeOffset() =>
+        DateTimeOffset.UtcNow;
+}


### PR DESCRIPTION
A support broker for the current time — the clock source the audit spine needs for metrics. `ITimeBroker.GetCurrentDateTimeOffset()` (sync, like the FileBroker's `SelectFiles`/`DirectoryExists`), so timing is testable by mocking a controlled clock. The logging broker will use it to stamp elapsed on the trace's outcome lines next. Category: BROKERS (no unit test — support broker). Suite green.