### PR TITLE
MINOR DOCUMENTATION: The Judge's Reason Feeds The Revise-Out

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -276,15 +276,19 @@ var agent = new StandardAgent(url, key, "LLooMA2.0")
 ```
 
 **Why it's useful.** Without a judge, the first draft is the final answer — including a confident,
-wrong one. With a judge, a low-scoring draft is *rejected*: it's fed back as an observation and the
-agent tries again, so the answer that reaches you has survived a second opinion.
+wrong one. With a judge, a low-scoring draft is *rejected with a reason*, and that reason is fed back
+so the next attempt knows what to fix — the agent revises *with feedback*, not blind, and the answer
+that reaches you has survived a second opinion.
 
 ```
-Draft: "47 * 89 = 4183."   → judge: 0.9 → returned
-Draft: "47 * 89 = 4020."   → judge: 0.1 → rejected, agent revises
+Draft: "47 * 89 = 4183."   → judge: 0.9                          → returned
+Draft: "47 * 89 = 4020."   → judge: 0.1, "the product is wrong"  → rejected; the reason
+                                                                    rides into the next turn
 ```
 
-Like the Gate, the Judge runs its own rubric and is never the brain certifying itself.
+The Judge screens the *output* the way the Gate screens the *input*: accept, or **revise out with a
+reason** — the mirror of the Gate's refuse-with-a-reason. Like the Gate it runs its own rubric and is
+never the brain certifying itself.
 
 **Locally, too.** `.LocalJudge(...)` scores the draft with an in-process model, same delegate shape:
 


### PR DESCRIPTION
Small follow-up to #211. That PR documented the enterprise controls thoroughly; this fills the one nuance §5 didn't capture — the Judge no longer just rejects, it rejects **with a reason**, and that reason is fed back so the next attempt revises *with feedback* instead of blind (PRs #202/#203).

Updates the "Why it's useful" paragraph and the score example to show the reason riding into the next turn, and frames the Judge as the mirror of the Gate: screen the input → refuse-with-a-reason; screen the output → revise-out-with-a-reason. Category: MINOR DOCUMENTATION.