### PR TITLE
MEDIUM CLIENTS: Turn On PII Redaction With .Redact()

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/RedactionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/RedactionTests.cs
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Generators;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+public class RedactionTests
+{
+    [Fact]
+    public async Task ShouldHidePiiFromBrainAndRestoreItInTheAnswerAsync()
+    {
+        // given
+        var generator = new Mock<IGeneratorBroker>();
+        generator.Setup(broker =>
+            broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("FINAL: I've emailed {{EMAIL_0}} the report");
+
+        var skills = new Mock<ISkillBroker>();
+        skills.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+        var knowledge = new Mock<IKnowledgeBroker>();
+        knowledge.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+
+        var agent = new StandardAgent()
+            .UseGenerator(generator.Object)
+            .UseSkills(skills.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(knowledge.Object)
+            .UseMcp(new Mock<IMcpBroker>().Object)
+            .Redact();
+
+        // when
+        string answer =
+            await agent.ProcessPromptAsync("please email jane@acme.com the report");
+
+        // then — the brain saw a token, never the address
+        generator.Verify(broker =>
+            broker.GenerateAsync(
+                It.IsAny<string>(),
+                It.Is<string>(prompt =>
+                    prompt.Contains("{{EMAIL_0}}")
+                        && prompt.Contains("jane@acme.com") == false)),
+                Times.AtLeastOnce);
+
+        // and the caller got the real address back
+        answer.Should().Contain("jane@acme.com");
+        answer.Should().NotContain("{{EMAIL_0}}");
+    }
+}

--- a/Standard.Agents/Models/Foundations/Brains/RedactionRules.cs
+++ b/Standard.Agents/Models/Foundations/Brains/RedactionRules.cs
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Foundations.Brains;
+
+public static class RedactionRules
+{
+    public static IReadOnlyList<RedactionRule> Default { get; } =
+    [
+        new RedactionRule
+        {
+            Label = "EMAIL",
+            Pattern = @"[\w.+-]+@[\w-]+\.[\w.-]+"
+        },
+
+        new RedactionRule
+        {
+            Label = "SSN",
+            Pattern = @"\b\d{3}-\d{2}-\d{4}\b"
+        },
+
+        new RedactionRule
+        {
+            Label = "CREDIT_CARD",
+            Pattern = @"\b\d{4}[ -]?\d{4}[ -]?\d{4}[ -]?\d{4}\b"
+        },
+
+        new RedactionRule
+        {
+            Label = "PHONE",
+            Pattern = @"\b\d{3}[-.]\d{3}[-.]\d{4}\b"
+        },
+    ];
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -613,7 +613,7 @@ public sealed partial class StandardAgent : IAgent
 
         DecisionOrchestrationService decision = new(
             new GateService(classifier, logging),
-            new BrainService(generator, logging),
+            new BrainService(generator, logging, this.redactionRules),
             new JudgeService(verifier, logging),
             logging);
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -17,6 +17,7 @@ using Standard.Agents.Brokers.Times;
 using Standard.Agents.Brokers.Tools;
 using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Foundations.Brains;
 using Standard.Agents.Models.Loggings;
 using Standard.Agents.Prompts;
 using Standard.Agents.Services.Coordinations;
@@ -45,6 +46,7 @@ public sealed partial class StandardAgent : IAgent
     private string consumptionPath = string.Empty;
     private string logPath = string.Empty;
     private string auditPath = string.Empty;
+    private IEnumerable<RedactionRule>? redactionRules;
     private TraceVerbosity traceVerbosity = TraceVerbosity.Full;
     private string memoryPath = "memory.txt";
     private int maxTurns = 7;
@@ -344,6 +346,17 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent Audit(string path) =>
         Set(() => this.auditPath = path);
+
+    /// <summary>
+    /// Turns on <b>PII redaction at the brain boundary</b>: before any prompt reaches the brain,
+    /// emails, SSNs, credit-card numbers and phone numbers are swapped for opaque <c>{{LABEL_N}}</c>
+    /// tokens, and the brain's reply is rehydrated so the caller gets the real values back. The brain
+    /// (and any remote host serving it) never sees the data in the clear. Off by default. The default
+    /// rule set is Data — see <see cref="RedactionRules.Default"/>.
+    /// </summary>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Redact() =>
+        Set(() => this.redactionRules = RedactionRules.Default);
 
     /// <summary>
     /// Caps how many Recall→Think→Act turns a single prompt may take before the agent stops —


### PR DESCRIPTION
Pillar 3, step 2 — expose the brain-boundary redaction (PR #206) as one appliance line:

```csharp
new StandardAgent()
    .UseGenerator(brain)
    .Redact();               // emails, SSNs, cards, phones → tokens, never sent in the clear
```

`.Redact()` wires the built-in `RedactionRules.Default` (EMAIL / SSN / CREDIT_CARD / PHONE) into `BrainService`. Off by default — the rule set is **Data**, so a caller can supply their own later without touching the loop or the API.

End-to-end acceptance test through the buffered `ProcessPromptAsync`: the prompt *"email jane@acme.com the report"* reaches the brain as `{{EMAIL_0}}` (never the address), and the caller's answer comes back with the real address restored.

**Scope (honest):** this protects the **brain** (generator) boundary on the buffered path. Two follow-ons, each its own method/PR: streaming (`GenerateStreamAsync`) redaction, and the **Judge/verifier** boundary (the Judge currently scores the rehydrated answer, so a remote judge would see PII — same tokenization, applied there next).

FAIL→PASS: `ShouldHidePiiFromBrainAndRestoreItInTheAnswerAsync` (genuine FAIL shown with Compose unwired). Category: MEDIUM CLIENTS. 275 unit + 10/10 conformance green.