### PR TITLE
DOCUMENTATION: The PeerLLM Skills Registry Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ nature for a real backend with one line — same seam, the dependency living in 
 |---|---|---|---|
 | Brain · *Decision* | hosted `.Brain(url,…)` | local GGUF (llama.cpp) | [`…Decision.Brains.LlamaSharp`](https://www.nuget.org/packages/Standard.Agents.Decision.Brains.LlamaSharp) |
 | Gate / Judge · *Decision* | hosted `.Gate` / `.Judge` | in-process | *core — `.LocalGate` / `.LocalJudge`* |
+| Skills · *Data* | local folder | PeerLLM registry | [`…Data.Skills.PeerLLM`](https://www.nuget.org/packages/Standard.Agents.Data.Skills.PeerLLM) |
 | Memory · *Data* | file | Redis | [`…Data.Memory.Redis`](https://www.nuget.org/packages/Standard.Agents.Data.Memory.Redis) |
 | Knowledge · *Data* | folder | PostgreSQL full-text | [`…Data.Knowledge.Postgres`](https://www.nuget.org/packages/Standard.Agents.Data.Knowledge.Postgres) |
 | Knowledge · *Data* | folder | SQL Server full-text | [`…Data.Knowledge.MsSql`](https://www.nuget.org/packages/Standard.Agents.Data.Knowledge.MsSql) |

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -158,6 +158,30 @@ A skill is listed only if it carries a `description` (the opt-in, exactly like a
 index in context and route-in on, the model reaches for the skill it needs — model-driven, the same
 way it reaches for a tool.
 
+### Skills from the registry
+
+A folder isn't the only source. Just as memory swaps to Redis and knowledge to Postgres, skills can
+come from the [PeerLLM registry](https://skills.peerllm.com) — versioned, shared, pulled at runtime —
+through the same `ISkillBroker` seam. The
+[`Standard.Agents.Data.Skills.PeerLLM`](https://www.nuget.org/packages/Standard.Agents.Data.Skills.PeerLLM)
+package points at a **skillset** (a versioned bundle):
+
+```bash
+dotnet add package Standard.Agents.Data.Skills.PeerLLM
+```
+
+```csharp
+using Standard.Agents.Data.Skills.PeerLLM;
+
+var agent = new StandardAgent(url, key, "LLooMA2.0")
+    .UseSkills(new PeerLLMSkillBroker("hassanhabib/my-skills", SkillSync.Hybrid));
+```
+
+Each skillset member arrives as a `Skill { Name, Description, Content }` — the same shape the file
+broker produces, so routing and the `{{skills}}` index work identically. Three sync modes trade
+freshness for chattiness: `Live` (fetch every turn), `Local` (pull once to a cache), `Hybrid` (cache,
+re-pull only when a newer version ships). Public skills need no key; pass a `psk_…` key for your own.
+
 ---
 
 ## 3 · Tools


### PR DESCRIPTION
Documents the new [`Standard.Agents.Data.Skills.PeerLLM`](https://www.nuget.org/packages/Standard.Agents.Data.Skills.PeerLLM) adapter alongside the others.

- **README** — a **Skills · Data** row in the backends-swap table (local folder → PeerLLM registry).
- **how-to §2** — a *Skills from the registry* subsection: install, the `.UseSkills(new PeerLLMSkillBroker(...))` wiring, the three `SkillSync` modes (Live / Local / Hybrid), and that skillset members map to the same `Skill { Name, Description, Content }` shape so routing + the `{{skills}}` index work identically.

Category: DOCUMENTATION.