### PR TITLE
MINOR ORCHESTRATIONS: Feed The Judge's Reason Into The Revise-Out

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.ThinkReason.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.ThinkReason.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Judges;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldFeedJudgeReasonBackAsRevisionFeedbackOnThinkAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+        SetupGateAllows();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL: a poor answer");
+
+        this.judgeServiceMock.Setup(service =>
+            service.EvaluateAsync(It.IsAny<string>()))
+                .ReturnsAsync(new Judgement
+                {
+                    Score = 0.1,
+                    Reason = "it never states the year"
+                });
+
+        // when
+        AgentContext actualContext =
+            await this.decisionOrchestrationService.ThinkAsync(inputContext);
+
+        // then
+        actualContext.Status.Should().Be(AgentStatus.Revising);
+
+        actualContext.Observations.Should()
+            .ContainSingle(observation =>
+                observation.Contains("it never states the year"));
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -116,7 +116,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
                 Observations =
                 [
                     .. context.Observations,
-                    $"A previous draft was rejected on review: {decided.Payload}"
+                    RevisionFeedback(judgement, decided.Payload)
                 ],
 
                 Status = AgentStatus.Revising
@@ -125,6 +125,12 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         return decided;
     });
+
+    private static string RevisionFeedback(Judgement judgement, string draft) =>
+        string.IsNullOrWhiteSpace(judgement.Reason)
+            ? $"A previous draft was rejected on review: {draft}"
+            : $"A previous draft was rejected on review — {judgement.Reason}. "
+                + $"The draft was: {draft}";
 
     public IDecisionStream ThinkStreamAsync(
         AgentContext context,
@@ -249,9 +255,12 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         Judgement judgement = await this.judgeService.EvaluateAsync(candidate: decided.Payload);
 
+        string judgeOutcome = judgement.Score < MinimumAcceptableScore
+            ? $"REJECT: {judgement.Reason}".TrimEnd(':', ' ')
+            : "ACCEPT";
+
         await this.loggingBroker.LogProcessAsync(
-            "Decision",
-            $"Judge → scored {judgement.Score:F2} → {(judgement.Score < MinimumAcceptableScore ? "REJECT" : "ACCEPT")}");
+            "Decision", $"Judge → scored {judgement.Score:F2} → {judgeOutcome}");
 
         if (judgement.Score < MinimumAcceptableScore)
         {
@@ -260,7 +269,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
                 Observations =
                 [
                     .. context.Observations,
-                    $"A previous draft was rejected on review: {decided.Payload}"
+                    RevisionFeedback(judgement, decided.Payload)
                 ],
 
                 Status = AgentStatus.Revising


### PR DESCRIPTION
Pillar 2, step 2 — the Judge's **revise-out now carries feedback**, completing Gate/Judge parity. Before, a rejected draft looped back with a generic `A previous draft was rejected` — the Brain revised **blind**. Now the Judge's reason rides the revision:

```
A previous draft was rejected on review — it never states the year. The draft was: ...
```

and it surfaces in the trace/audit exactly like the Gate's refusal reason:

```
Process 4: Decision: Judge → scored 0.10 → REJECT: it never states the year
```

- Shared `RevisionFeedback(judgement, draft)` helper, used by **both** the buffered (`ThinkAsync`) and streaming (`ThinkStreamAsync`) paths.
- Falls back to the generic message when the model gives no reason (empty `Reason`), so nothing regresses.

Now a rejection is *actionable*: screen the output → **revise out with a reason**, the mirror of screen the input → **refuse with a reason**. That's the Judge an auditor can read.

FAIL→PASS: `ShouldFeedJudgeReasonBackAsRevisionFeedbackOnThinkAsync`. Category: MINOR ORCHESTRATIONS. 270 unit + 10/10 conformance green.