### PR TITLE
CONFORMANCE: Vectors, Readiness Profiles And The Capability Matrix Gate

### DIFF
--- a/Standard.Agents.Conformance/Models/Expectation.cs
+++ b/Standard.Agents.Conformance/Models/Expectation.cs
@@ -14,4 +14,17 @@ public sealed record Expectation(
     // from (Excludes) — BOTH the composed Gate rubric AND the composed Judge rubric, since a
     // constitution binds both guardians and a consumption skill replaces the policy in both.
     List<string>? GuardianRubricContains = null,
-    List<string>? GuardianRubricExcludes = null);
+    List<string>? GuardianRubricExcludes = null,
+
+    // Decision-log assertions (SPEC.md §4.7, §4.4), observed through the log's Custom sink so
+    // the certification does not depend on any particular storage.
+    //
+    //   AuditRunCount              — how many distinct runs the log must hold: one per prompt,
+    //                                never fewer. Fewer means runs were merged or discarded.
+    //   AuditRetainsEveryPrompt    — every prompt's evidence must still be present at the end,
+    //                                which is what fails when beginning a run truncates the log.
+    //   AuditSequencesUniquePerRun — within a run the record numbers must not repeat, which is
+    //                                what fails when run counters are shared between runs.
+    int? AuditRunCount = null,
+    bool AuditRetainsEveryPrompt = false,
+    bool AuditSequencesUniquePerRun = false);

--- a/Standard.Agents.Conformance/Models/Profile.cs
+++ b/Standard.Agents.Conformance/Models/Profile.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Conformance;
+
+/// <summary>
+/// A readiness profile: the named set of vectors an implementation must pass to claim it.
+/// Profiles turn "enterprise-ready" from a claim into something a build can fail.
+/// </summary>
+/// <param name="Name">Core, Reliable, Enterprise or Critical.</param>
+/// <param name="Description">What an agent at this profile can be trusted to do.</param>
+/// <param name="Inherits">The profile this one builds on; its requirements apply too.</param>
+/// <param name="Requires">
+/// Vector names that must pass. A named vector that does not exist is a failure, not a skip —
+/// otherwise a profile could be claimed by simply never writing its evidence.
+/// </param>
+public sealed record Profile(
+    string Name,
+    string? Description,
+    string? Inherits,
+    List<string> Requires);

--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -21,4 +21,12 @@ public sealed record Vector(
     string? Constitution = null,
     string? Consumption = null,
     string? GateVerdict = null,
-    string? JudgeScore = null);
+    string? JudgeScore = null,
+
+    // Multi-run vectors. The decision log's durability (SPEC.md §4.7) and run isolation
+    // (§4.4) are only observable across more than one run, so a vector may drive several
+    // prompts through one agent instead of one. Prompts overrides Prompt when present;
+    // Concurrent runs them all at once rather than in order, which is the only way to
+    // certify that one run's bookkeeping never leaks into another's.
+    List<string>? Prompts = null,
+    bool Concurrent = false);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -6,6 +6,7 @@
 using System.Text.Json;
 using Standard.Agents;
 using Standard.Agents.Conformance;
+using Standard.Agents.Models.Brokers.Audits;
 
 string vectorsPath = args.Length > 0
     ? args[0]
@@ -45,7 +46,10 @@ foreach (string vectorFile in
     bool rubricConformant =
         RubricConformant(vector.Expect, run.GateRubric, run.JudgeRubric, out string? rubricFailure);
 
-    if (resultConformant && toolInputConformant && rubricConformant)
+    bool auditConformant =
+        AuditConformant(vector, run.AuditRecords, out string? auditFailure);
+
+    if (resultConformant && toolInputConformant && rubricConformant && auditConformant)
     {
         passed++;
         Console.WriteLine($"PASS  {vector.Name}");
@@ -84,6 +88,15 @@ foreach (string vectorFile in
             Console.WriteLine($"        gate rubric:  {Show(run.GateRubric ?? "(gate never ran)")}");
             Console.WriteLine($"        judge rubric: {Show(run.JudgeRubric ?? "(judge never ran)")}");
         }
+
+        if (auditConformant is false)
+        {
+            Console.WriteLine($"        decision log: {auditFailure}");
+
+            Console.WriteLine(
+                $"        records: {run.AuditRecords.Count} "
+                    + $"across {run.AuditRecords.Select(record => record.RunId).Distinct().Count()} run(s)");
+        }
     }
 }
 
