### PR TITLE
BROKERS: Insert Audit Record

### DIFF
--- a/Standard.Agents/Brokers/Audits/FileAuditBroker.cs
+++ b/Standard.Agents/Brokers/Audits/FileAuditBroker.cs
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Standard.Agents.Models.Brokers.Audits;
+
+namespace Standard.Agents.Brokers.Audits;
+
+// The decision log's file sink — one JSON object per line (SPEC.md §4.7).
+//
+// The broker owns three sink mechanics and no business flow: it appends, it serializes
+// concurrent writers, and it chains hashes. The chain lives here because only the sink
+// knows what the previous record on THIS sink was.
+//
+// Each write appends and closes rather than holding the file open. A decision log is read
+// while it is being written — by a tail, a shipper, a test — and a retained write handle
+// locks those readers out on Windows. The cost of reopening is paid once per record and
+// buys a sink anything can read at any moment.
+public sealed class FileAuditBroker : IAuditBroker
+{
+    private static readonly JsonSerializerOptions jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private readonly string auditPath;
+    private readonly SemaphoreSlim writeLock = new(initialCount: 1, maxCount: 1);
+
+    private bool chainSeeded;
+    private string? previousHash;
+
+    public FileAuditBroker(string auditPath) =>
+        this.auditPath = Path.GetFullPath(auditPath);
+
+    public async ValueTask WriteAsync(AuditRecord record)
+    {
+        // One writer at a time. Records from concurrent runs may interleave, but a record is
+        // never interleaved into — SPEC.md §4.7.
+        await this.writeLock.WaitAsync();
+
+        try
+        {
+            SeedChain();
+
+            AuditRecord chainedRecord = record with { PreviousHash = this.previousHash };
+            string line = JsonSerializer.Serialize(chainedRecord, jsonOptions);
+
+            // Append, never truncate. This is the durability rule (SPEC.md §4.7); there is
+            // deliberately no code path in this broker that can shorten the sink.
+            await File.AppendAllTextAsync(this.auditPath, line + Environment.NewLine);
+
+            this.previousHash = Hash(line);
+        }
+        finally
+        {
+            this.writeLock.Release();
+        }
+    }
+
+    // Verifies a sink written by this broker: every record's previousHash must equal the hash
+    // of the line before it. Returns the 1-based line number of the first record that does
+    // not, or null when the chain is intact — so a caller can prove a decision log was neither
+    // altered nor truncated (SPEC.md §4.7).
+    public static int? FindBrokenLink(IEnumerable<string> lines)
+    {
+        string? expectedHash = null;
+        int lineNumber = 0;
+
+        foreach (string line in lines)
+        {
+            lineNumber++;
+
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            AuditRecord? record = JsonSerializer.Deserialize<AuditRecord>(line, jsonOptions);
+
+            if (record?.PreviousHash != expectedHash)
+            {
+                return lineNumber;
+            }
+
+            expectedHash = Hash(line);
+        }
+
+        return null;
+    }
+
+    // Continues an existing sink's chain rather than restarting it, so a process restart does
+    // not read as tampering. Done once, on the first write, because the sink may not exist yet
+    // when the broker is constructed.
+    private void SeedChain()
+    {
+        if (this.chainSeeded)
+        {
+            return;
+        }
+
+        this.chainSeeded = true;
+
+        string? directory = Path.GetDirectoryName(this.auditPath);
+
+        if (string.IsNullOrEmpty(directory) is false)
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        if (File.Exists(this.auditPath) is false)
+        {
+            return;
+        }
+
+        string? lastLine = File.ReadLines(this.auditPath)
+            .LastOrDefault(line => string.IsNullOrWhiteSpace(line) is false);
+
+        this.previousHash = lastLine is null ? null : Hash(lastLine);
+    }
+
+    private static string Hash(string line) =>
+        Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(line)));
+}

--- a/Standard.Agents/Brokers/Audits/FunctionAuditBroker.cs
+++ b/Standard.Agents/Brokers/Audits/FunctionAuditBroker.cs
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Audits;
+
+namespace Standard.Agents.Brokers.Audits;
+
+// The Custom mode's substrate: a host-supplied function standing in for a broker, the same
+// shape FunctionGeneratorBroker gives a host-supplied brain.
+public sealed class FunctionAuditBroker : IAuditBroker
+{
+    private readonly Func<AuditRecord, ValueTask> write;
+
+    public FunctionAuditBroker(Func<AuditRecord, ValueTask> write) =>
+        this.write = write;
+
+    public ValueTask WriteAsync(AuditRecord record) =>
+        this.write(record);
+}

