### PR TITLE
MEDIUM FOUNDATIONS: A {{skills}} Index — Model-Driven Progressive Disclosure

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/SkillCatalogTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/SkillCatalogTests.cs
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.IO;
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Generators;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
+using Standard.Agents.Brokers.Memorys;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+public class SkillCatalogTests
+{
+    [Fact]
+    public async Task ShouldExpandSkillsMarkerIntoTheDescribedSkillCatalogAsync()
+    {
+        // given — a base skill with the {{skills}} marker + a described specialist skill
+        string root = Path.Combine(Path.GetTempPath(), "skills-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "weather-skill"));
+
+        await File.WriteAllTextAsync(
+            Path.Combine(root, "00-base.md"),
+            "You are helpful.\n\nAvailable skills:\n{{skills}}");
+
+        await File.WriteAllTextAsync(
+            Path.Combine(root, "weather-skill", "SKILL.md"),
+            "---\nname: weather\ndescription: answers weather questions\n---\n"
+                + "Give a three-day forecast.");
+
+        string capturedSystemPrompt = string.Empty;
+
+        var generator = new Mock<IGeneratorBroker>();
+        generator.Setup(broker =>
+            broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback<string, string>((systemPrompt, _) => capturedSystemPrompt = systemPrompt)
+                .ReturnsAsync("FINAL: ok");
+
+        var memory = new Mock<IMemoryBroker>();
+        memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+        var knowledge = new Mock<IKnowledgeBroker>();
+        knowledge.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>())).ReturnsAsync([]);
+
+        var agent = new StandardAgent()
+            .UseGenerator(generator.Object)
+            .UseMemory(memory.Object)
+            .UseKnowledge(knowledge.Object)
+            .UseMcp(new Mock<IMcpBroker>().Object)
+            .Skills(root);
+
+        // when
+        await agent.ProcessPromptAsync("hello");
+        Directory.Delete(root, recursive: true);
+
+        // then — the marker expanded into the described-skill index, and is gone
+        capturedSystemPrompt.Should().Contain("- weather — answers weather questions");
+        capturedSystemPrompt.Should().NotContain("{{skills}}");
+    }
+}

--- a/Standard.Agents/Services/Foundations/Skills/ISkillService.cs
+++ b/Standard.Agents/Services/Foundations/Skills/ISkillService.cs
@@ -8,4 +8,6 @@ namespace Standard.Agents.Services.Foundations.Skills;
 public interface ISkillService
 {
     ValueTask<string> RetrieveSkillsAsync(string route = "");
+
+    ValueTask<string> RetrieveSkillCatalogAsync();
 }

--- a/Standard.Agents/Services/Foundations/Skills/SkillService.cs
+++ b/Standard.Agents/Services/Foundations/Skills/SkillService.cs
@@ -46,4 +46,17 @@ public partial class SkillService : ISkillService
 
         return string.Join(SkillSeparator, selectedSkills.Select(skill => skill.Content));
     });
+
+    public ValueTask<string> RetrieveSkillCatalogAsync() =>
+    TryCatch(async () =>
+    {
+        IReadOnlyList<Skill> skills = await this.skillBroker.SelectSkillsAsync();
+
+        IEnumerable<string> catalogEntries = skills
+            .Where(skill => string.IsNullOrWhiteSpace(skill.Description) is false)
+            .OrderBy(skill => skill.Name, StringComparer.Ordinal)
+                .Select(skill => $"- {skill.Name} — {skill.Description}");
+
+        return string.Join(Environment.NewLine, catalogEntries);
+    });
 }

--- a/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/DataOrchestrationService.cs
@@ -14,6 +14,7 @@ namespace Standard.Agents.Services.Orchestrations.Data;
 public partial class DataOrchestrationService : IDataOrchestrationService
 {
     private const string ToolsMarker = "{{tools}}";
+    private const string SkillsMarker = "{{skills}}";
 
     private readonly ISkillService skillService;
     private readonly IMemoryService memoryService;
@@ -45,6 +46,12 @@ public partial class DataOrchestrationService : IDataOrchestrationService
         IReadOnlyList<string> knowledge = await this.knowledgeService.RetrieveKnowledgeAsync(context.Prompt);
 
         string systemPrompt = skills.Replace(ToolsMarker, this.toolCatalog);
+
+        if (systemPrompt.Contains(SkillsMarker))
+        {
+            string skillCatalog = await this.skillService.RetrieveSkillCatalogAsync();
+            systemPrompt = systemPrompt.Replace(SkillsMarker, skillCatalog);
+        }
 
         await this.loggingBroker.LogProcessAsync("Data", $"Received prompt: \"{context.Prompt}\"");
         await this.loggingBroker.LogProcessAsync("Data", $"Recalled {memories.Count} memories");

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -138,6 +138,26 @@ Every `.md` **under the folder — subfolders included** — is loaded and conca
 it's stripped from what the brain sees and becomes the skill's index entry. (Remember the
 copy-to-output rule from the top — subfolders travel with it.)
 
+**A `{{skills}}` index.** Just as `{{tools}}` advertises tools, a `{{skills}}` marker in a skill
+expands into an index of your **described** skills — one `- name — description` line each — so the
+agent knows what specialist skills it has and can route to the right one:
+
+```markdown
+You are a helpful assistant. Your specialist skills:
+{{skills}}
+```
+
+becomes:
+
+```
+- weather — answers weather questions
+- billing — explains invoices and charges
+```
+
+A skill is listed only if it carries a `description` (the opt-in, exactly like a tool's). With the
+index in context and route-in on, the model reaches for the skill it needs — model-driven, the same
+way it reaches for a tool.
+
 ---
 
 ## 3 · Tools


### PR DESCRIPTION
Builds the local **skill index** on the new `FileSkillBroker` (PR #216): the agent knows what each skill *is* and pulls the right one when relevant — model-driven, the exact parallel of `{{tools}}`.

- **`SkillService.RetrieveSkillCatalogAsync()`** renders the index of **described** skills — one `- name — description` line each (ordered by name). A skill is listed only if it carries a frontmatter `description` (the opt-in, exactly like a tool's description).
- **`DataOrchestrationService`** expands a `{{skills}}` marker in the composed skills into that catalog — only when the marker is present (no extra read otherwise), mirroring `{{tools}}`.
- With the index in context and **route-in** (already shipped), the decider reaches for the skill it needs and Data loads its body next turn — the same way the brain reaches for a tool.

```markdown
You are a helpful assistant. Your specialist skills:
{{skills}}
```
→
```
- weather — answers weather questions
- billing — explains invoices and charges
```

FAIL→PASS: acceptance `ShouldExpandSkillsMarkerIntoTheDescribedSkillCatalogAsync` (a `{{skills}}` marker + a described nested specialist → the catalog appears in the system prompt, marker gone). 282 unit + 10/10 conformance green. Category: MEDIUM FOUNDATIONS.

Follow-on (noted): full progressive-disclosure loading (catalog-only until routed) — this ships the index + the seam; described specialists' bodies still load by default until that tuning lands.