### PR TITLE
DATA: Add Audit Record Model

### DIFF
--- a/Standard.Agents/Models/Brokers/Audits/AuditKind.cs
+++ b/Standard.Agents/Models/Brokers/Audits/AuditKind.cs
@@ -1,0 +1,16 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Brokers.Audits;
+
+public enum AuditKind
+{
+    Run,
+    Turn,
+    Step,
+    Process,
+    Outcome,
+    Error
+}

--- a/Standard.Agents/Models/Brokers/Audits/AuditRecord.cs
+++ b/Standard.Agents/Models/Brokers/Audits/AuditRecord.cs
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Brokers.Audits;
+
+public sealed record AuditRecord
+{
+    public string RunId { get; init; } = "";
+    public int Sequence { get; init; }
+    public DateTimeOffset Timestamp { get; init; }
+    public AuditKind Kind { get; init; }
+
+    public string Actor { get; init; } = "";
+    public string Message { get; init; } = "";
+    public bool Detail { get; init; }
+
+    public string? Principal { get; init; }
+    public string? PreviousHash { get; init; }
+}


### PR DESCRIPTION
Part of Standard.Agents 0.19.0.0 — The Audit Spine. Spec first: implements SPEC.md §3.3 / §4.7 / §4.8, merged as The-Standard-Agent-Specs#10.

Stacked on `main` — merge in order.