### PR TITLE
MEDIUM BROKERS: Add Structured JSON Audit Sink

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/TraceAuditTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/TraceAuditTests.cs
@@ -1,0 +1,79 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.IO;
+using FluentAssertions;
+using Moq;
+using Standard.Agents;
+using Standard.Agents.Brokers.Classifiers;
+using Standard.Agents.Brokers.Generators;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Brokers.Verifiers;
+using Standard.Agents.Models.Clients.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+public class TraceAuditTests
+{
+    private static async IAsyncEnumerable<string> ToStream(params string[] tokens)
+    {
+        foreach (string token in tokens)
+        {
+            await Task.CompletedTask;
+
+            yield return token;
+        }
+    }
+
+    [Fact]
+    public async Task ShouldWriteStructuredJsonAuditRecordsAsync()
+    {
+        // given
+        string auditPath = Path.GetTempFileName();
+
+        var generator = new Mock<IGeneratorBroker>();
+        generator.Setup(broker => broker.GenerateStreamAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(ToStream("FINAL: 42"));
+
+        var skills = new Mock<ISkillBroker>();
+        skills.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync("Answer directly.");
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+        var knowledge = new Mock<IKnowledgeBroker>();
+        knowledge.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+        var gate = new Mock<IClassifierBroker>();
+        gate.Setup(broker => broker.ClassifyAsync(It.IsAny<string>())).ReturnsAsync("accept");
+        var judge = new Mock<IVerifierBroker>();
+        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>())).ReturnsAsync("1.0");
+
+        var agent = new StandardAgent()
+            .UseGenerator(generator.Object)
+            .UseSkills(skills.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(knowledge.Object)
+            .UseGate(gate.Object)
+            .UseJudge(judge.Object)
+            .UseMcp(new Mock<IMcpBroker>().Object)
+            .Audit(auditPath);
+
+        // when
+        await foreach (AgentStreamEvent _ in agent.StreamPromptAsync("what is the answer?"))
+        {
+        }
+
+        string audit = await File.ReadAllTextAsync(auditPath);
+        File.Delete(auditPath);
+
+        // then — one JSON object per trace event, machine-ingestible
+        audit.Should().Contain("\"kind\":\"turn\"");
+        audit.Should().Contain("\"kind\":\"process\"");
+        audit.Should().Contain("\"kind\":\"outcome\"");
+    }
+}

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -15,6 +15,7 @@ public sealed class LoggingBroker : ILoggingBroker
     private readonly ITimeBroker timeBroker;
     private readonly TraceVerbosity verbosity;
     private readonly string? logPath;
+    private readonly string? auditPath;
     private int processIndex;
     private DateTimeOffset runStart;
 
@@ -22,12 +23,14 @@ public sealed class LoggingBroker : ILoggingBroker
         ILogger<LoggingBroker> logger,
         ITimeBroker timeBroker,
         TraceVerbosity verbosity = TraceVerbosity.Full,
-        string? logPath = null)
+        string? logPath = null,
+        string? auditPath = null)
     {
         this.logger = logger;
         this.timeBroker = timeBroker;
         this.verbosity = verbosity;
         this.logPath = logPath is null ? null : Path.GetFullPath(logPath);
+        this.auditPath = auditPath is null ? null : Path.GetFullPath(auditPath);
     }
 
     public async ValueTask LogInformationAsync(string message) =>

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Standard.Agents.Brokers.Times;
 using Standard.Agents.Models.Loggings;
@@ -49,6 +50,7 @@ public sealed class LoggingBroker : ILoggingBroker
     {
         this.logger.LogError(exception, exception.Message);
 
+        await AuditAsync(new { kind = "error", message = exception.Message });
         await EmitAsync($"  → ERROR: {exception.Message.ReplaceLineEndings(" ")}");
     }
 
@@ -56,6 +58,7 @@ public sealed class LoggingBroker : ILoggingBroker
     {
         this.logger.LogCritical(exception, exception.Message);
 
+        await AuditAsync(new { kind = "critical", message = exception.Message });
         await EmitAsync($"  → CRITICAL: {exception.Message.ReplaceLineEndings(" ")}");
     }
 
@@ -68,14 +71,25 @@ public sealed class LoggingBroker : ILoggingBroker
         {
             await File.WriteAllTextAsync(this.logPath, string.Empty);
         }
+
+        if (this.auditPath is not null)
+        {
+            await File.WriteAllTextAsync(this.auditPath, string.Empty);
+        }
     }
 
