### PR TITLE
MEDIUM FOUNDATIONS: Judge Returns A Judgement (Score And Reason)

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Logic.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Logic.Evaluate.cs
@@ -6,6 +6,7 @@
 using System.Globalization;
 using FluentAssertions;
 using Moq;
+using Standard.Agents.Models.Foundations.Judges;
 using Xunit;
 
 namespace Standard.Agents.Tests.Unit.Services.Foundations.Judges;
@@ -28,11 +29,11 @@ public partial class JudgeServiceTests
                 .ReturnsAsync(verdict);
 
         // when
-        double actualScore =
+        Judgement actualJudgement =
             await this.judgeService.EvaluateAsync(randomCandidate);
 
         // then
-        actualScore.Should().Be(expectedScore);
+        actualJudgement.Score.Should().Be(expectedScore);
 
         this.verifierBrokerMock.Verify(broker =>
             broker.VerifyAsync(randomCandidate),
@@ -57,11 +58,38 @@ public partial class JudgeServiceTests
                 .ReturnsAsync(verdict);
 
         // when
-        double actualScore =
+        Judgement actualJudgement =
             await this.judgeService.EvaluateAsync(randomCandidate);
 
         // then
-        actualScore.Should().Be(expectedScore);
+        actualJudgement.Score.Should().Be(expectedScore);
+
+        this.verifierBrokerMock.Verify(broker =>
+            broker.VerifyAsync(randomCandidate),
+                Times.Once);
+
+        this.verifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldParseScoreAndReasonOnEvaluateAsync()
+    {
+        // given
+        string randomCandidate = CreateRandomString();
+        string verdict = "SCORE: 0.4\nREASON: it never states the year";
+
+        this.verifierBrokerMock.Setup(broker =>
+            broker.VerifyAsync(randomCandidate))
+                .ReturnsAsync(verdict);
+
+        // when
+        Judgement actualJudgement =
+            await this.judgeService.EvaluateAsync(randomCandidate);
+
+        // then
+        actualJudgement.Score.Should().Be(0.4);
+        actualJudgement.Reason.Should().Be("it never states the year");
 
         this.verifierBrokerMock.Verify(broker =>
             broker.VerifyAsync(randomCandidate),

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Validations.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Validations.Evaluate.cs
@@ -6,6 +6,7 @@
 using System.Globalization;
 using FluentAssertions;
 using Moq;
+using Standard.Agents.Models.Foundations.Judges;
 using Standard.Agents.Models.Foundations.Judges.Exceptions;
 using Xunit;
 
@@ -31,7 +32,7 @@ public partial class JudgeServiceTests
                 innerException: invalidJudgeException);
 
         // when
-        ValueTask<double> evaluateTask =
+        ValueTask<Judgement> evaluateTask =
             this.judgeService.EvaluateAsync(invalidCandidate!);
 
         JudgeValidationException actualJudgeValidationException =
@@ -82,7 +83,7 @@ public partial class JudgeServiceTests
                 .ReturnsAsync(nonNumericVerdict!);
 
         // when
-        ValueTask<double> evaluateTask =
+        ValueTask<Judgement> evaluateTask =
             this.judgeService.EvaluateAsync(randomCandidate);
 
         JudgeValidationException actualJudgeValidationException =
@@ -132,7 +133,7 @@ public partial class JudgeServiceTests
                 .ReturnsAsync(verdict);
 
         // when
-        ValueTask<double> evaluateTask =
+        ValueTask<Judgement> evaluateTask =
             this.judgeService.EvaluateAsync(randomCandidate);
 
         JudgeValidationException actualJudgeValidationException =

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
@@ -5,6 +5,7 @@
 
 using FluentAssertions;
 using Moq;
+using Standard.Agents.Models.Foundations.Judges;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Xunit;
 
@@ -93,7 +94,7 @@ public partial class DecisionOrchestrationServiceTests
 
         this.judgeServiceMock.Setup(service =>
             service.EvaluateAsync(It.IsAny<string>()))
-                .ReturnsAsync(0.1);
+                .ReturnsAsync(new Judgement { Score = 0.1 });
 
         // when
         AgentContext actualContext =
@@ -117,7 +118,7 @@ public partial class DecisionOrchestrationServiceTests
 
         this.judgeServiceMock.Setup(service =>
             service.EvaluateAsync(It.IsAny<string>()))
-                .ReturnsAsync(0.1);
+                .ReturnsAsync(new Judgement { Score = 0.1 });
 
         // when
         AgentContext actualContext =

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
@@ -6,6 +6,7 @@
 using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Foundations.Judges;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Foundations.Brains;
 using Standard.Agents.Services.Foundations.Gates;
@@ -57,7 +58,7 @@ public partial class DecisionOrchestrationServiceTests
     private void SetupJudgeApproves() =>
         this.judgeServiceMock.Setup(service =>
             service.EvaluateAsync(It.IsAny<string>()))
-                .ReturnsAsync(1.0);
+                .ReturnsAsync(new Judgement { Score = 1.0 });
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);

--- a/Standard.Agents/Models/Foundations/Judges/Judgement.cs
+++ b/Standard.Agents/Models/Foundations/Judges/Judgement.cs
@@ -3,11 +3,10 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
-using Standard.Agents.Models.Foundations.Judges;
+namespace Standard.Agents.Models.Foundations.Judges;
 
-namespace Standard.Agents.Services.Foundations.Judges;
-
-public interface IJudgeService
+public record Judgement
 {
-    ValueTask<Judgement> EvaluateAsync(string candidate);
+    public double Score { get; init; }
+    public string Reason { get; init; } = string.Empty;
 }

--- a/Standard.Agents/Prompts/Guardians/judge.contract.md
+++ b/Standard.Agents/Prompts/Guardians/judge.contract.md
@@ -1,2 +1,6 @@
-Reply with exactly one decimal number between 0.0 and 1.0 and nothing else — no words, no
-punctuation, no explanation. Just the number.
+Reply with exactly two lines and nothing else:
+
+SCORE: a single decimal number between 0.0 and 1.0
+REASON: one short sentence naming what is missing or wrong — or the word ok if the answer is good
+
+Nothing before or after these two lines.

--- a/Standard.Agents/Prompts/Guardians/judge.policy.md
+++ b/Standard.Agents/Prompts/Guardians/judge.policy.md
@@ -1,6 +1,7 @@
 You are the Judge — the conscience that reviews the Brain's answer before it is returned.
 
 You are not the Brain. You do not rewrite, improve, or continue the answer. Your only job is
-to score how well the candidate answer addresses the task it was given.
+to score how well the candidate answer addresses the task it was given, and to say briefly why.
 
-Consider correctness, completeness, and relevance. A confident but wrong answer scores low.
+Consider correctness, completeness, and relevance. A confident but wrong answer scores low. When
+you score below a passing mark, your reason must name the specific gap so the answer can be fixed.

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.Exceptions.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using RESTFulSense.Exceptions;
+using Standard.Agents.Models.Foundations.Judges;
 using Standard.Agents.Models.Foundations.Judges.Exceptions;
 using Xeptions;
 
@@ -11,13 +12,13 @@ namespace Standard.Agents.Services.Foundations.Judges;
 
 public partial class JudgeService
 {
-    private delegate ValueTask<double> ReturningScoreFunction();
+    private delegate ValueTask<Judgement> ReturningJudgementFunction();
 
-    private async ValueTask<double> TryCatch(ReturningScoreFunction returningScoreFunction)
+    private async ValueTask<Judgement> TryCatch(ReturningJudgementFunction returningJudgementFunction)
     {
         try
         {
-            return await returningScoreFunction();
+            return await returningJudgementFunction();
         }
         catch (InvalidJudgeException invalidJudgeException)
         {

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.Validations.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using System.Globalization;
+using Standard.Agents.Models.Foundations.Judges;
 using Standard.Agents.Models.Foundations.Judges.Exceptions;
 
 namespace Standard.Agents.Services.Foundations.Judges;
@@ -12,6 +13,8 @@ public partial class JudgeService
 {
     private const double MinimumScore = 0.0;
     private const double MaximumScore = 1.0;
+    private const string ScoreLabel = "SCORE:";
+    private const string ReasonLabel = "REASON:";
 
     private static void ValidateEvaluate(string candidate)
     {
@@ -22,10 +25,19 @@ public partial class JudgeService
         }
     }
 
-    private static double ParseScore(string verdict)
+    private static Judgement ParseJudgement(string verdict)
     {
+        string text = verdict?.Trim() ?? string.Empty;
+
+        string? labeledScore = ExtractLabeled(text, ScoreLabel);
+
+        string scoreText = labeledScore is null
+            ? text
+            : labeledScore.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .FirstOrDefault() ?? labeledScore;
+
         bool isNumeric = double.TryParse(
-            verdict?.Trim(),
+            scoreText,
             NumberStyles.Float,
             CultureInfo.InvariantCulture,
             out double score);
@@ -36,7 +48,22 @@ public partial class JudgeService
                 message: "Invalid judge score. Score must be a number between 0.0 and 1.0.");
         }
 
-        return score;
+        return new Judgement { Score = score };
+    }
+
+    private static string? ExtractLabeled(string text, string label)
+    {
+        foreach (string line in text.Split('\n'))
+        {
+            string trimmedLine = line.Trim();
+
+            if (trimmedLine.StartsWith(label, StringComparison.OrdinalIgnoreCase))
+            {
+                return trimmedLine[label.Length..].Trim();
+            }
+        }
+
+        return null;
     }
 
     private static void ValidateScore(double score)

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.Validations.cs
@@ -48,7 +48,9 @@ public partial class JudgeService
                 message: "Invalid judge score. Score must be a number between 0.0 and 1.0.");
         }
 
