### PR TITLE
MINOR CLIENTS: Audit Local, External And Custom Plus Principal

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Audits.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Audits.cs
@@ -60,4 +60,26 @@ public class StandardAgentAuditTests
                 Times.AtLeastOnce);
     }
 
+    [Fact]
+    public async Task ShouldWriteToCustomAuditDelegateOnProcessPromptAsync()
+    {
+        // given
+        List<AuditRecord> capturedRecords = [];
+
+        StandardAgent agent = AnsweringAgent()
+            .OnAudit(record =>
+            {
+                capturedRecords.Add(record);
+
+                return ValueTask.CompletedTask;
+            });
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "what is the answer?");
+
+        // then
+        capturedRecords.Should().NotBeEmpty();
+        capturedRecords.Should().Contain(record => record.Kind == AuditKind.Run);
+        capturedRecords.Select(record => record.Sequence).Should().BeInAscendingOrder();
+    }
 }

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Audits.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Audits.cs
@@ -82,4 +82,30 @@ public class StandardAgentAuditTests
         capturedRecords.Should().Contain(record => record.Kind == AuditKind.Run);
         capturedRecords.Select(record => record.Sequence).Should().BeInAscendingOrder();
     }
+
+    [Fact]
+    public async Task ShouldStampPrincipalOnEveryAuditRecordOnProcessPromptAsync()
+    {
+        // given
+        string expectedPrincipal = "user-42";
+        List<AuditRecord> capturedRecords = [];
+
+        StandardAgent agent = AnsweringAgent()
+            .Principal(() => expectedPrincipal)
+            .OnAudit(record =>
+            {
+                capturedRecords.Add(record);
+
+                return ValueTask.CompletedTask;
+            });
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "what is the answer?");
+
+        // then
+        capturedRecords.Should().NotBeEmpty();
+
+        capturedRecords.Should().OnlyContain(record =>
+            record.Principal == expectedPrincipal);
+    }
 }

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Audits.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Audits.cs
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Audits;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Brokers.Audits;
+using Standard.Agents.Models.Foundations.Skills;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+// The decision log's three access modes (SPEC.md §4.8): Local is .Audit(path) and is
+// covered by the acceptance suite, since a file sink is only interesting end to end.
+// External and Custom are covered here, where the sink can be observed directly.
+public class StandardAgentAuditTests
+{
+    private static StandardAgent AnsweringAgent()
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+
+        skillBroker.Setup(broker => broker.SelectSkillsAsync())
+            .ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .OnBrain(async (systemPrompt, userPrompt) => "FINAL: 42");
+    }
+
+    [Fact]
+    public async Task ShouldWriteToExternalAuditBrokerOnProcessPromptAsync()
+    {
+        // given
+        var auditBroker = new Mock<IAuditBroker>();
+
+        StandardAgent agent = AnsweringAgent()
+            .UseAudit(auditBroker.Object);
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "what is the answer?");
+
+        // then
+        auditBroker.Verify(broker =>
+            broker.WriteAsync(It.IsAny<AuditRecord>()),
+                Times.AtLeastOnce);
+    }
+
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -75,6 +75,7 @@ public sealed partial class StandardAgent : IAgent
     private Func<string, string, ValueTask<string>>? localJudgeEvaluate;
     private IMcpBroker? mcpBroker;
     private ILoggingBroker? loggingBroker;
+    private IAuditBroker? auditBroker;
 
     private IAgentCoordinationService? agent;
 
@@ -401,7 +402,7 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="broker">The audit broker to write records to.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent UseAudit(IAuditBroker broker) =>
-        Set(() => { });
+        Set(() => this.auditBroker = broker);
 
     /// <summary>
     /// Sends each decision-log record to your own delegate — the <b>Custom</b> mode (SPEC.md §4.8),
@@ -618,9 +619,10 @@ public sealed partial class StandardAgent : IAgent
                 new TimeBroker(),
                 this.traceVerbosity,
                 string.IsNullOrEmpty(this.logPath) ? null : this.logPath,