@@ -107,6 +120,12 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     string? gateRubric = null;
     string? judgeRubric = null;
 
+    // The decision log is observed through its own Custom sink (SPEC.md §4.8), so the
+    // certification watches the records the framework produces rather than any storage.
+    // Concurrent vectors write from many runs at once, hence the lock.
+    List<AuditRecord> auditRecords = [];
+    object auditLock = new();
+
     StandardAgent agent = new StandardAgent()
         .UseSkills(new StubSkillBroker())
         .UseGenerator(new ScriptedGeneratorBroker(vector.GeneratorReplies))
@@ -125,6 +144,15 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
             judgeRubric = rubric;
 
             return new ValueTask<string>(vector.JudgeScore ?? "1.0");
+        })
+        .OnAudit(record =>
+        {
+            lock (auditLock)
+            {
+                auditRecords.Add(record);
+            }
+
+            return ValueTask.CompletedTask;
         });
 
     if (string.IsNullOrEmpty(vector.Constitution) is false)
@@ -141,9 +169,96 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         agent.Consumption(fileName);
     }
 
-    string result = await agent.ProcessPromptAsync(vector.Prompt);
+    IReadOnlyList<string> prompts = vector.Prompts is { Count: > 0 }
+        ? vector.Prompts
+        : [vector.Prompt];
 
-    return new VectorRun(result, stubTools, gateRubric, judgeRubric);
+    string result;
+
+    if (vector.Concurrent)
+    {
+        string[] results = await Task.WhenAll(
+            prompts.Select(prompt => agent.ProcessPromptAsync(prompt).AsTask()));
+
+        result = results[0];
+    }
+    else
+    {
+        result = string.Empty;
+
+        foreach (string prompt in prompts)
+        {
+            result = await agent.ProcessPromptAsync(prompt);
+        }
+    }
+
+    return new VectorRun(result, stubTools, gateRubric, judgeRubric, auditRecords);
+}
+
+// The decision log's guarantees, certified from the records themselves: one run per prompt,
+// every prompt's evidence still present at the end, and record numbers that never repeat
+// within a run (SPEC.md §4.7, §4.4).
+static bool AuditConformant(Vector vector, List<AuditRecord> records, out string? failure)
+{
+    failure = null;
+
+    Expectation expect = vector.Expect;
+
+    if (expect.AuditRunCount is null
+        && expect.AuditRetainsEveryPrompt is false
+        && expect.AuditSequencesUniquePerRun is false)
+    {
+        return true;
+    }
+
+    IReadOnlyList<string> prompts = vector.Prompts is { Count: > 0 }
+        ? vector.Prompts
+        : [vector.Prompt];
+
+    if (expect.AuditRunCount is int expectedRunCount)
+    {
+        int actualRunCount = records.Select(record => record.RunId).Distinct().Count();
+
+        if (actualRunCount != expectedRunCount)
+        {
+            failure = $"expected {expectedRunCount} distinct run(s), found {actualRunCount}";
+
+            return false;
+        }
+    }
+
+    if (expect.AuditRetainsEveryPrompt)
+    {
+        foreach (string prompt in prompts)
+        {
+            bool retained = records.Any(record =>
+                record.Message.Contains(prompt, StringComparison.Ordinal));
+
+            if (retained is false)
+            {
+                failure = $"no record retained evidence of the prompt {Show(prompt)}";
+
+                return false;
+            }
+        }
+    }
+
+    if (expect.AuditSequencesUniquePerRun)
+    {
+        foreach (IGrouping<string, AuditRecord> run in records.GroupBy(record => record.RunId))
+        {
+            int[] sequences = run.Select(record => record.Sequence).ToArray();
+
+            if (sequences.Length != sequences.Distinct().Count())
+            {
+                failure = $"run '{run.Key}' repeated a record number — runs shared a counter";
+
+                return false;
+            }
+        }
+    }
+
+    return true;
 }
 
 // A rubric guarantee is certified against BOTH guardians, so both rubrics must have been