--- a/Standard.Agents/Brokers/Audits/IAuditBroker.cs
+++ b/Standard.Agents/Brokers/Audits/IAuditBroker.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Audits;
+
+namespace Standard.Agents.Brokers.Audits;
+
+public interface IAuditBroker
+{
+    ValueTask WriteAsync(AuditRecord record);
+}

--- a/Standard.Agents/Brokers/Audits/NotConfiguredAuditBroker.cs
+++ b/Standard.Agents/Brokers/Audits/NotConfiguredAuditBroker.cs
@@ -1,0 +1,16 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Audits;
+
+namespace Standard.Agents.Brokers.Audits;
+
+// The default. SPEC.md §4.7: absent configuration no decision log is emitted, no
+// sink is touched, and behavior is exactly as if the section did not exist.
+public sealed class NotConfiguredAuditBroker : IAuditBroker
+{
+    public ValueTask WriteAsync(AuditRecord record) =>
+        ValueTask.CompletedTask;
+}

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -3,9 +3,10 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Standard.Agents.Brokers.Audits;
 using Standard.Agents.Brokers.Times;
+using Standard.Agents.Models.Brokers.Audits;
 using Standard.Agents.Models.Loggings;
 
 namespace Standard.Agents.Brokers.Loggings;
@@ -14,10 +15,14 @@ public sealed class LoggingBroker : ILoggingBroker
 {
     private readonly ILogger<LoggingBroker> logger;
     private readonly ITimeBroker timeBroker;
+    private readonly IAuditBroker auditBroker;
     private readonly TraceVerbosity verbosity;
     private readonly string? logPath;
-    private readonly string? auditPath;
+    private readonly Func<string?>? principal;
+
     private int processIndex;
+    private int sequence;
+    private string runId = string.Empty;
     private DateTimeOffset runStart;
 
     public LoggingBroker(
@@ -25,13 +30,15 @@ public sealed class LoggingBroker : ILoggingBroker
         ITimeBroker timeBroker,
         TraceVerbosity verbosity = TraceVerbosity.Full,
         string? logPath = null,
-        string? auditPath = null)
+        IAuditBroker? auditBroker = null,
+        Func<string?>? principal = null)
     {
         this.logger = logger;
         this.timeBroker = timeBroker;
+        this.auditBroker = auditBroker ?? new NotConfiguredAuditBroker();
         this.verbosity = verbosity;
         this.logPath = logPath is null ? null : Path.GetFullPath(logPath);
-        this.auditPath = auditPath is null ? null : Path.GetFullPath(auditPath);
+        this.principal = principal;
     }
 
     public async ValueTask LogInformationAsync(string message) =>
@@ -50,7 +57,7 @@ public sealed class LoggingBroker : ILoggingBroker
     {
         this.logger.LogError(exception, exception.Message);
 
-        await AuditAsync(new { kind = "error", message = exception.Message });
+        await AuditAsync(AuditKind.Error, actor: "Agent", message: exception.Message);
         await EmitAsync($"  → ERROR: {exception.Message.ReplaceLineEndings(" ")}");
     }
 
@@ -58,13 +65,18 @@ public sealed class LoggingBroker : ILoggingBroker
     {
         this.logger.LogCritical(exception, exception.Message);
 
-        await AuditAsync(new { kind = "critical", message = exception.Message });
+        await AuditAsync(AuditKind.Error, actor: "Agent", message: exception.Message);
         await EmitAsync($"  → CRITICAL: {exception.Message.ReplaceLineEndings(" ")}");
     }
 
+    // Starts a run. The human-readable trace is transient and is reset here; the decision
+    // log is durable and MUST NOT be — SPEC.md §4.7 is explicit that this reset does not
+    // propagate to it. Truncating the audit here is exactly the defect this release fixes.
     public async ValueTask LogResetAsync()
     {
         this.processIndex = 0;
+        this.sequence = 0;
+        this.runId = Guid.NewGuid().ToString("n");
         this.runStart = this.timeBroker.GetCurrentDateTimeOffset();
 
         if (this.logPath is not null)
@@ -72,15 +84,12 @@ public sealed class LoggingBroker : ILoggingBroker
             await File.WriteAllTextAsync(this.logPath, string.Empty);
         }
 
