### PR TITLE
MINOR ORCHESTRATIONS: Narrate Estimated Tokens On The Brain Exchange

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.Tokens.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Trace.Tokens.cs
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldNarrateEstimatedTokensOnThinkStreamAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(ToAsyncStream("FINAL: 42"));
+
+        // when
+        IDecisionStream decisionStream =
+            this.decisionOrchestrationService.ThinkStreamAsync(inputContext);
+
+        await DrainAsync(decisionStream);
+
+        // then — a cost signal is recorded for the brain exchange
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Decision",
+                It.Is<string>(message =>
+                    message.Contains("tokens") && message.Contains("estimated")),
+                It.IsAny<bool>()),
+                    Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -188,10 +188,11 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         var classifier = new ReplyStreamClassifier();
         var reply = new StringBuilder();
+        string userMessage = BuildUserMessage(context);
 
         IAsyncEnumerable<string> tokens = this.brainService.GenerateStreamAsync(
             systemPrompt: context.SystemPrompt,
-            userPrompt: BuildUserMessage(context),
+            userPrompt: userMessage,
             cancellationToken: cancellationToken);
 
         await foreach (string delta in tokens.WithCancellation(cancellationToken))
@@ -213,6 +214,14 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         await this.loggingBroker.LogProcessAsync(
             "Decision", $"Brain replied →{Environment.NewLine}{reply.ToString().Trim()}", detail: true);
+
+        int estimatedTokens =
+            (context.SystemPrompt.Length + userMessage.Length + reply.Length) / 4;
+
+        await this.loggingBroker.LogProcessAsync(
+            "Decision",
+            $"Brain → ~{estimatedTokens} tokens (prompt + reply, estimated)",
+            detail: true);
 
         await this.loggingBroker.LogProcessAsync(
             "Decision", $"Interpreted → {decided.DirectionType}");


### PR DESCRIPTION
Audit spine — the **cost signal**. Every decision now records an estimated token count for the brain exchange (system prompt + user message + reply), narrated as a Full/audit process line:

```
Process 3: Decision: Brain → ~1180 tokens (prompt + reply, estimated)
```

It flows into the structured `.Audit(...)` JSON like any other process event, so cost is now **telemetered per turn** — the last open metric on the spine.

**Honest by design:** labeled *estimated* (chars ÷ 4, a stable proxy). The accurate count belongs to the model's own tokenizer — a clean follow-on: `IGeneratorBroker` grows an optional `CountTokensAsync` with this estimate as the **default**, and the LlamaSharp / hosted adapters override it with real counts. Non-breaking seam, working default now, accuracy when an adapter opts in — the collapsible-substrate rule exactly.

FAIL→PASS: `ShouldNarrateEstimatedTokensOnThinkStreamAsync`. Category: MINOR ORCHESTRATIONS. 268 unit + 10/10 conformance green.