-                string.IsNullOrEmpty(this.auditPath)
-                    ? new NotConfiguredAuditBroker()
-                    : new FileAuditBroker(this.auditPath));
+                this.auditBroker
+                    ?? (string.IsNullOrEmpty(this.auditPath)
+                        ? new NotConfiguredAuditBroker()
+                        : new FileAuditBroker(this.auditPath)));
 
         IGeneratorBroker generator =
             this.generatorBroker ?? new GeneratorBroker(

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -412,7 +412,7 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="write">A <c>record =&gt; ...</c> delegate invoked once per record.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent OnAudit(Func<AuditRecord, ValueTask> write) =>
-        Set(() => { });
+        Set(() => this.auditBroker = new FunctionAuditBroker(write));
 
     /// <summary>
     /// Records <b>on whose behalf</b> each run executes. The value is resolved per record, so a

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -76,6 +76,7 @@ public sealed partial class StandardAgent : IAgent
     private IMcpBroker? mcpBroker;
     private ILoggingBroker? loggingBroker;
     private IAuditBroker? auditBroker;
+    private Func<string?>? principalResolver;
 
     private IAgentCoordinationService? agent;
 
@@ -423,7 +424,7 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="principal">A function returning the current principal's identifier.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent Principal(Func<string?> principal) =>
-        Set(() => { });
+        Set(() => this.principalResolver = principal);
 
     /// <summary>
     /// Turns on <b>PII redaction at the brain boundary</b>: before any prompt reaches the brain,
@@ -622,7 +623,8 @@ public sealed partial class StandardAgent : IAgent
                 this.auditBroker
                     ?? (string.IsNullOrEmpty(this.auditPath)
                         ? new NotConfiguredAuditBroker()
-                        : new FileAuditBroker(this.auditPath)));
+                        : new FileAuditBroker(this.auditPath)),
+                this.principalResolver);
 
         IGeneratorBroker generator =
             this.generatorBroker ?? new GeneratorBroker(

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -17,6 +17,7 @@ using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Brokers.Times;
 using Standard.Agents.Brokers.Tools;
 using Standard.Agents.Brokers.Verifiers;
+using Standard.Agents.Models.Brokers.Audits;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Foundations.Brains;
 using Standard.Agents.Models.Loggings;
@@ -387,10 +388,41 @@ public sealed partial class StandardAgent : IAgent
     /// human-readable <see cref="LogTo"/> trace. Always full detail, for ingestion into a SIEM
     /// or telemetry pipeline.
     /// </summary>
-    /// <param name="path">Path to the JSON-lines audit file (created if it does not exist).</param>
+    /// <param name="path">Path to the JSON-lines decision log (created if it does not exist).</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent Audit(string path) =>
         Set(() => this.auditPath = path);
+
+    /// <summary>
+    /// Sends the decision log to a provider — the <b>External</b> mode (SPEC.md §4.8). Install a
+    /// sink package (OpenTelemetry, a SIEM, an append-only store), pass its broker, and nothing
+    /// else about the agent changes.
+    /// </summary>
+    /// <param name="broker">The audit broker to write records to.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent UseAudit(IAuditBroker broker) =>
+        Set(() => { });
+
+    /// <summary>
+    /// Sends each decision-log record to your own delegate — the <b>Custom</b> mode (SPEC.md §4.8),
+    /// for when neither a file nor a provider package fits and authoring a whole broker would be
+    /// disproportionate.
+    /// </summary>
+    /// <param name="write">A <c>record =&gt; ...</c> delegate invoked once per record.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent OnAudit(Func<AuditRecord, ValueTask> write) =>
+        Set(() => { });
+
+    /// <summary>
+    /// Records <b>on whose behalf</b> each run executes. The value is resolved per record, so a
+    /// per-request principal works on a shared agent, and it is stamped on every record of the run
+    /// — the decision log then answers <i>who</i> as well as <i>what</i> (SPEC.md §4.7). Absent,
+    /// records carry no principal.
+    /// </summary>
+    /// <param name="principal">A function returning the current principal's identifier.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Principal(Func<string?> principal) =>
+        Set(() => { });
 
     /// <summary>
     /// Turns on <b>PII redaction at the brain boundary</b>: before any prompt reaches the brain,


### PR DESCRIPTION
Part of Standard.Agents 0.19.0.0 — The Audit Spine. Spec first: implements SPEC.md §3.3 / §4.7 / §4.8, merged as The-Standard-Agent-Specs#10.

Stacked on `users/hassanhabib/BROKERS-logging-update` — merge in order.