-        if (this.auditPath is not null)
-        {
-            await File.WriteAllTextAsync(this.auditPath, string.Empty);
-        }
+        await AuditAsync(AuditKind.Run, actor: "Agent", message: "run started");
     }
 
     public async ValueTask LogTurnAsync(int turn)
     {
-        await AuditAsync(new { kind = "turn", turn });
+        await AuditAsync(AuditKind.Turn, actor: "Agent", message: $"turn {turn}");
 
         await EmitAsync($"{Environment.NewLine}Turn {turn}");
     }
@@ -89,7 +98,7 @@ public sealed class LoggingBroker : ILoggingBroker
     {
         TimeSpan elapsed = this.timeBroker.GetCurrentDateTimeOffset() - this.runStart;
 
-        await AuditAsync(new { kind = "outcome", message, elapsedMs = elapsed.TotalMilliseconds });
+        await AuditAsync(AuditKind.Outcome, actor: "Agent", message: message);
 
         await EmitAsync($"  → {message} ({elapsed.TotalMilliseconds:F0}ms)");
     }
@@ -98,7 +107,7 @@ public sealed class LoggingBroker : ILoggingBroker
     {
         this.processIndex = 0;
 
-        await AuditAsync(new { kind = "step", step = step.ToString() });
+        await AuditAsync(AuditKind.Step, actor: step.ToString(), message: step.ToString());
 
         if (TraceVerbosity.Natures <= this.verbosity)
         {
@@ -108,7 +117,7 @@ public sealed class LoggingBroker : ILoggingBroker
 
     public async ValueTask LogProcessAsync(string actor, string message, bool detail = false)
     {
-        await AuditAsync(new { kind = "process", actor, message, detail });
+        await AuditAsync(AuditKind.Process, actor, message, detail);
 
         TraceVerbosity level = detail ? TraceVerbosity.Full : TraceVerbosity.Natures;
 
@@ -132,12 +141,24 @@ public sealed class LoggingBroker : ILoggingBroker
         }
     }
 
-    private async ValueTask AuditAsync(object record)
+    private async ValueTask AuditAsync(
+        AuditKind kind,
+        string actor,
+        string message,
+        bool detail = false)
     {
-        if (this.auditPath is not null)
+        var record = new AuditRecord
         {
-            await File.AppendAllTextAsync(
-                this.auditPath, JsonSerializer.Serialize(record) + Environment.NewLine);
-        }
+            RunId = this.runId,
+            Sequence = this.sequence++,
+            Timestamp = this.timeBroker.GetCurrentDateTimeOffset(),
+            Kind = kind,
+            Actor = actor,
+            Message = message,
+            Detail = detail,
+            Principal = this.principal?.Invoke()
+        };
+
+        await this.auditBroker.WriteAsync(record);
     }
 }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -5,6 +5,7 @@
 
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging.Abstractions;
+using Standard.Agents.Brokers.Audits;
 using Standard.Agents.Brokers.Classifiers;
 using Standard.Agents.Brokers.Files;
 using Standard.Agents.Brokers.Generators;
@@ -585,7 +586,9 @@ public sealed partial class StandardAgent : IAgent
                 new TimeBroker(),
                 this.traceVerbosity,
                 string.IsNullOrEmpty(this.logPath) ? null : this.logPath,
-                string.IsNullOrEmpty(this.auditPath) ? null : this.auditPath);
+                string.IsNullOrEmpty(this.auditPath)
+                    ? new NotConfiguredAuditBroker()
+                    : new FileAuditBroker(this.auditPath));
 
         IGeneratorBroker generator =
             this.generatorBroker ?? new GeneratorBroker(


### PR DESCRIPTION
Part of Standard.Agents 0.19.0.0 — The Audit Spine. Spec first: implements SPEC.md §3.3 / §4.7 / §4.8, merged as The-Standard-Agent-Specs#10.

Merge in listed order; each unit's diff narrows as its predecessor lands.