@@ -219,4 +334,5 @@ internal sealed record VectorRun(
     string Result,
     Dictionary<string, StubTool> Tools,
     string? GateRubric,
-    string? JudgeRubric);
+    string? JudgeRubric,
+    List<AuditRecord> AuditRecords);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -8,9 +8,16 @@ using Standard.Agents;
 using Standard.Agents.Conformance;
 using Standard.Agents.Models.Brokers.Audits;
 
-string vectorsPath = args.Length > 0
-    ? args[0]
-    : Path.Combine(FindRepositoryRoot(), "conformance", "vectors");
+string? profileName = ReadProfileArgument(args);
+
+// Drop the flag and the value it consumed, so an optional vectors path stays positional.
+string[] positionalArgs = [.. PositionalArguments(args)];
+
+string conformanceRoot = Path.Combine(FindRepositoryRoot(), "conformance");
+
+string vectorsPath = positionalArgs.Length > 0
+    ? positionalArgs[0]
+    : Path.Combine(conformanceRoot, "vectors");
 
 JsonSerializerOptions jsonOptions = new()
 {
@@ -18,10 +25,17 @@ JsonSerializerOptions jsonOptions = new()
 };
 
 Console.WriteLine($"Conformance vectors: {vectorsPath}");
+
+if (profileName is not null)
+{
+    Console.WriteLine($"Certifying profile: {profileName}");
+}
+
 Console.WriteLine();
 
 int passed = 0;
 int failed = 0;
+HashSet<string> passedVectors = new(StringComparer.OrdinalIgnoreCase);
 
 foreach (string vectorFile in
     Directory.EnumerateFiles(vectorsPath, "*.json").OrderBy(path => path, StringComparer.Ordinal))
