### PR TITLE
MEDIUM ORCHESTRATIONS: Least-Privilege Tool Allow-List (RBAC At The Direction Perimeter)

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Guardians.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Guardians.Act.cs
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Services.Orchestrations.Direction;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+
+public partial class DirectionOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ShouldDenyToolNotInAllowListOnActAsync()
+    {
+        // given
+        var restrictedService = new DirectionOrchestrationService(
+            internalToolService: this.internalToolServiceMock.Object,
+            externalToolService: this.externalToolServiceMock.Object,
+            returnService: this.returnServiceMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object,
+            allowedTools: ["calculator"]);
+
+        AgentContext inputContext =
+            CreateContextWithDirection("webhook", "https://evil.example/exfiltrate");
+
+        // when
+        AgentContext actualContext = await restrictedService.ActAsync(inputContext);
+
+        // then — the forbidden tool never ran; the agent stays working and can recover
+        actualContext.Status.Should().Be(AgentStatus.Working);
+
+        actualContext.Observations.Should()
+            .ContainSingle(observation => observation.Contains("not permitted"));
+
+        this.internalToolServiceMock.Verify(service =>
+            service.HandlesAsync(It.IsAny<string>()), Times.Never);
+
+        this.internalToolServiceMock.Verify(service =>
+            service.RunAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+
+        this.externalToolServiceMock.Verify(service =>
+            service.CallAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ShouldAllowToolInAllowListOnActAsync()
+    {
+        // given
+        var restrictedService = new DirectionOrchestrationService(
+            internalToolService: this.internalToolServiceMock.Object,
+            externalToolService: this.externalToolServiceMock.Object,
+            returnService: this.returnServiceMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object,
+            allowedTools: ["calculator"]);
+
+        AgentContext inputContext = CreateContextWithDirection("calculator", "2 + 2");
+
+        this.internalToolServiceMock.Setup(service =>
+            service.HandlesAsync("calculator")).ReturnsAsync(true);
+
+        this.internalToolServiceMock.Setup(service =>
+            service.RunAsync("calculator", "2 + 2")).ReturnsAsync("4");
+
+        // when
+        AgentContext actualContext = await restrictedService.ActAsync(inputContext);
+
+        // then — an allow-listed tool runs normally
+        actualContext.Result.Should().Be("4");
+
+        this.internalToolServiceMock.Verify(service =>
+            service.RunAsync("calculator", "2 + 2"), Times.Once);
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -21,18 +21,27 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
     private readonly IExternalToolService externalToolService;
     private readonly IReturnService returnService;
     private readonly ILoggingBroker loggingBroker;
+    private readonly HashSet<string> allowedToolNames;
 
     public DirectionOrchestrationService(
         IInternalToolService internalToolService,
         IExternalToolService externalToolService,
         IReturnService returnService,
-        ILoggingBroker loggingBroker)
+        ILoggingBroker loggingBroker,
+        IEnumerable<string>? allowedTools = null)
     {
         this.internalToolService = internalToolService;
         this.externalToolService = externalToolService;
         this.returnService = returnService;
         this.loggingBroker = loggingBroker;
+
+        this.allowedToolNames =
+            new HashSet<string>(allowedTools ?? [], StringComparer.OrdinalIgnoreCase);
     }
+
+    private bool IsToolForbidden(string toolName) =>
+        this.allowedToolNames.Count > 0
+            && this.allowedToolNames.Contains(toolName) is false;
 
     public ValueTask<AgentContext> ActAsync(AgentContext context) =>
     TryCatch(async () =>

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -62,6 +62,22 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
             };
         }
 
+        if (IsToolForbidden(context.DirectionType))
+        {
+            string denial = $"tool '{context.DirectionType}' is not permitted";
+
+            await this.loggingBroker.LogProcessAsync(
+                "Direction",
+                $"RBAC → DENIED '{context.DirectionType}' (not in the allow-list)");
+
+            return context with
+            {
+                Result = denial,
+                Observations = [.. context.Observations, $"{context.DirectionType}: {denial}"],
+                Status = AgentStatus.Working
+            };
+        }
+
         bool isLocalTool = await this.internalToolService.HandlesAsync(context.DirectionType);
 
         string output = isLocalTool


### PR DESCRIPTION
Pillar 3 — the perimeter's other half: **capability is gated where it is exercised.** Direction is where tools actually run, so that's where least-privilege lives. An opt-in allow-list (Data) names the tools this agent may use; anything else is denied **before** it executes:

- A forbidden tool call **never reaches** the InternalTool/ExternalTool services — `HandlesAsync`/`RunAsync`/`CallAsync` are not invoked.
- The denial is fed back as an observation (`webhook: tool 'webhook' is not permitted`) and the turn stays **Working**, so the agent can recover and choose a permitted path — the same shape as vector 05 (unknown-tool-recovers), not a crash.
- The denial is recorded on the audit spine: `RBAC → DENIED 'webhook' (not in the allow-list)`.
- **Off by default:** an empty allow-list means no restriction, so existing behavior and every existing Direction test are untouched. Case-insensitive matching.

This is least-privilege per the doctrine (Ch 9–10): the model can *propose* any tool, but the perimeter decides what may *run*. Jurisdiction/location-scoped variants ride the same seam next.

FAIL→PASS: `ShouldDenyToolNotInAllowListOnActAsync` (forbidden tool blocked, services never called) + `ShouldAllowToolInAllowListOnActAsync` (permitted tool runs). Category: MEDIUM ORCHESTRATIONS. 278 unit + 10/10 conformance green.