### PR TITLE
COORDINATIONS: Run Isolation — One Instance Serves Concurrent Prompts

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/DecisionLogTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/DecisionLogTests.cs
@@ -124,13 +124,73 @@ public class DecisionLogTests : IDisposable
         actualShortenedLink.Should().NotBeNull();
     }
 
-    // Sequential runs only, deliberately. SPEC.md §4.7 also requires that CONCURRENT runs stay
-    // attributable, and this release does not satisfy that: LoggingBroker holds runId and
-    // sequence as instance fields, and one broker is composed per agent, so two prompts in
-    // flight on one instance overwrite each other's run identity. Fixing it moves run identity
-    // out of the broker's state, which is Run Isolation's work — and it is a conformance
-    // prerequisite for the decision log, not an enhancement to it. The concurrency assertion
-    // lands there, with the rest of the isolation guarantee.
+    // SPEC.md §4.4 and §4.7: one instance serves prompts concurrently, records from concurrent
+    // runs MAY interleave in the sink, and every record MUST still be attributable to exactly
+    // one run. This is the assertion that caught run identity living in broker instance fields.
+    [Fact]
+    public async Task ShouldKeepConcurrentRunsAttributableInTheDecisionLogAsync()
+    {
+        // given
+        StandardAgent agent = AnsweringAgent();
+        int expectedRunCount = 64;
+
+        // when — one agent instance, sixty-four prompts in flight at once
+        await Task.WhenAll(Enumerable.Range(0, expectedRunCount).Select(index =>
+            agent.ProcessPromptAsync(prompt: $"question {index}").AsTask()));
+
+        // then
+        string[] actualLines = await File.ReadAllLinesAsync(this.auditPath);
+
+        actualLines.Should().OnlyContain(line => IsParseable(line));
+        actualLines.Select(RunIdOf).Distinct().Should().HaveCount(expectedRunCount);
+
+        foreach (IGrouping<string, string> run in actualLines.GroupBy(RunIdOf))
+        {
+            int[] sequences = run.Select(SequenceOf).ToArray();
+
+            sequences.Should().OnlyHaveUniqueItems();
+            sequences.Should().Contain(0);
+        }
+    }
+
+    // The regression that opened the enterprise plan: with .LogTo and .Audit both on, a single
+    // agent instance failed seven of eight concurrent prompts with an IOException on the sink.
+    // Turning on the enterprise features was exactly what made the agent single-threaded.
+    [Fact]
+    public async Task ShouldServeConcurrentPromptsWithBothSinksConfiguredAsync()
+    {
+        // given
+        string tracePath =
+            Path.Combine(Path.GetTempPath(), $"trace-{Guid.NewGuid():n}.txt");
+
+        StandardAgent agent = AnsweringAgent().LogTo(tracePath);
+        int expectedAnswerCount = 64;
+
+        // when
+        string[] actualAnswers = await Task.WhenAll(
+            Enumerable.Range(0, expectedAnswerCount).Select(index =>
+                agent.ProcessPromptAsync(prompt: $"question {index}").AsTask()));
+
+        // then
+        actualAnswers.Should().HaveCount(expectedAnswerCount);
+        actualAnswers.Should().OnlyContain(answer => answer == "42");
+
+        File.Delete(tracePath);
+    }
+
+    private static bool IsParseable(string line)
+    {
+        try
+        {
+            JsonDocument.Parse(line);
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
 
     public void Dispose()
     {

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -20,10 +20,14 @@ public sealed class LoggingBroker : ILoggingBroker
     private readonly string? logPath;
     private readonly Func<string?>? principal;
 
-    private int processIndex;
-    private int sequence;
-    private string runId = string.Empty;
-    private DateTimeOffset runStart;
+    // No run state lives here. SPEC.md §4.4: run identity and counters are per invocation,
+    // never per instance — one broker serves every concurrent run, so a field here would let
+    // one prompt overwrite another's record. The run is read from the ambient AgentRun that
+    // Coordination begins; the fallback run covers a broker driven outside the loop.
+    private readonly AgentRun fallbackRun = AgentRun.Detached();
+    private readonly SemaphoreSlim traceLock = new(initialCount: 1, maxCount: 1);
+
+    private AgentRun Run => AgentRun.Current ?? this.fallbackRun;
 
     public LoggingBroker(
         ILogger<LoggingBroker> logger,
@@ -74,14 +78,21 @@ public sealed class LoggingBroker : ILoggingBroker
     // propagate to it. Truncating the audit here is exactly the defect this release fixes.
     public async ValueTask LogResetAsync()
     {
-        this.processIndex = 0;
-        this.sequence = 0;
-        this.runId = Guid.NewGuid().ToString("n");
-        this.runStart = this.timeBroker.GetCurrentDateTimeOffset();
+        this.Run.ResetProcessIndex();
+        this.Run.StartedOn = this.timeBroker.GetCurrentDateTimeOffset();
 
         if (this.logPath is not null)
         {
-            await File.WriteAllTextAsync(this.logPath, string.Empty);
+            await this.traceLock.WaitAsync();
+
+            try
+            {
+                await File.WriteAllTextAsync(this.logPath, string.Empty);
+            }
+            finally
+            {
+                this.traceLock.Release();
+            }
         }
 
         await AuditAsync(AuditKind.Run, actor: "Agent", message: "run started");
@@ -96,7 +107,7 @@ public sealed class LoggingBroker : ILoggingBroker
 
     public async ValueTask LogOutcomeAsync(string message)
     {
-        TimeSpan elapsed = this.timeBroker.GetCurrentDateTimeOffset() - this.runStart;
+        TimeSpan elapsed = this.timeBroker.GetCurrentDateTimeOffset() - this.Run.StartedOn;
 
         await AuditAsync(AuditKind.Outcome, actor: "Agent", message: message);
 
@@ -105,7 +116,7 @@ public sealed class LoggingBroker : ILoggingBroker
 
     public async ValueTask LogStepAsync(AgentStep step)
     {
-        this.processIndex = 0;
+        this.Run.ResetProcessIndex();
 
         await AuditAsync(AuditKind.Step, actor: step.ToString(), message: step.ToString());
 
@@ -125,19 +136,36 @@ public sealed class LoggingBroker : ILoggingBroker
         {
             string indented = message.ReplaceLineEndings($"{Environment.NewLine}      ");
 
-            await EmitAsync($"    Process {this.processIndex++}: {actor}: {indented}");
+            await EmitAsync($"    Process {this.Run.NextProcessIndex()}: {actor}: {indented}");
         }
     }
 
+    // The trace is a shared file and one broker serves every concurrent run, so writes are
+    // serialized — without this, sixty-four prompts in flight collide on the handle and most
+    // of them fail with an IOException rather than an answer.
+    //
+    // Concurrent runs interleave in the trace, and each run's reset truncates it. That is the
+    // trace being what SPEC.md §4.7 calls it: transient, a development aid, resettable. The
+    // artifact for a concurrent deployment is the decision log, which is append-only and keeps
+    // every run whole.
     private async ValueTask EmitAsync(string line)
     {
         if (this.logPath is null)
         {
             this.logger.LogInformation(line);
+
+            return;
         }
-        else
+
+        await this.traceLock.WaitAsync();
+
+        try
         {
             await File.AppendAllTextAsync(this.logPath, line + Environment.NewLine);
+        }
+        finally
+        {
+            this.traceLock.Release();
         }
     }
 
@@ -147,10 +175,12 @@ public sealed class LoggingBroker : ILoggingBroker
         string message,
         bool detail = false)
     {
+        AgentRun run = this.Run;
+
         var record = new AuditRecord
         {
-            RunId = this.runId,
-            Sequence = this.sequence++,
+            RunId = run.Id,
+            Sequence = run.NextSequence(),
             Timestamp = this.timeBroker.GetCurrentDateTimeOffset(),
             Kind = kind,
             Actor = actor,

--- a/Standard.Agents/Models/Loggings/AgentRun.cs
+++ b/Standard.Agents/Models/Loggings/AgentRun.cs
@@ -59,6 +59,13 @@ public sealed class AgentRun
         return new Scope(enclosingRun);
     }
 
+    /// <summary>
+    /// A run that is not on any flow — for a trace driven outside the coordination loop, so it
+    /// still numbers its records rather than faulting.
+    /// </summary>
+    public static AgentRun Detached() =>
+        new(Guid.NewGuid().ToString("n"));
+
     /// <summary>The next record number for this run — monotonic, starting at zero.</summary>
     public int NextSequence() =>
         Interlocked.Increment(ref this.sequence) - 1;

--- a/Standard.Agents/Models/Loggings/AgentRun.cs
+++ b/Standard.Agents/Models/Loggings/AgentRun.cs
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Loggings;
+
+/// <summary>
+/// One prompt's run — its identity and its counters. SPEC.md §4.4 requires run state to be
+/// <b>per invocation, never per instance</b>: one agent serves many prompts at once, and an
+/// implementation that keeps a run's identity or counters in shared fields lets a second prompt
+/// silently corrupt the first's record.
+/// </summary>
+/// <remarks>
+/// The run is carried as ambient per-flow state, the pattern .NET itself uses for
+/// <c>Activity.Current</c> in distributed tracing. Coordination calls <see cref="Begin"/> at the
+/// top of a prompt; everything that prompt awaits — every orchestration, foundation and broker
+/// beneath it — reads the same run through <see cref="Current"/>, while a concurrent prompt sees
+/// only its own.
+///
+/// <para>Why ambient rather than a parameter or a context field: the alternative is threading a
+/// run identifier through <c>ILoggingBroker</c> and therefore through all thirteen services that
+/// log, or adding it to <c>AgentContext</c> and making this a model change. Both cost far more
+/// comprehension than they buy, and the loop and the Tri-Nature are supposed to stay the whole
+/// mental model.</para>
+///
+/// <para>The isolation comes from the runtime: mutating an <c>AsyncLocal</c> inside an async
+/// method does not flow back to its caller, so each <c>ProcessPromptAsync</c> invocation gets its
+/// own run even when many are started from the same place.</para>
+/// </remarks>
+public sealed class AgentRun
+{
+    private static readonly AsyncLocal<AgentRun?> current = new();
+
+    private int sequence;
+    private int processIndex;
+
+    private AgentRun(string id) =>
+        Id = id;
+
+    /// <summary>The run active on this flow, or <c>null</c> outside a run.</summary>
+    public static AgentRun? Current => current.Value;
+
+    /// <summary>Identifies exactly one prompt; never reused (SPEC.md §3.3).</summary>
+    public string Id { get; }
+
+    /// <summary>When the run started, stamped by the trace so the run reads one clock.</summary>
+    public DateTimeOffset StartedOn { get; set; }
+
+    /// <summary>
+    /// Starts a run on the calling flow and returns the scope that ends it. Call it from the
+    /// coordination loop, before anything the run should be credited with.
+    /// </summary>
+    public static IDisposable Begin()
+    {
+        AgentRun? enclosingRun = current.Value;
+        current.Value = new AgentRun(Guid.NewGuid().ToString("n"));
+
+        return new Scope(enclosingRun);
+    }
+
+    /// <summary>The next record number for this run — monotonic, starting at zero.</summary>
+    public int NextSequence() =>
+        Interlocked.Increment(ref this.sequence) - 1;
+
+    /// <summary>The next process number within the current step.</summary>
+    public int NextProcessIndex() =>
+        Interlocked.Increment(ref this.processIndex) - 1;
+
+    /// <summary>Restarts process numbering, called when a step begins.</summary>
+    public void ResetProcessIndex() =>
+        Interlocked.Exchange(ref this.processIndex, 0);
+
+    // Restores whatever run was active before, so a nested agent (the fractal — an agent used as
+    // a tool of another agent) returns its caller's run rather than leaving it cleared.
+    private sealed class Scope : IDisposable
+    {
+        private readonly AgentRun? enclosingRun;
+
+        internal Scope(AgentRun? enclosingRun) =>
+            this.enclosingRun = enclosingRun;
+
+        public void Dispose() =>
+            current.Value = this.enclosingRun;
+    }
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -46,6 +46,11 @@ public partial class AgentCoordinationService : IAgentCoordinationService
     {
         ValidatePrompt(prompt);
 
+        // This prompt's run. SPEC.md §4.4: one instance serves prompts concurrently, and each
+        // invocation establishes its own identity, so everything recorded below is credited to
+        // this run and to no other.
+        using IDisposable run = AgentRun.Begin();
+
         await this.loggingBroker.LogResetAsync();
 
         AgentContext context = new() { Prompt = prompt };
@@ -102,6 +107,9 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ValidatePrompt(prompt);
+
+        // This prompt's run — see ProcessPromptAsync. A streamed prompt is a run like any other.
+        using IDisposable run = AgentRun.Begin();
 
         await this.loggingBroker.LogResetAsync();
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -42,6 +42,7 @@ namespace Standard.Agents;
 public sealed partial class StandardAgent : IAgent
 {
     private readonly List<ITool> tools = [];
+    private readonly Lock compositionLock = new();
 
     private string skillsPath = "Skills";
     private string constitutionPath = string.Empty;
@@ -541,9 +542,7 @@ public sealed partial class StandardAgent : IAgent
     // be hit at the assignment, nowhere near the await they were guarding.
     public async ValueTask<string> ProcessPromptAsync(string prompt)
     {
-        this.agent ??= Compose();
-
-        return await this.agent.ProcessPromptAsync(prompt);
+        return await ResolveAgent().ProcessPromptAsync(prompt);
     }
 
     /// <summary>
@@ -560,14 +559,23 @@ public sealed partial class StandardAgent : IAgent
         string prompt,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        this.agent ??= Compose();
-
         IAsyncEnumerable<AgentStreamEvent> events =
-            this.agent.ProcessPromptStreamAsync(prompt, cancellationToken);
+            ResolveAgent().ProcessPromptStreamAsync(prompt, cancellationToken);
 
         await foreach (AgentStreamEvent streamEvent in events.WithCancellation(cancellationToken))
         {
             yield return streamEvent;
+        }
+    }
+
+    // Composes once and reuses. Guarded because one agent serves prompts concurrently
+    // (SPEC.md §4.4) and an unguarded `??=` lets two arriving prompts each build a graph —
+    // two brokers over one audit sink, two of everything, one silently discarded.
+    private IAgentCoordinationService ResolveAgent()
+    {
+        lock (this.compositionLock)
+        {
+            return this.agent ??= Compose();
         }
     }
 
@@ -576,8 +584,11 @@ public sealed partial class StandardAgent : IAgent
     // ignore the change.
     private StandardAgent Set(Action configure)
     {
-        configure();
-        this.agent = null;
+        lock (this.compositionLock)
+        {
+            configure();
+            this.agent = null;
+        }
 
         return this;
     }


### PR DESCRIPTION
Run Isolation, the conformance prerequisite the decision log turned out to need. Spec first: implements SPEC.md §4.4 / §7.4, merged as The-Standard-Agent-Specs#11.

Five commits, one per issue, in dependency order:

| Commit | Category |
|---|---|
| Add Agent Run Model | `DATA` |
| Read Run Identity From The Ambient Run | `MAJOR BROKERS` |
| Establish A Run Per Prompt | `MEDIUM COORDINATIONS` |
| Guard Composition Against Races | `MEDIUM CLIENTS` |
| Concurrent Runs Stay Isolated | `MAJOR ACCEPTANCE` |

## What was wrong

`LoggingBroker` held `runId`, `sequence`, `processIndex` and `runStart` as **instance** fields, and one broker is composed per agent. Two prompts in flight overwrote each other's identity and duplicated sequence numbers. Separately, trace writes and the composition cache were both unguarded.

Measured before: with `.LogTo` and `.Audit` on, **7 of 8** concurrent prompts failed with an `IOException`. Turning on the enterprise features was exactly what made the agent single-threaded.

## What it is now

**64 concurrent prompts on one instance, both sinks on — all 64 answer**, 64 distinct runs, sequences unique within each run.

Run state is carried as an ambient per-flow `AgentRun`, the pattern .NET uses for `Activity.Current`. Chosen over threading a run id through `ILoggingBroker` and its thirteen callers, or adding one to `AgentContext` and making this a model change to the spec core — both cost more comprehension than they buy, and the loop and the Tri-Nature are meant to stay the whole mental model.

291 unit tests, 10/10 conformance vectors, 0 warnings.