-        return new Judgement { Score = score };
+        string reason = ExtractLabeled(text, ReasonLabel) ?? string.Empty;
+
+        return new Judgement { Score = score, Reason = reason };
     }
 
     private static string? ExtractLabeled(string text, string label)

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
@@ -5,6 +5,7 @@
 
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Verifiers;
+using Standard.Agents.Models.Foundations.Judges;
 
 namespace Standard.Agents.Services.Foundations.Judges;
 
@@ -21,17 +22,17 @@ public partial class JudgeService : IJudgeService
         this.loggingBroker = loggingBroker;
     }
 
-    public ValueTask<double> EvaluateAsync(string candidate) =>
+    public ValueTask<Judgement> EvaluateAsync(string candidate) =>
     TryCatch(async () =>
     {
         ValidateEvaluate(candidate);
 
         string verdict = await this.verifierBroker.VerifyAsync(candidate);
 
-        double score = ParseScore(verdict);
+        Judgement judgement = ParseJudgement(verdict);
 
-        ValidateScore(score);
+        ValidateScore(judgement.Score);
 
-        return score;
+        return judgement;
     });
 }

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Foundations.Gates;
+using Standard.Agents.Models.Foundations.Judges;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Foundations.Brains;
 using Standard.Agents.Services.Foundations.Gates;
