### PR TITLE
MEDIUM FOUNDATIONS: Redact PII At The Brain Boundary On Generate

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.Redact.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.Redact.cs
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Brains;
+using Standard.Agents.Services.Foundations.Brains;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Brains;
+
+public partial class BrainServiceTests
+{
+    [Fact]
+    public async Task ShouldRedactPiiBeforeBrainAndRehydrateReplyOnGenerateAsync()
+    {
+        // given
+        var emailRule = new RedactionRule
+        {
+            Label = "EMAIL",
+            Pattern = @"[\w.+-]+@[\w-]+\.[\w.-]+"
+        };
+
+        var redactingBrainService = new BrainService(
+            generatorBroker: this.generatorBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object,
+            redactionRules: [emailRule]);
+
+        string systemPrompt = CreateRandomString();
+        string userPrompt = "please email jane@acme.com the report";
+
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("sure, sending it to {{EMAIL_0}} now");
+
+        // when
+        string actualReply =
+            await redactingBrainService.GenerateAsync(systemPrompt, userPrompt);
+
+        // then — the brain never saw the real email
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateAsync(
+                It.IsAny<string>(),
+                It.Is<string>(prompt =>
+                    prompt.Contains("{{EMAIL_0}}")
+                        && prompt.Contains("jane@acme.com") == false)),
+                Times.Once);
+
+        // and the caller got the real email back
+        actualReply.Should().Be("sure, sending it to jane@acme.com now");
+    }
+}

--- a/Standard.Agents/Models/Foundations/Brains/RedactionRule.cs
+++ b/Standard.Agents/Models/Foundations/Brains/RedactionRule.cs
@@ -1,0 +1,12 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Foundations.Brains;
+
+public record RedactionRule
+{
+    public string Label { get; init; } = string.Empty;
+    public string Pattern { get; init; } = string.Empty;
+}

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.Redactions.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.Redactions.cs
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using Standard.Agents.Models.Foundations.Brains;
+
+namespace Standard.Agents.Services.Foundations.Brains;
+
+public partial class BrainService
+{
+    private string Redact(string text, IDictionary<string, string> vault) =>
+        text;
+
+    private static string Rehydrate(string text, IReadOnlyDictionary<string, string> vault) =>
+        text;
+}

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.Redactions.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.Redactions.cs
@@ -10,9 +10,54 @@ namespace Standard.Agents.Services.Foundations.Brains;
 
 public partial class BrainService
 {
-    private string Redact(string text, IDictionary<string, string> vault) =>
-        text;
+    private string Redact(string text, IDictionary<string, string> vault)
+    {
+        if (this.redactionRules.Count == 0 || string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
 
-    private static string Rehydrate(string text, IReadOnlyDictionary<string, string> vault) =>
-        text;
+        string redactedText = text;
+
+        foreach (RedactionRule rule in this.redactionRules)
+        {
+            redactedText = Regex.Replace(
+                redactedText,
+                rule.Pattern,
+                match => Tokenize(rule, match.Value, vault));
+        }
+
+        return redactedText;
+    }
+
+    private static string Tokenize(
+        RedactionRule rule,
+        string value,
+        IDictionary<string, string> vault)
+    {
+        string existingToken =
+            vault.FirstOrDefault(entry => entry.Value == value).Key;
+
+        if (existingToken is not null)
+        {
+            return existingToken;
+        }
+
+        string token = "{{" + rule.Label + "_" + vault.Count + "}}";
+        vault[token] = value;
+
+        return token;
+    }
+
+    private static string Rehydrate(string text, IReadOnlyDictionary<string, string> vault)
+    {
+        string rehydratedText = text;
+
+        foreach (KeyValuePair<string, string> entry in vault)
+        {
+            rehydratedText = rehydratedText.Replace(entry.Key, entry.Value);
+        }
+
+        return rehydratedText;
+    }
 }

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.cs
@@ -6,6 +6,7 @@
 using System.Runtime.CompilerServices;
 using Standard.Agents.Brokers.Generators;
 using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Foundations.Brains;
 
 namespace Standard.Agents.Services.Foundations.Brains;
 
@@ -13,13 +14,16 @@ public partial class BrainService : IBrainService
 {
     private readonly IGeneratorBroker generatorBroker;
     private readonly ILoggingBroker loggingBroker;
+    private readonly IReadOnlyList<RedactionRule> redactionRules;
 
     public BrainService(
         IGeneratorBroker generatorBroker,
-        ILoggingBroker loggingBroker)
+        ILoggingBroker loggingBroker,
+        IEnumerable<RedactionRule>? redactionRules = null)
     {
         this.generatorBroker = generatorBroker;
         this.loggingBroker = loggingBroker;
+        this.redactionRules = redactionRules?.ToList() ?? [];
     }
 
     public ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt) =>
@@ -27,7 +31,14 @@ public partial class BrainService : IBrainService
     {
         ValidateUserPrompt(userPrompt);
 
-        return await this.generatorBroker.GenerateAsync(systemPrompt, userPrompt);
+        var vault = new Dictionary<string, string>();
+        string redactedSystemPrompt = Redact(systemPrompt, vault);
+        string redactedUserPrompt = Redact(userPrompt, vault);
+
+        string reply = await this.generatorBroker.GenerateAsync(
+            redactedSystemPrompt, redactedUserPrompt);
+
+        return Rehydrate(reply, vault);
     });
 
     public async IAsyncEnumerable<string> GenerateStreamAsync(


### PR DESCRIPTION
Pillar 3 (the security perimeter), step 1 — **data never reaches the brain in the clear.** `BrainService` is the brain's boundary abstraction, and redaction/rehydration is **mapping** — a foundation responsibility — so it lives here, not in a broker (a broker may hold no business logic or flow control per The Standard; regex matching is both).

On `GenerateAsync`:
1. **Redact** the system + user prompts against a set of `RedactionRule`s (label + regex), swapping each match to a `{{LABEL_N}}` token and recording token → original in a per-call vault.
2. Call the generator with the **redacted** text — the model/host sees tokens, never the PII.
3. **Rehydrate** the reply from the vault, so the caller gets their real data back.

- **Opt-in, zero-cost when off:** the rules are injected (empty by default). No rules ⇒ `Redact`/`Rehydrate` are pass-throughs, so existing behavior and every existing BrainService test are untouched. The rules are **Data**.
- **Consistent tokens:** the same value reuses its token within a call, so the brain can still reason about "the same email, mentioned twice."
- The vault is **local to the call** — it never enters `AgentContext`, never persists, never leaves the boundary.

This is the exact tokenization invariant the PeerLLM orchestrator lives by, brought into the reference framework. `GenerateStreamAsync` is unchanged here — streaming redaction is the next method (one method per PR).

FAIL→PASS: `ShouldRedactPiiBeforeBrainAndRehydrateReplyOnGenerateAsync` (brain receives `{{EMAIL_0}}`, never the address; caller gets the address back). Category: MEDIUM FOUNDATIONS. 274 unit + 10/10 conformance green.