### PR TITLE
MINOR ORCHESTRATIONS: Neutralize And Record Guardian Overreach (Invariant 6)

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Overreach.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Overreach.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Orchestrations.Decision;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Decision;
+
+public partial class DecisionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldNarrateGuardianOverreachWhenGateActsLikeBrainAsync()
+    {
+        // given
+        AgentContext inputContext = CreateRandomAgentContext();
+
+        this.gateServiceMock.Setup(service =>
+            service.ScreenAsync(It.IsAny<string>()))
+                .ReturnsAsync("FINAL: Paris");
+
+        SetupJudgeApproves();
+
+        this.brainServiceMock.Setup(service =>
+            service.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(ToAsyncStream("FINAL: Paris"));
+
+        // when — the Gate tries to answer instead of classifying
+        IDecisionStream decisionStream =
+            this.decisionOrchestrationService.ThinkStreamAsync(inputContext);
+
+        await DrainAsync(decisionStream);
+
+        // then — the overreach is neutralized and recorded (Invariant 6)
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogProcessAsync(
+                "Decision",
+                It.Is<string>(message => message.Contains("Invariant 6")),
+                It.IsAny<bool>()),
+                    Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -164,6 +164,15 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             yield break;
         }
 
+        if (IsGuardianOverreach(verdict))
+        {
+            await this.loggingBroker.LogProcessAsync(
+                "Decision",
+                "Gate overreach — a guardian tried to answer or act instead of classifying; "
+                    + "neutralized and passed to the Brain "
+                    + "(Invariant 6: a guardian is never the Brain)");
+        }
+
         await this.loggingBroker.LogProcessAsync(
             "Decision",
             IsRoute(verdict)
@@ -412,6 +421,11 @@ verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase
 
     private static bool IsRoute(string verdict) =>
         verdict.TrimStart().StartsWith(RouteVerdict, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsGuardianOverreach(string verdict) =>
+        verdict.Contains(FinalPrefix, StringComparison.OrdinalIgnoreCase)
+            || verdict.Contains(ActionPrefix, StringComparison.OrdinalIgnoreCase)
+            || verdict.Contains(ToolPrefix, StringComparison.OrdinalIgnoreCase);
 
     private static string ExtractRouteLabel(string verdict)
     {


### PR DESCRIPTION
Pillar 2, final step — make **Invariant 6 ("a guardian is never the Brain") observable.** The framework already fails safe: a Gate verdict that isn't `refuse`/`route` falls through and the real Brain runs. But if a guardian *tried to answer or act* — returning `FINAL: …`, `ACTION: …`, or `TOOL: …` — that overreach was swallowed silently. Now it's neutralized **and recorded**:

```
Process 1: Decision: Gate overreach — a guardian tried to answer or act instead of
  classifying; neutralized and passed to the Brain (Invariant 6: a guardian is never the Brain)
Process 2: Decision: Gate → ACCEPT: FINAL: Paris
```

Behavior is unchanged (the guardian's attempted answer is ignored, the Brain still produces the response) — the addition is the **audit signal**. An auditor, or an on-call engineer, can now see when a guardian model goes rogue, instead of it passing invisibly. It rides the audit spine (PR #200), so the overreach lands in the structured JSON too.

FAIL→PASS: `ShouldNarrateGuardianOverreachWhenGateActsLikeBrainAsync`. Category: MINOR ORCHESTRATIONS. 273 unit + 10/10 conformance green.

---
**Pillar 2 complete:** Judge/Gate parity (reason + revise-out, #202/#203) · deterministic rule guardians (#204) · guardian ≠ brain, observable (this PR).