@@ -52,6 +66,7 @@ foreach (string vectorFile in
     if (resultConformant && toolInputConformant && rubricConformant && auditConformant)
     {
         passed++;
+        passedVectors.Add(vector.Name);
         Console.WriteLine($"PASS  {vector.Name}");
     }
     else
@@ -103,7 +118,37 @@ foreach (string vectorFile in
 Console.WriteLine();
 Console.WriteLine($"{passed} passed, {failed} failed");
 
-return failed == 0 ? 0 : 1;
+if (profileName is null)
+{
+    return failed == 0 ? 0 : 1;
+}
+
+// Certifying a profile is a separate question from running the vectors: not "did everything
+// we happen to have pass" but "is every requirement of this level actually evidenced". A
+// requirement whose vector does not exist fails — otherwise a profile could be claimed by
+// never writing its evidence, which is the failure mode profiles exist to prevent.
+List<string> missing =
+    ProfileRequirements(profileName, Path.Combine(conformanceRoot, "profiles"), jsonOptions)
+        .Where(requirement => passedVectors.Contains(requirement) is false)
+        .ToList();
+
+Console.WriteLine();
+
+if (missing.Count == 0)
+{
+    Console.WriteLine($"CERTIFIED  {profileName}");
+
+    return failed == 0 ? 0 : 1;
+}
+
+Console.WriteLine($"NOT CERTIFIED  {profileName} — {missing.Count} requirement(s) unmet:");
+
+foreach (string requirement in missing)
+{
+    Console.WriteLine($"  - {requirement}");
+}
+
+return 1;
 
 async Task<VectorRun> RunVectorAsync(Vector vector)
 {
@@ -309,6 +354,62 @@ static bool RubricConformant(
     }
 
     return true;
+}
+
+static string? ReadProfileArgument(string[] args)
+{
+    int index = Array.FindIndex(args, argument =>
+        argument.Equals("--profile", StringComparison.OrdinalIgnoreCase));
+
+    return index >= 0 && index + 1 < args.Length
+        ? args[index + 1]
+        : null;
+}
+
+static IEnumerable<string> PositionalArguments(string[] args)
+{
+    for (int index = 0; index < args.Length; index++)
+    {
+        if (args[index].Equals("--profile", StringComparison.OrdinalIgnoreCase))
+        {
+            index++;
+
+            continue;
+        }
+
+        yield return args[index];
+    }
+}
+
+// A profile's requirements are its own plus everything it inherits, so certifying Reliable
+// certifies Core too — a level is a floor, never a substitute.
+static List<string> ProfileRequirements(
+    string profileName,
+    string profilesPath,
+    JsonSerializerOptions jsonOptions)
+{
+    List<string> requirements = [];
+    string? nextProfileName = profileName;
+
+    while (nextProfileName is not null)
+    {
+        string profileFile =
+            Path.Combine(profilesPath, $"{nextProfileName.ToLowerInvariant()}.json");
+
+        if (File.Exists(profileFile) is false)
+        {
+            throw new FileNotFoundException(
+                $"No such readiness profile: '{nextProfileName}'. Expected {profileFile}.");
+        }
+
+        Profile profile =
+            JsonSerializer.Deserialize<Profile>(File.ReadAllText(profileFile), jsonOptions)!;
+
+        requirements.AddRange(profile.Requires);
+        nextProfileName = profile.Inherits;
+    }
+
+    return [.. requirements.Distinct(StringComparer.OrdinalIgnoreCase)];
 }
 
 static string Show(string value) =>

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Capabilities.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Capabilities.cs
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+// SPEC.md §4.8: every capability MUST be reachable three ways — Local (in the core, point at a
+// resource), External (a provider package, passed as a broker) and Custom (host-authored code).
+//
+// This is the principle most likely to erode quietly: nothing about adding a capability with one
+// mode fails a build, and by the time anyone notices there are six of them. So it is a test
+// rather than a convention. A missing mode is a build failure; a mode that genuinely does not
+// apply is waived here, in code, with its reason — which makes waiving it a reviewed change
+// rather than an omission nobody sees.
+public class StandardAgentCapabilityTests
+{
+    private sealed record Capability(
+        string Name,
+        string Local,
+        string External,
+        string Custom,
+        string? Waiver = null);
+
+    // The matrix. Every capability the agent exposes, and the method that reaches it each way.
+    private static readonly Capability[] capabilities =
+    [
+        new("Skills", Local: "Skills", External: "UseSkills", Custom: "OnSkills",
+            Waiver: "Custom pending: ISkillBroker is the override until a delegate form lands"),
+
+        new("Memory", Local: "Memory", External: "UseMemory", Custom: "OnMemory",
+            Waiver: "Custom pending: IMemoryBroker is the override until a delegate form lands"),
+
+        new("Knowledge", Local: "Knowledge", External: "UseKnowledge", Custom: "OnKnowledge",
+            Waiver: "Custom pending: IKnowledgeBroker is the override until a delegate form lands"),
+
+        new("Brain", Local: "Brain", External: "UseGenerator", Custom: "OnBrain"),
+
+        new("Gate", Local: "RuleGate", External: "Gate", Custom: "OnGate"),
+
+        new("Judge", Local: "RuleJudge", External: "Judge", Custom: "OnJudge"),
+
+        new("Tools", Local: "Tool", External: "Mcp", Custom: "Tool"),
+
+        new("Trace", Local: "LogTo", External: "UseLogging", Custom: "UseLogging"),
+
+        new("Audit", Local: "Audit", External: "UseAudit", Custom: "OnAudit")
+    ];
+
+    private static readonly string[] publicMethodNames =
+        [.. typeof(StandardAgent)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Select(method => method.Name)
+            .Distinct()];
+
+    public static TheoryData<string, string, string> UnwaivedModes()
+    {
+        var modes = new TheoryData<string, string, string>();
+
+        foreach (Capability capability in capabilities)
+        {
+            modes.Add(capability.Name, "Local", capability.Local);
+            modes.Add(capability.Name, "External", capability.External);
+
+            if (capability.Waiver is null)
+            {
+                modes.Add(capability.Name, "Custom", capability.Custom);
+            }
+        }
+
+        return modes;
+    }
+
+    [Theory]
+    [MemberData(nameof(UnwaivedModes))]
+    public void ShouldExposeEveryCapabilityLocalExternalAndCustom(
+        string capabilityName,
+        string mode,
+        string expectedMethodName)
+    {
+        // given, when, then
+        publicMethodNames.Should().Contain(
+            expectedMethodName,
+            because: $"{capabilityName} must be reachable {mode} through .{expectedMethodName}(...) "
+                + "— SPEC.md §4.8 makes a capability with a missing mode incomplete");
+    }
+
+    // The waiver list is the plan's outstanding debt, and it must reach zero by the release that
+    // completes the capability matrix. Pinning the count means retiring a waiver is a deliberate
+    // edit here, and adding one to a NEW capability fails immediately rather than quietly.
+    [Fact]
+    public void ShouldWaiveNoMoreCapabilityModesThanTheMatrixAllows()
+    {
+        // given
+        int expectedWaiverCount = 3;
+
+        // when
+        Capability[] actualWaived =
+            [.. capabilities.Where(capability => capability.Waiver is not null)];
+
+        // then
+        actualWaived.Should().HaveCount(
+            expectedWaiverCount,
+            because: "every waiver is debt against SPEC.md §4.8 and must be retired, "
+                + "and no new capability may ship with one");
+
+        actualWaived.Should().OnlyContain(capability =>
+            string.IsNullOrWhiteSpace(capability.Waiver) == false);
+    }
+}

--- a/conformance/profiles/core.json
+++ b/conformance/profiles/core.json
@@ -1,0 +1,12 @@
+{
+  "name": "Core",
+  "description": "The minimal viable agent (SPEC.md 8.1): the loop, skills, a brain, local tools, a return, and the reply protocol. Guardians may be pass-through.",
+  "requires": [
+    "direct-answer",
+    "tool-then-final",
+    "first-line-action-only",
+    "multiline-final",
+    "unknown-tool-recovers",
+    "max-turns-cap"
+  ]
+}

--- a/conformance/profiles/critical.json
+++ b/conformance/profiles/critical.json
@@ -1,0 +1,11 @@
+{
+  "name": "Critical",
+  "description": "Enterprise, plus conversation that survives a process, effects that can be unwound, and adversarial evaluation. The level a wire transfer needs.",
+  "inherits": "Enterprise",
+  "requires": [
+    "conversation-carries-history",
+    "native-tool-call-round-trips",
+    "awaiting-input-resumes-in-a-new-process",
+    "effect-outcome-survives-a-crash"
+  ]
+}

--- a/conformance/profiles/enterprise.json
+++ b/conformance/profiles/enterprise.json
@@ -1,0 +1,14 @@
+{
+  "name": "Enterprise",
+  "description": "Reliable, plus a perimeter that assumes everything crossing it is hostile, effects that cannot happen twice, identity-aware authorization, budgets, and retrieval that actually retrieves.",
+  "inherits": "Reliable",
+  "requires": [
+    "approval-blocks-irreversible-tool",
+    "injected-instruction-in-tool-output-is-refused",
+    "duplicate-effect-executes-once",
+    "budget-stops-the-loop",
+    "guardian-screens-once-per-prompt",
+    "open-circuit-falls-back-to-secondary",
+    "knowledge-retrieves-by-relevance"
+  ]
+}

--- a/conformance/profiles/reliable.json
+++ b/conformance/profiles/reliable.json
@@ -1,0 +1,18 @@
+{
+  "name": "Reliable",
+  "description": "Core, plus guardians that can see what they guard, a durable decision log, run isolation, cancellation and timeouts. The first level at which a deployment can be trusted to explain itself. Requirements without a vector yet are listed on purpose: a level is earned by evidence, and naming the evidence before it exists is what stops the level being claimed early.",
+  "inherits": "Core",
+  "requires": [
+    "structured-tool-call",
+    "gate-refusal-short-circuits",
+    "constitution-binds-guardians",
+    "consumption-replaces-policy",
+    "audit-retains-every-run",
+    "concurrent-runs-are-isolated",
+    "judge-receives-the-task",
+    "redaction-covers-every-model-call",
+    "guardian-overreach-is-neutralized",
+    "cancellation-stops-the-loop",
+    "transient-failure-recovers"
+  ]
+}

--- a/conformance/vectors/11-audit-retains-every-run.json
+++ b/conformance/vectors/11-audit-retains-every-run.json
@@ -1,0 +1,13 @@
+{
+  "name": "audit-retains-every-run",
+  "description": "SPEC.md 4.7: the decision log is append-only. Beginning a run MUST NOT discard prior records, and the trace reset MUST NOT propagate to it. Two prompts through one agent therefore leave two runs of evidence, each under its own runId, with the first prompt still recoverable after the second has run.",
+  "generatorReplies": ["FINAL: done"],
+  "tools": {},
+  "prompt": "the ALPHA question",
+  "prompts": ["the ALPHA question", "the BRAVO question"],
+  "expect": {
+    "result": "done",
+    "auditRunCount": 2,
+    "auditRetainsEveryPrompt": true
+  }
+}

--- a/conformance/vectors/12-concurrent-runs-are-isolated.json
+++ b/conformance/vectors/12-concurrent-runs-are-isolated.json
@@ -1,0 +1,24 @@
+{
+  "name": "concurrent-runs-are-isolated",
+  "description": "SPEC.md 4.4: one instance serves prompts concurrently, and each invocation establishes its own run identity. Eight prompts in flight at once produce eight distinct runs whose records never share a number, which is what fails when run identity or counters live in instance state rather than per invocation.",
+  "generatorReplies": ["FINAL: done"],
+  "tools": {},
+  "prompt": "question 0",
+  "prompts": [
+    "question 0",
+    "question 1",
+    "question 2",
+    "question 3",
+    "question 4",
+    "question 5",
+    "question 6",
+    "question 7"
+  ],
+  "concurrent": true,
+  "expect": {
+    "result": "done",
+    "auditRunCount": 8,
+    "auditRetainsEveryPrompt": true,
+    "auditSequencesUniquePerRun": true
+  }
+}


### PR DESCRIPTION
The four items the audit spine and run isolation shipped without. All three are **enforcement** — the mechanisms that stop the remaining principles eroding quietly — so they land before the next release rather than after it.

## Conformance vectors 11 and 12

The xUnit suite proves the C# works; a vector proves the *contract*, and the contract is what another language implements. Vector 11 certifies SPEC §4.7 (two prompts leave two runs of evidence), vector 12 certifies §4.4 (eight concurrent prompts, eight runs, no shared record numbers).

The runner gains only what those need: a vector may drive several prompts through one agent, in order or all at once, and may assert on the decision log — observed through its own **Custom sink**, so certification watches records rather than storage.

**Verified non-vacuous:** reintroducing the defect fails both vectors; reverting passes them.

## Readiness profiles + `--profile`

Four levels, each inheriting the one below. A requirement whose vector doesn't exist counts as **unmet, not skipped** — otherwise a level could be claimed by never writing its evidence.

```
--profile Core       CERTIFIED                                    exit 0
--profile Reliable   NOT CERTIFIED — 5 requirement(s) unmet       exit 1
                       - judge-receives-the-task
                       - redaction-covers-every-model-call
                       - guardian-overreach-is-neutralized
                       - cancellation-stops-the-loop
                       - transient-failure-recovers
```

My first draft of `reliable.json` listed only what already passed, and cheerfully certified Reliable. That is the same self-congratulation profiles exist to prevent, so the levels now name their evidence ahead of building it.

## Capability matrix gate

`ShouldExposeEveryCapabilityLocalExternalAndCustom` reflects over the public surface and fails the build on a missing mode. Three modes are waived with their reason **in code**, and the waiver count is pinned — so retiring one is deliberate, and a new capability cannot ship with a waiver at all.

316 unit tests · 12/12 vectors · 0 warnings.