### PR TITLE
MEDIUM FOUNDATIONS: Redact PII On The Streaming Brain Path

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.RedactStream.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.RedactStream.cs
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Foundations.Brains;
+using Standard.Agents.Services.Foundations.Brains;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Brains;
+
+public partial class BrainServiceTests
+{
+    [Fact]
+    public async Task ShouldRedactPiiBeforeBrainAndRehydrateStreamedReplyOnGenerateStreamAsync()
+    {
+        // given
+        var emailRule = new RedactionRule
+        {
+            Label = "EMAIL",
+            Pattern = @"[\w.+-]+@[\w-]+\.[\w.-]+"
+        };
+
+        var redactingBrainService = new BrainService(
+            generatorBroker: this.generatorBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object,
+            redactionRules: [emailRule]);
+
+        string userPrompt = "email jane@acme.com the report";
+
+        // the brain echoes the token, split across two chunks
+        this.generatorBrokerMock.Setup(broker =>
+            broker.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(ToAsyncStream("sent to {{EMA", "IL_0}} now"));
+
+        // when
+        List<string> tokens = await DrainAsync(
+            redactingBrainService.GenerateStreamAsync("system", userPrompt));
+
+        string joined = string.Concat(tokens);
+
+        // then — the brain never saw the address
+        this.generatorBrokerMock.Verify(broker =>
+            broker.GenerateStreamAsync(
+                It.IsAny<string>(),
+                It.Is<string>(prompt =>
+                    prompt.Contains("{{EMAIL_0}}")
+                        && prompt.Contains("jane@acme.com") == false),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+
+        // and the streamed answer is rehydrated, even across the chunk split
+        joined.Should().Be("sent to jane@acme.com now");
+        joined.Should().NotContain("{{EMAIL_0}}");
+    }
+}

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.Redactions.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.Redactions.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Text;
 using System.Text.RegularExpressions;
 using Standard.Agents.Models.Foundations.Brains;
 
@@ -10,6 +11,28 @@ namespace Standard.Agents.Services.Foundations.Brains;
 
 public partial class BrainService
 {
+    private static string DrainReady(
+        StringBuilder pending,
+        IReadOnlyDictionary<string, string> vault)
+    {
+        string buffer = Rehydrate(pending.ToString(), vault);
+
+        int hold = buffer.LastIndexOf('{');
+
+        while (hold > 0 && buffer[hold - 1] == '{')
+        {
+            hold--;
+        }
+
+        string ready = hold >= 0 ? buffer[..hold] : buffer;
+        string keep = hold >= 0 ? buffer[hold..] : string.Empty;
+
+        pending.Clear();
+        pending.Append(keep);
+
+        return ready;
+    }
+
     private string Redact(string text, IDictionary<string, string> vault)
     {
         if (this.redactionRules.Count == 0 || string.IsNullOrEmpty(text))

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using System.Runtime.CompilerServices;
+using System.Text;
 using Standard.Agents.Brokers.Generators;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Foundations.Brains;
@@ -47,19 +48,25 @@ public partial class BrainService : IBrainService
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         IAsyncEnumerator<string> tokens;
+        var vault = new Dictionary<string, string>();
 
         try
         {
             ValidateUserPrompt(userPrompt);
 
+            string redactedSystemPrompt = Redact(systemPrompt, vault);
+            string redactedUserPrompt = Redact(userPrompt, vault);
+
             tokens = this.generatorBroker
-                .GenerateStreamAsync(systemPrompt, userPrompt, cancellationToken)
+                .GenerateStreamAsync(redactedSystemPrompt, redactedUserPrompt, cancellationToken)
                 .GetAsyncEnumerator(cancellationToken);
         }
         catch (Exception exception)
         {
             throw await MapStreamExceptionAsync(exception);
         }
+
+        var pending = new StringBuilder();
 
         try
         {
@@ -81,7 +88,25 @@ public partial class BrainService : IBrainService
                     throw await MapStreamExceptionAsync(exception);
                 }
 
-                yield return token;
+                if (vault.Count == 0)
+                {
+                    yield return token;
+
+                    continue;
+                }
+
+                pending.Append(token);
+                string ready = DrainReady(pending, vault);
+
+                if (ready.Length > 0)
+                {
+                    yield return ready;
+                }
+            }
+
+            if (vault.Count > 0 && pending.Length > 0)
+            {
+                yield return Rehydrate(pending.ToString(), vault);
             }
         }
         finally


### PR DESCRIPTION
Pillar 3 — closes the security-critical gap left by PR #206/#207: the **streaming** path (`GenerateStreamAsync`) is the primary one, and it was still sending PII to the brain in the clear when `.Redact()` was on. Now it doesn't.

- **Input** is redacted before the generator is asked to stream — the brain (and any host) sees only `{{LABEL_N}}` tokens on this path too.
- **Output** is rehydrated as it streams, with a small hold-back buffer so a placeholder **split across chunks** (`"…{{EMA"` then `"IL_0}} now"`) is reassembled and restored to the real value — never emitted half-tokenized. The `{{` opener is grouped so a chunk boundary can't split the braces.
- **Zero cost when off:** with no redaction rules the vault is empty and tokens pass straight through — byte-identical to before, no buffering, no added latency. Every existing streaming test is untouched.

Together with #206/#207, **`.Redact()` now protects both the buffered and streaming brain boundaries.** Remaining follow-on: the Judge/verifier boundary (a remote judge still scores the rehydrated answer) — same tokenization, applied there next.

FAIL→PASS: `ShouldRedactPiiBeforeBrainAndRehydrateStreamedReplyOnGenerateStreamAsync` (token echoed split across two chunks; brain sees `{{EMAIL_0}}`, stream yields the real address). Category: MEDIUM FOUNDATIONS. 276 unit + 10/10 conformance green.