### PR TITLE
RELEASES: Standard.Agents 0.17.0.0

### DIFF
--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -65,7 +65,7 @@
          3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1 goes to 1 when the spec settles.
          (0.8.0.0: memory and knowledge came alive — knowledge retrieval in Recall + a built-in
          'remember' tool.) -->
-    <Version>0.16.0.0</Version>
+    <Version>0.17.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>


### PR DESCRIPTION
Bumps `<Version>` `0.16.0.0 → 0.17.0.0` for the v0.17.0 release — the skills subsystem.

- **Skills get their own `FileSkillBroker`** (#216): local skills are discovered **recursively** (nested directories now load), each read through a dedicated broker, with **YAML frontmatter** (`name:` / `description:`) parsed and stripped. `ISkillBroker` now returns per-skill `Skill { Name, Description, Content }` — a **breaking change to that seam** (hence the minor bump), but the public `.Skills(path)` builder API is unchanged. Route-in now works for nested skills.
- **A `{{skills}}` index** (#217): a marker that expands into the catalog of described skills, the parallel of `{{tools}}` — the model sees what specialist skills it has and route-in pulls the right one.

282 unit + 10/10 conformance green (Release config). Publishing the `v0.17.0` GitHub Release triggers the conformance-gated NuGet push. Category: RELEASES.