### PR TITLE
MEDIUM CLIENTS: Deterministic Rule-Based Guardians (RuleGate / RuleJudge)

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/RuleGuardianTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/RuleGuardianTests.cs
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Generators;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Clients.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+public class RuleGuardianTests
+{
+    private static async IAsyncEnumerable<string> ToStream(params string[] tokens)
+    {
+        foreach (string token in tokens)
+        {
+            await Task.CompletedTask;
+
+            yield return token;
+        }
+    }
+
+    private static StandardAgent BuildAgent(Mock<IGeneratorBroker> generator)
+    {
+        var skills = new Mock<ISkillBroker>();
+        skills.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+        var knowledge = new Mock<IKnowledgeBroker>();
+        knowledge.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+
+        return new StandardAgent()
+            .UseGenerator(generator.Object)
+            .UseSkills(skills.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(knowledge.Object)
+            .UseMcp(new Mock<IMcpBroker>().Object)
+            .RuleGate("password");
+    }
+
+    private static async Task<string> DrainAsync(StandardAgent agent, string prompt)
+    {
+        string last = string.Empty;
+
+        await foreach (AgentStreamEvent streamEvent in agent.StreamPromptAsync(prompt))
+        {
+            last = streamEvent.Content;
+        }
+
+        return last;
+    }
+
+    [Fact]
+    public async Task ShouldRefuseDeterministicallyWhenRuleGateMatchesAsync()
+    {
+        // given
+        var generator = new Mock<IGeneratorBroker>();
+        generator.Setup(broker => broker.GenerateStreamAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(ToStream("FINAL: your password is hunter2"));
+
+        StandardAgent agent = BuildAgent(generator);
+
+        // when — a prompt that trips the rule
+        await DrainAsync(agent, "please reset my PASSWORD");
+
+        // then — the brain is never reached; the gate stopped it deterministically
+        generator.Verify(broker => broker.GenerateStreamAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+    }
+
+    [Fact]
+    public async Task ShouldAllowThroughWhenRuleGateDoesNotMatchAsync()
+    {
+        // given
+        var generator = new Mock<IGeneratorBroker>();
+        generator.Setup(broker => broker.GenerateStreamAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(ToStream("FINAL: Paris"));
+
+        StandardAgent agent = BuildAgent(generator);
+
+        // when — a benign prompt
+        await DrainAsync(agent, "capital of France?");
+
+        // then — the brain is reached; the gate let it through
+        generator.Verify(broker => broker.GenerateStreamAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.AtLeastOnce);
+    }
+}

--- a/Standard.Agents/Brokers/Classifiers/RuleClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/RuleClassifierBroker.cs
@@ -19,7 +19,12 @@ public sealed class RuleClassifierBroker : IClassifierBroker
     {
         await Task.CompletedTask;
 
-        return Accept;
+        string? matchedRule = this.refusePatterns.FirstOrDefault(pattern =>
+            input.Contains(pattern, StringComparison.OrdinalIgnoreCase));
+
+        return matchedRule is null
+            ? Accept
+            : $"refuse: blocked by rule '{matchedRule}'";
     }
 
     public async ValueTask<string> AssessAsync(string systemPrompt, string input)

--- a/Standard.Agents/Brokers/Classifiers/RuleClassifierBroker.cs
+++ b/Standard.Agents/Brokers/Classifiers/RuleClassifierBroker.cs
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Classifiers;
+
+public sealed class RuleClassifierBroker : IClassifierBroker
+{
+    private const string Accept = "accept";
+    private const string NoConflict = "NONE";
+
+    private readonly IReadOnlyList<string> refusePatterns;
+
+    public RuleClassifierBroker(IEnumerable<string> refusePatterns) =>
+        this.refusePatterns = refusePatterns.ToList();
+
+    public async ValueTask<string> ClassifyAsync(string input)
+    {
+        await Task.CompletedTask;
+
+        return Accept;
+    }
+
+    public async ValueTask<string> AssessAsync(string systemPrompt, string input)
+    {
+        await Task.CompletedTask;
+
+        return NoConflict;
+    }
+}

--- a/Standard.Agents/Brokers/Verifiers/RuleVerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/RuleVerifierBroker.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Verifiers;
+
+public sealed class RuleVerifierBroker : IVerifierBroker
+{
+    private const string Pass = "SCORE: 1.0\nREASON: ok";
+
+    private readonly IReadOnlyList<string> requiredPatterns;
+
+    public RuleVerifierBroker(IEnumerable<string> requiredPatterns) =>
+        this.requiredPatterns = requiredPatterns.ToList();
+
+    public async ValueTask<string> VerifyAsync(string candidate)
+    {
+        await Task.CompletedTask;
+
+        string? missingPattern = this.requiredPatterns.FirstOrDefault(pattern =>
+            candidate.Contains(pattern, StringComparison.OrdinalIgnoreCase) is false);
+
+        return missingPattern is null
+            ? Pass
+            : $"SCORE: 0.0\nREASON: missing required content '{missingPattern}'";
+    }
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -233,6 +233,30 @@ public sealed partial class StandardAgent : IAgent
             new InferenceSettings(apiUrl, apiKey, model, temperature, maxTokens, timeoutSeconds));
 
     /// <summary>
+    /// Turns on a <b>deterministic</b> Gate: a guardian backed by a rule, not a model. It refuses
+    /// any prompt containing one of <paramref name="refusePatterns"/> (case-insensitive) and accepts
+    /// everything else — compliance that cannot be a coin-flip. Rides the same
+    /// <see cref="IClassifierBroker"/> seam as the model-backed <see cref="Gate"/>, so the loop and
+    /// the Tri-Nature are unchanged; only the substrate is swapped. The patterns are Data.
+    /// </summary>
+    /// <param name="refusePatterns">Substrings that, if present in a prompt, cause a refusal.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent RuleGate(params string[] refusePatterns) =>
+        Set(() => this.classifierBroker = new RuleClassifierBroker(refusePatterns));
+
+    /// <summary>
+    /// Turns on a <b>deterministic</b> Judge: a guardian backed by a rule, not a model. It passes a
+    /// draft answer only when the answer contains every one of <paramref name="requiredPatterns"/>
+    /// (case-insensitive), and otherwise rejects it — naming the first missing item as the revise-out
+    /// reason. Rides the same <see cref="IVerifierBroker"/> seam as the model-backed <see cref="Judge"/>.
+    /// The patterns are Data.
+    /// </summary>
+    /// <param name="requiredPatterns">Substrings the answer must contain to pass review.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent RuleJudge(params string[] requiredPatterns) =>
+        Set(() => this.verifierBroker = new RuleVerifierBroker(requiredPatterns));
+
+    /// <summary>
     /// Gives the agent a memory file it reads on recall and writes to through the built-in
     /// <c>remember</c> tool, so facts survive across turns and runs.
     /// </summary>


### PR DESCRIPTION
Pillar 2, step 3 — **compliance can't be a coin-flip LLM.** Two new guardians backed by a *rule*, not a model:

```csharp
new StandardAgent()
    .UseGenerator(brain)
    .RuleGate("password", "ssn", "wire transfer")     // refuse deterministically
    .RuleJudge("as of", "source:");                    // answer must cite
```

- `RuleGate(...refusePatterns)` — refuses any prompt containing a blocked pattern (case-insensitive), accepts everything else. The brain is **never reached** on a match.
- `RuleJudge(...requiredPatterns)` — passes a draft only if it contains every required pattern, else rejects and names the first missing item as the **revise-out reason** (parity with the model Judge — it produces `SCORE:`/`REASON:`, so the same JudgeService parses it).

**The collapsible substrate, exactly:** both ride the existing `IClassifierBroker` / `IVerifierBroker` seams — same interface a model-backed guardian implements. The loop, the Tri-Nature, and the public API are unchanged; only the substrate swaps. The patterns are **Data**, passed in at build time. A rule gate does no LLM skill-conflict detection (`AssessAsync` → `NONE`).

Brokers carry no unit tests (Standard); the behavior is certified end-to-end by acceptance tests — a `password` prompt is refused with the brain never invoked; a benign prompt passes through. FAIL→PASS. Category: MEDIUM CLIENTS. 272 unit + 10/10 conformance green.