@@ -105,10 +106,10 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             return decided;
         }
 
-        double score =
+        Judgement judgement =
             await this.judgeService.EvaluateAsync(candidate: decided.Payload);
 
-        if (score < MinimumAcceptableScore)
+        if (judgement.Score < MinimumAcceptableScore)
         {
             return context with
             {
@@ -246,13 +247,13 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             yield break;
         }
 
-        double score = await this.judgeService.EvaluateAsync(candidate: decided.Payload);
+        Judgement judgement = await this.judgeService.EvaluateAsync(candidate: decided.Payload);
 
         await this.loggingBroker.LogProcessAsync(
             "Decision",
-            $"Judge → scored {score:F2} → {(score < MinimumAcceptableScore ? "REJECT" : "ACCEPT")}");
+            $"Judge → scored {judgement.Score:F2} → {(judgement.Score < MinimumAcceptableScore ? "REJECT" : "ACCEPT")}");
 
-        if (score < MinimumAcceptableScore)
+        if (judgement.Score < MinimumAcceptableScore)
         {
             setResult(context with
             {


### PR DESCRIPTION
Pillar 2 (guardians that pass an auditor), step 1 — bring the **Judge toward parity with the Gate**. The Gate is a classifier that gives a *reason*; the Judge was a bare `double`. Now it returns a `Judgement { Score, Reason }`.

- **New Data model** `Models/Foundations/Judges/Judgement.cs` — the Judge's verdict, mirroring how the Gate returns a verdict string.
- **`judge.contract.md`** now asks for two lines — `SCORE:` and `REASON:` — while **preserving the framework-owned `Reply with exactly` contract phrase** (conformance vector 09) and `judge.policy.md` keeps **`You are not the Brain.`** (Invariant 6). Both guardian-rubric assertions stay green.
- **Backward-compatible, robust parser:** an explicit `SCORE:` line wins; otherwise the whole reply is parsed strictly as before — so a bare `0.8` still works, and prose-with-digits (`I would rate this a 9 out of 10.`) still correctly fails as non-numeric. `REASON:` is optional (empty when absent).

This PR only *carries* the reason (Decision reads `.Score`, behavior unchanged). The **next PR wires the reason into the revise-out** so the Brain revises with feedback instead of guessing.

FAIL→PASS: `ShouldParseScoreAndReasonOnEvaluateAsync`. Category: MEDIUM FOUNDATIONS. 269 unit + 10/10 conformance green.