-    public async ValueTask LogTurnAsync(int turn) =>
+    public async ValueTask LogTurnAsync(int turn)
+    {
+        await AuditAsync(new { kind = "turn", turn });
+
         await EmitAsync($"{Environment.NewLine}Turn {turn}");
+    }
 
     public async ValueTask LogOutcomeAsync(string message)
     {
         TimeSpan elapsed = this.timeBroker.GetCurrentDateTimeOffset() - this.runStart;
+
+        await AuditAsync(new { kind = "outcome", message, elapsedMs = elapsed.TotalMilliseconds });
 
         await EmitAsync($"  → {message} ({elapsed.TotalMilliseconds:F0}ms)");
     }
@@ -83,6 +97,8 @@ public sealed class LoggingBroker : ILoggingBroker
     public async ValueTask LogStepAsync(AgentStep step)
     {
         this.processIndex = 0;
+
+        await AuditAsync(new { kind = "step", step = step.ToString() });
 
         if (TraceVerbosity.Natures <= this.verbosity)
         {
@@ -92,6 +108,8 @@ public sealed class LoggingBroker : ILoggingBroker
 
     public async ValueTask LogProcessAsync(string actor, string message, bool detail = false)
     {
+        await AuditAsync(new { kind = "process", actor, message, detail });
+
         TraceVerbosity level = detail ? TraceVerbosity.Full : TraceVerbosity.Natures;
 
         if (level <= this.verbosity)
@@ -111,6 +129,15 @@ public sealed class LoggingBroker : ILoggingBroker
         else
         {
             await File.AppendAllTextAsync(this.logPath, line + Environment.NewLine);
+        }
+    }
+
+    private async ValueTask AuditAsync(object record)
+    {
+        if (this.auditPath is not null)
+        {
+            await File.AppendAllTextAsync(
+                this.auditPath, JsonSerializer.Serialize(record) + Environment.NewLine);
         }
     }
 }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -44,6 +44,7 @@ public sealed partial class StandardAgent : IAgent
     private string constitutionPath = string.Empty;
     private string consumptionPath = string.Empty;
     private string logPath = string.Empty;
+    private string auditPath = string.Empty;
     private TraceVerbosity traceVerbosity = TraceVerbosity.Full;
     private string memoryPath = "memory.txt";
     private int maxTurns = 7;
@@ -310,6 +311,17 @@ public sealed partial class StandardAgent : IAgent
     });
 
     /// <summary>
+    /// Writes a structured, machine-readable audit log — one JSON object per trace event
+    /// (turn, step, process, outcome, error) — to <paramref name="path"/>, alongside any
+    /// human-readable <see cref="LogTo"/> trace. Always full detail, for ingestion into a SIEM
+    /// or telemetry pipeline.
+    /// </summary>
+    /// <param name="path">Path to the JSON-lines audit file (created if it does not exist).</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Audit(string path) =>
+        Set(() => this.auditPath = path);
+
+    /// <summary>
     /// Caps how many Recall→Think→Act turns a single prompt may take before the agent stops —
     /// the shared budget across tool calls and Judge revisions. Defaults to 7. A value below 1
     /// is treated as 1.
@@ -480,7 +492,8 @@ public sealed partial class StandardAgent : IAgent
                 new NullLogger<LoggingBroker>(),
                 new TimeBroker(),
                 this.traceVerbosity,
-                string.IsNullOrEmpty(this.logPath) ? null : this.logPath);
+                string.IsNullOrEmpty(this.logPath) ? null : this.logPath,
+                string.IsNullOrEmpty(this.auditPath) ? null : this.auditPath);
 
         IGeneratorBroker generator =
             this.generatorBroker ?? new GeneratorBroker(


### PR DESCRIPTION
Audit spine, step 4 — the trace becomes **machine-ingestible**. `.Audit(path)` writes one JSON object per trace event (JSON-lines) alongside the human-readable `.LogTo` text:

```json
{"kind":"turn","turn":0}
{"kind":"step","step":"Decision"}
{"kind":"process","actor":"Decision","message":"Gate → ACCEPT: accept","detail":false}
{"kind":"outcome","message":"done: Responded","elapsedMs":1240}
{"kind":"error","message":"..."}
```

- **Always full detail** (audit is complete, independent of the text verbosity), truncated per run.
- Core stays **dependency-free** — `System.Text.Json` is in the BCL. A true OpenTelemetry exporter is a natural next adapter (a sink that maps these events to OTel spans), keeping the core clean.

That's the audit spine's structured finale. FAIL→PASS (acceptance): `ShouldWriteStructuredJsonAuditRecordsAsync`. Category: MEDIUM BROKERS. 267 unit + 10/10 conformance green.