### PR TITLE
MEDIUM BROKERS: Stamp Elapsed Time On Trace Outcomes

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/TraceMetricsTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/TraceMetricsTests.cs
@@ -1,0 +1,79 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.IO;
+using FluentAssertions;
+using Moq;
+using Standard.Agents;
+using Standard.Agents.Brokers.Classifiers;
+using Standard.Agents.Brokers.Generators;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Brokers.Verifiers;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Loggings;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+public class TraceMetricsTests
+{
+    private static async IAsyncEnumerable<string> ToStream(params string[] tokens)
+    {
+        foreach (string token in tokens)
+        {
+            await Task.CompletedTask;
+
+            yield return token;
+        }
+    }
+
+    [Fact]
+    public async Task ShouldStampElapsedOnRunOutcomeAsync()
+    {
+        // given
+        string logPath = Path.GetTempFileName();
+
+        var generator = new Mock<IGeneratorBroker>();
+
+        generator.Setup(broker => broker.GenerateStreamAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(ToStream("FINAL: 42"));
+
+        var skills = new Mock<ISkillBroker>();
+        skills.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync("Answer directly.");
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+        var knowledge = new Mock<IKnowledgeBroker>();
+        knowledge.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+        var gate = new Mock<IClassifierBroker>();
+        gate.Setup(broker => broker.ClassifyAsync(It.IsAny<string>())).ReturnsAsync("accept");
+        var judge = new Mock<IVerifierBroker>();
+        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>())).ReturnsAsync("1.0");
+
+        var agent = new StandardAgent()
+            .UseGenerator(generator.Object)
+            .UseSkills(skills.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(knowledge.Object)
+            .UseGate(gate.Object)
+            .UseJudge(judge.Object)
+            .UseMcp(new Mock<IMcpBroker>().Object)
+            .LogTo(logPath, TraceVerbosity.Full);
+
+        // when
+        await foreach (AgentStreamEvent _ in agent.StreamPromptAsync("what is the answer?"))
+        {
+        }
+
+        string transcript = await File.ReadAllTextAsync(logPath);
+        File.Delete(logPath);
+
+        // then — the run outcome carries an elapsed duration
+        transcript.Should().Contain("ms)");
+    }
+}

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
+using Standard.Agents.Brokers.Times;
 using Standard.Agents.Models.Loggings;
 
 namespace Standard.Agents.Brokers.Loggings;
@@ -11,16 +12,20 @@ namespace Standard.Agents.Brokers.Loggings;
 public sealed class LoggingBroker : ILoggingBroker
 {
     private readonly ILogger<LoggingBroker> logger;
+    private readonly ITimeBroker timeBroker;
     private readonly TraceVerbosity verbosity;
     private readonly string? logPath;
     private int processIndex;
+    private DateTimeOffset runStart;
 
     public LoggingBroker(
         ILogger<LoggingBroker> logger,
+        ITimeBroker timeBroker,
         TraceVerbosity verbosity = TraceVerbosity.Full,
         string? logPath = null)
     {
         this.logger = logger;
+        this.timeBroker = timeBroker;
         this.verbosity = verbosity;
         this.logPath = logPath is null ? null : Path.GetFullPath(logPath);
     }
@@ -54,6 +59,7 @@ public sealed class LoggingBroker : ILoggingBroker
     public async ValueTask LogResetAsync()
     {
         this.processIndex = 0;
+        this.runStart = this.timeBroker.GetCurrentDateTimeOffset();
 
         if (this.logPath is not null)
         {
@@ -64,8 +70,12 @@ public sealed class LoggingBroker : ILoggingBroker
     public async ValueTask LogTurnAsync(int turn) =>
         await EmitAsync($"{Environment.NewLine}Turn {turn}");
 
-    public async ValueTask LogOutcomeAsync(string message) =>
-        await EmitAsync($"  → {message}");
+    public async ValueTask LogOutcomeAsync(string message)
+    {
+        TimeSpan elapsed = this.timeBroker.GetCurrentDateTimeOffset() - this.runStart;
+
+        await EmitAsync($"  → {message} ({elapsed.TotalMilliseconds:F0}ms)");
+    }
 
     public async ValueTask LogStepAsync(AgentStep step)
     {

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -13,6 +13,7 @@ using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Brokers.Times;
 using Standard.Agents.Brokers.Tools;
 using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Models.Clients.Agents;
@@ -477,6 +478,7 @@ public sealed partial class StandardAgent : IAgent
         ILoggingBroker logging =
             this.loggingBroker ?? new LoggingBroker(
                 new NullLogger<LoggingBroker>(),
+                new TimeBroker(),
                 this.traceVerbosity,
                 string.IsNullOrEmpty(this.logPath) ? null : this.logPath);
 


### PR DESCRIPTION
Audit spine, step 3 — **metrics (timing)**. The logging broker stamps the run start on `LogResetAsync` (via the time broker) and appends elapsed to every outcome line:

```
  → turn 0: Responded (1210ms)
  → done: Responded (1240ms)
```

Cumulative-since-run-start, so you read the progression and the total at a glance. Uses `ITimeBroker` (mockable for deterministic timing tests). `Compose` wires `new TimeBroker()`; the concrete `LoggingBroker` gained a constructor arg (only construction site is `Compose`; the `ILoggingBroker` interface is unchanged, so mocks are unaffected).

Next: tokens/cost (needs a generator-broker usage hook) and the structured JSON/OTel sink. FAIL→PASS (acceptance): `ShouldStampElapsedOnRunOutcomeAsync`. Category: MEDIUM BROKERS. 266 unit + 10/10 conformance green.