### PR TITLE
MAJOR FOUNDATIONS: Evaluate The Answer Against Its Task

### DIFF
--- a/Standard.Agents.Conformance/Models/Expectation.cs
+++ b/Standard.Agents.Conformance/Models/Expectation.cs
@@ -27,4 +27,12 @@ public sealed record Expectation(
     //                                what fails when run counters are shared between runs.
     int? AuditRunCount = null,
     bool AuditRetainsEveryPrompt = false,
-    bool AuditSequencesUniquePerRun = false);
+    bool AuditSequencesUniquePerRun = false,
+
+    // Guardian-input assertions (SPEC.md §4.2, §7.6).
+    //
+    //   JudgeSawTask         — the task must have reached the Judge, not the candidate alone.
+    //   GuardianNeverAnswers — a guardian that tries to answer or act must be neutralized, and
+    //                          its text must never become the agent's result.
+    bool JudgeSawTask = false,
+    bool GuardianNeverAnswers = false);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -63,7 +63,14 @@ foreach (string vectorFile in
     bool auditConformant =
         AuditConformant(vector, run.AuditRecords, out string? auditFailure);
 
-    if (resultConformant && toolInputConformant && rubricConformant && auditConformant)
+    bool guardianInputConformant =
+        GuardianInputConformant(vector, run, actualResult, out string? guardianFailure);
+
+    if (resultConformant
+        && toolInputConformant
+        && rubricConformant
+        && auditConformant
+        && guardianInputConformant)
     {
         passed++;
         passedVectors.Add(vector.Name);
@@ -102,6 +109,12 @@ foreach (string vectorFile in
             Console.WriteLine($"        guardian rubric: {rubricFailure}");
             Console.WriteLine($"        gate rubric:  {Show(run.GateRubric ?? "(gate never ran)")}");
             Console.WriteLine($"        judge rubric: {Show(run.JudgeRubric ?? "(judge never ran)")}");
+        }
+
+        if (guardianInputConformant is false)
+        {
+            Console.WriteLine($"        guardian input: {guardianFailure}");
+            Console.WriteLine($"        judge input: {Show(run.JudgeInput ?? "(judge never ran)")}");
         }
 
         if (auditConformant is false)
@@ -164,6 +177,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     // no guardian fields behaves exactly as an always-allowing gate and an always-approving judge.
     string? gateRubric = null;
     string? judgeRubric = null;
+    string? judgeInput = null;
 
     // The decision log is observed through its own Custom sink (SPEC.md §4.8), so the
     // certification watches the records the framework produces rather than any storage.
@@ -187,6 +201,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         .OnJudge((rubric, candidate) =>
         {
             judgeRubric = rubric;
+            judgeInput = candidate;
 
             return new ValueTask<string>(vector.JudgeScore ?? "1.0");
         })
@@ -237,7 +252,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         }
     }
 
-    return new VectorRun(result, stubTools, gateRubric, judgeRubric, auditRecords);
+    return new VectorRun(result, stubTools, gateRubric, judgeRubric, judgeInput, auditRecords);
 }
 
 // The decision log's guarantees, certified from the records themselves: one run per prompt,
@@ -356,6 +371,44 @@ static bool RubricConformant(
     return true;
 }
 
+// What a guardian was allowed to see, and what it was not allowed to become (SPEC.md §4.2, §7.6).
+static bool GuardianInputConformant(
+    Vector vector,
+    VectorRun run,
+    string actualResult,
+    out string? failure)
+{
+    failure = null;
+
+    if (vector.Expect.JudgeSawTask)
+    {
+        if (run.JudgeInput is null)
+        {
+            failure = "the judge never ran, so it cannot have seen the task";
+
+            return false;
+        }
+
+        if (run.JudgeInput.Contains(vector.Prompt, StringComparison.Ordinal) is false)
+        {
+            failure = $"the judge never saw the task {Show(vector.Prompt)}";
+
+            return false;
+        }
+    }
+
+    if (vector.Expect.GuardianNeverAnswers
+        && vector.GateVerdict is not null
+        && actualResult.Contains(vector.GateVerdict, StringComparison.Ordinal))
+    {
+        failure = "the guardian's own text became the agent's answer";
+
+        return false;
+    }
+
+    return true;
+}
+
 static string? ReadProfileArgument(string[] args)
 {
     int index = Array.FindIndex(args, argument =>
@@ -436,4 +489,5 @@ internal sealed record VectorRun(
     Dictionary<string, StubTool> Tools,
     string? GateRubric,
     string? JudgeRubric,
+    string? JudgeInput,
     List<AuditRecord> AuditRecords);

--- a/Standard.Agents.Tests.Unit/Acceptance/TraceAuditTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/TraceAuditTests.cs
@@ -52,7 +52,7 @@ public class TraceAuditTests
         var gate = new Mock<IClassifierBroker>();
         gate.Setup(broker => broker.ClassifyAsync(It.IsAny<string>())).ReturnsAsync("accept");
         var judge = new Mock<IVerifierBroker>();
-        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>())).ReturnsAsync("1.0");
+        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("1.0");
 
         var agent = new StandardAgent()
             .UseGenerator(generator.Object)

--- a/Standard.Agents.Tests.Unit/Acceptance/TraceMetricsTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/TraceMetricsTests.cs
@@ -54,7 +54,7 @@ public class TraceMetricsTests
         var gate = new Mock<IClassifierBroker>();
         gate.Setup(broker => broker.ClassifyAsync(It.IsAny<string>())).ReturnsAsync("accept");
         var judge = new Mock<IVerifierBroker>();
-        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>())).ReturnsAsync("1.0");
+        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("1.0");
 
         var agent = new StandardAgent()
             .UseGenerator(generator.Object)

--- a/Standard.Agents.Tests.Unit/Acceptance/TraceTranscriptTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/TraceTranscriptTests.cs
@@ -58,7 +58,7 @@ public class TraceTranscriptTests
         gate.Setup(broker => broker.ClassifyAsync(It.IsAny<string>())).ReturnsAsync("allow");
 
         var judge = new Mock<IVerifierBroker>();
-        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>())).ReturnsAsync("1.0");
+        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("1.0");
 
         return new StandardAgent()
             .UseGenerator(generator.Object)

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -42,7 +42,7 @@ public class StandardAgentTests
             .ReturnsAsync("allow");
 
         var verifierBroker = new Mock<IVerifierBroker>();
-        verifierBroker.Setup(broker => broker.VerifyAsync(It.IsAny<string>()))
+        verifierBroker.Setup(broker => broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync("1.0");
 
         var mcpBroker = new Mock<IMcpBroker>();
@@ -177,7 +177,7 @@ public class StandardAgentTests
             .ReturnsAsync("allow");
 
         var verifierBroker = new Mock<IVerifierBroker>();
-        verifierBroker.Setup(broker => broker.VerifyAsync(It.IsAny<string>()))
+        verifierBroker.Setup(broker => broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync("1.0");
 
         var skillBroker = new Mock<ISkillBroker>();
@@ -248,7 +248,7 @@ public class StandardAgentTests
             .ReturnsAsync("allow");
 
         var judge = new Mock<IVerifierBroker>();
-        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>()))
+        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync("1.0");
 
         var memory = new Mock<IMemoryBroker>();
@@ -290,7 +290,7 @@ public class StandardAgentTests
             .ReturnsAsync("allow");
 
         var judge = new Mock<IVerifierBroker>();
-        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>()))
+        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync("1.0");
 
         var memory = new Mock<IMemoryBroker>();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Logic.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Logic.Evaluate.cs
@@ -25,18 +25,45 @@ public partial class JudgeServiceTests
         double expectedScore = score;
 
         this.verifierBrokerMock.Setup(broker =>
-            broker.VerifyAsync(randomCandidate))
+            broker.VerifyAsync(It.IsAny<string>(), randomCandidate))
                 .ReturnsAsync(verdict);
 
         // when
         Judgement actualJudgement =
-            await this.judgeService.EvaluateAsync(randomCandidate);
+            await this.judgeService.EvaluateAsync(CreateRandomString(), randomCandidate);
 
         // then
         actualJudgement.Score.Should().Be(expectedScore);
 
         this.verifierBrokerMock.Verify(broker =>
-            broker.VerifyAsync(randomCandidate),
+            broker.VerifyAsync(It.IsAny<string>(), randomCandidate),
+                Times.Once);
+
+        this.verifierBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // SPEC.md §4.2: an answer is good or bad FOR a question. A Judge handed only the candidate
+    // scores a fit it cannot see, and the failure is silent — it still returns a plausible
+    // number, still rejects, and still spends a turn of the loop's budget on a revision it
+    // could not have reasoned about.
+    [Fact]
+    public async Task ShouldPassTheTaskToTheVerifierOnEvaluateAsync()
+    {
+        // given
+        string randomTask = CreateRandomString();
+        string randomCandidate = CreateRandomString();
+
+        this.verifierBrokerMock.Setup(broker =>
+            broker.VerifyAsync(randomTask, randomCandidate))
+                .ReturnsAsync("1.0");
+
+        // when
+        await this.judgeService.EvaluateAsync(randomTask, randomCandidate);
+
+        // then
+        this.verifierBrokerMock.Verify(broker =>
+            broker.VerifyAsync(randomTask, randomCandidate),
                 Times.Once);
 
         this.verifierBrokerMock.VerifyNoOtherCalls();
@@ -54,18 +81,18 @@ public partial class JudgeServiceTests
         string randomCandidate = CreateRandomString();
 
         this.verifierBrokerMock.Setup(broker =>
-            broker.VerifyAsync(randomCandidate))
+            broker.VerifyAsync(It.IsAny<string>(), randomCandidate))
                 .ReturnsAsync(verdict);
 
         // when
         Judgement actualJudgement =
-            await this.judgeService.EvaluateAsync(randomCandidate);
+            await this.judgeService.EvaluateAsync(CreateRandomString(), randomCandidate);
 
         // then
         actualJudgement.Score.Should().Be(expectedScore);
 
         this.verifierBrokerMock.Verify(broker =>
-            broker.VerifyAsync(randomCandidate),
+            broker.VerifyAsync(It.IsAny<string>(), randomCandidate),
                 Times.Once);
 
         this.verifierBrokerMock.VerifyNoOtherCalls();
@@ -80,19 +107,19 @@ public partial class JudgeServiceTests
         string verdict = "SCORE: 0.4\nREASON: it never states the year";
 
         this.verifierBrokerMock.Setup(broker =>
-            broker.VerifyAsync(randomCandidate))
+            broker.VerifyAsync(It.IsAny<string>(), randomCandidate))
                 .ReturnsAsync(verdict);
 
         // when
         Judgement actualJudgement =
-            await this.judgeService.EvaluateAsync(randomCandidate);
+            await this.judgeService.EvaluateAsync(CreateRandomString(), randomCandidate);
 
         // then
         actualJudgement.Score.Should().Be(0.4);
         actualJudgement.Reason.Should().Be("it never states the year");
 
         this.verifierBrokerMock.Verify(broker =>
-            broker.VerifyAsync(randomCandidate),
+            broker.VerifyAsync(It.IsAny<string>(), randomCandidate),
                 Times.Once);
 
         this.verifierBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Validations.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Validations.Evaluate.cs
@@ -33,7 +33,7 @@ public partial class JudgeServiceTests
 
         // when
         ValueTask<Judgement> evaluateTask =
-            this.judgeService.EvaluateAsync(invalidCandidate!);
+            this.judgeService.EvaluateAsync(CreateRandomString(), invalidCandidate!);
 
         JudgeValidationException actualJudgeValidationException =
             await Assert.ThrowsAsync<JudgeValidationException>(
@@ -49,7 +49,7 @@ public partial class JudgeServiceTests
                     Times.Once);
 
         this.verifierBrokerMock.Verify(broker =>
-            broker.VerifyAsync(It.IsAny<string>()),
+            broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()),
                 Times.Never);
 
         this.verifierBrokerMock.VerifyNoOtherCalls();
@@ -79,12 +79,12 @@ public partial class JudgeServiceTests
                 innerException: invalidJudgeScoreException);
 
         this.verifierBrokerMock.Setup(broker =>
-            broker.VerifyAsync(randomCandidate))
+            broker.VerifyAsync(It.IsAny<string>(), randomCandidate))
                 .ReturnsAsync(nonNumericVerdict!);
 
         // when
         ValueTask<Judgement> evaluateTask =
-            this.judgeService.EvaluateAsync(randomCandidate);
+            this.judgeService.EvaluateAsync(CreateRandomString(), randomCandidate);
 
         JudgeValidationException actualJudgeValidationException =
             await Assert.ThrowsAsync<JudgeValidationException>(
@@ -95,7 +95,7 @@ public partial class JudgeServiceTests
             .BeEquivalentTo(expectedJudgeValidationException);
 
         this.verifierBrokerMock.Verify(broker =>
-            broker.VerifyAsync(randomCandidate),
+            broker.VerifyAsync(It.IsAny<string>(), randomCandidate),
                 Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>
@@ -129,12 +129,12 @@ public partial class JudgeServiceTests
                 innerException: invalidJudgeScoreException);
 
         this.verifierBrokerMock.Setup(broker =>
-            broker.VerifyAsync(randomCandidate))
+            broker.VerifyAsync(It.IsAny<string>(), randomCandidate))
                 .ReturnsAsync(verdict);
 
         // when
         ValueTask<Judgement> evaluateTask =
-            this.judgeService.EvaluateAsync(randomCandidate);
+            this.judgeService.EvaluateAsync(CreateRandomString(), randomCandidate);
 
         JudgeValidationException actualJudgeValidationException =
             await Assert.ThrowsAsync<JudgeValidationException>(
@@ -145,7 +145,7 @@ public partial class JudgeServiceTests
             .BeEquivalentTo(expectedJudgeValidationException);
 
         this.verifierBrokerMock.Verify(broker =>
-            broker.VerifyAsync(randomCandidate),
+            broker.VerifyAsync(It.IsAny<string>(), randomCandidate),
                 Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.Think.cs
@@ -74,7 +74,7 @@ public partial class DecisionOrchestrationServiceTests
                 Times.Never);
 
         this.judgeServiceMock.Verify(service =>
-            service.EvaluateAsync(It.IsAny<string>()),
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()),
                 Times.Never);
 
         this.brainServiceMock.VerifyNoOtherCalls();
@@ -93,7 +93,7 @@ public partial class DecisionOrchestrationServiceTests
                 .ReturnsAsync("FINAL: a poor answer");
 
         this.judgeServiceMock.Setup(service =>
-            service.EvaluateAsync(It.IsAny<string>()))
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new Judgement { Score = 0.1 });
 
         // when
@@ -117,7 +117,7 @@ public partial class DecisionOrchestrationServiceTests
                 .ReturnsAsync("FINAL: a poor answer");
 
         this.judgeServiceMock.Setup(service =>
-            service.EvaluateAsync(It.IsAny<string>()))
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new Judgement { Score = 0.1 });
 
         // when
@@ -145,7 +145,7 @@ public partial class DecisionOrchestrationServiceTests
 
         // then
         this.judgeServiceMock.Verify(service =>
-            service.EvaluateAsync(It.IsAny<string>()),
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()),
                 Times.Never);
 
         this.judgeServiceMock.VerifyNoOtherCalls();
@@ -172,7 +172,7 @@ public partial class DecisionOrchestrationServiceTests
                 Times.Once);
 
         this.judgeServiceMock.Verify(service =>
-            service.EvaluateAsync("the draft"),
+            service.EvaluateAsync(It.IsAny<string>(), "the draft"),
                 Times.Once);
     }
 }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.ThinkReason.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Guardians.ThinkReason.cs
@@ -25,7 +25,7 @@ public partial class DecisionOrchestrationServiceTests
                 .ReturnsAsync("FINAL: a poor answer");
 
         this.judgeServiceMock.Setup(service =>
-            service.EvaluateAsync(It.IsAny<string>()))
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new Judgement
                 {
                     Score = 0.1,

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.Think.cs
@@ -274,7 +274,7 @@ public partial class DecisionOrchestrationServiceTests
         actualContext.Payload.Should().BeEmpty();
 
         this.judgeServiceMock.Verify(service =>
-            service.EvaluateAsync(It.IsAny<string>()),
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()),
                 Times.Never);
     }
 }

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.ThinkStream.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.Logic.ThinkStream.cs
@@ -76,7 +76,7 @@ public partial class DecisionOrchestrationServiceTests
         decisionStream.Result.Payload.Should().Be("2+2");
 
         this.judgeServiceMock.Verify(service =>
-            service.EvaluateAsync(It.IsAny<string>()),
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()),
                 Times.Never);
     }
 

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Decision/DecisionOrchestrationServiceTests.cs
@@ -57,7 +57,7 @@ public partial class DecisionOrchestrationServiceTests
 
     private void SetupJudgeApproves() =>
         this.judgeServiceMock.Setup(service =>
-            service.EvaluateAsync(It.IsAny<string>()))
+            service.EvaluateAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new Judgement { Score = 1.0 });
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>

--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
@@ -90,7 +90,7 @@ public class AgentToolTests
             .ReturnsAsync("allow");
 
         var judge = new Mock<Brokers.Verifiers.IVerifierBroker>();
-        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>()))
+        judge.Setup(broker => broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync("1.0");
 
         var outerAgent = new StandardAgent()

--- a/Standard.Agents/Brokers/Redactions/IRedactionBroker.cs
+++ b/Standard.Agents/Brokers/Redactions/IRedactionBroker.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Redactions;
+
+public interface IRedactionBroker
+{
+    string Redact(string text, IDictionary<string, string> vault);
+
+    string Rehydrate(string text, IReadOnlyDictionary<string, string> vault);
+}

--- a/Standard.Agents/Brokers/Redactions/NotConfiguredRedactionBroker.cs
+++ b/Standard.Agents/Brokers/Redactions/NotConfiguredRedactionBroker.cs
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Redactions;
+
+// The default. SPEC.md §4.6: redaction is opt-in, and absent it the agent behaves exactly as
+// if the section did not exist — no scanning, no vault, no cost.
+public sealed class NotConfiguredRedactionBroker : IRedactionBroker
+{
+    public string Redact(string text, IDictionary<string, string> vault) =>
+        text;
+
+    public string Rehydrate(string text, IReadOnlyDictionary<string, string> vault) =>
+        text;
+}

--- a/Standard.Agents/Brokers/Redactions/RuleRedactionBroker.cs
+++ b/Standard.Agents/Brokers/Redactions/RuleRedactionBroker.cs
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using Standard.Agents.Models.Foundations.Brains;
+
+namespace Standard.Agents.Brokers.Redactions;
+
+// Redaction at the model boundary (SPEC.md §4.6), extracted from the Brain so every model the
+// agent drives can share it. The Gate screens the raw task and the Judge reads the task and the
+// draft, so both see exactly the values redaction exists to hide — and a guardian may run on a
+// different host than the Brain, which makes an unredacted guardian a wider exposure, not a
+// narrower one.
+//
+// The rules are Data (RedactionRules.Default); this broker is the liaison to the regex engine
+// that applies them, and holds no policy of its own.
+public sealed class RuleRedactionBroker : IRedactionBroker
+{
+    private readonly IReadOnlyList<RedactionRule> rules;
+
+    public RuleRedactionBroker(IEnumerable<RedactionRule> rules) =>
+        this.rules = [.. rules];
+
+    public string Redact(string text, IDictionary<string, string> vault)
+    {
+        if (this.rules.Count == 0 || string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        string redactedText = text;
+
+        foreach (RedactionRule rule in this.rules)
+        {
+            redactedText = Regex.Replace(
+                redactedText,
+                rule.Pattern,
+                match => Tokenize(rule, match.Value, vault));
+        }
+
+        return redactedText;
+    }
+
+    public string Rehydrate(string text, IReadOnlyDictionary<string, string> vault)
+    {
+        string rehydratedText = text;
+
+        foreach (KeyValuePair<string, string> entry in vault)
+        {
+            rehydratedText = rehydratedText.Replace(entry.Key, entry.Value);
+        }
+
+        return rehydratedText;
+    }
+
+    // One token per distinct value, so the same email redacts to the same placeholder twice and
+    // the model can still reason about it being the same person.
+    private static string Tokenize(
+        RedactionRule rule,
+        string value,
+        IDictionary<string, string> vault)
+    {
+        string existingToken =
+            vault.FirstOrDefault(entry => entry.Value == value).Key;
+
+        if (existingToken is not null)
+        {
+            return existingToken;
+        }
+
+        string token = "{{" + rule.Label + "_" + vault.Count + "}}";
+        vault[token] = value;
+
+        return token;
+    }
+}

--- a/Standard.Agents/Brokers/Verifiers/FunctionVerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/FunctionVerifierBroker.cs
@@ -18,6 +18,14 @@ public sealed class FunctionVerifierBroker : IVerifierBroker
         this.systemPrompt = systemPrompt;
     }
 
-    public async ValueTask<string> VerifyAsync(string candidate) =>
-        await this.evaluate(this.systemPrompt, candidate);
+    // A host-supplied judge is handed the task and the candidate together, so the delegate's
+    // second argument stays a single piece of text while still carrying what SPEC.md §4.2
+    // requires the Judge to see. The labels are the same ones the judge contract already uses.
+    public async ValueTask<string> VerifyAsync(string task, string candidate) =>
+        await this.evaluate(this.systemPrompt, FormatVerdictRequest(task, candidate));
+
+    internal static string FormatVerdictRequest(string task, string candidate) =>
+        string.IsNullOrWhiteSpace(task)
+            ? candidate
+            : $"TASK: {task}{Environment.NewLine}{Environment.NewLine}ANSWER: {candidate}";
 }

--- a/Standard.Agents/Brokers/Verifiers/IVerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/IVerifierBroker.cs
@@ -7,5 +7,7 @@ namespace Standard.Agents.Brokers.Verifiers;
 
 public interface IVerifierBroker
 {
-    ValueTask<string> VerifyAsync(string candidate);
+    // The task travels with the candidate: an answer is good or bad FOR a question, and a
+    // verdict on a fit the verifier cannot see is noise dressed as a number (SPEC.md §4.2).
+    ValueTask<string> VerifyAsync(string task, string candidate);
 }

--- a/Standard.Agents/Brokers/Verifiers/NotConfiguredVerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/NotConfiguredVerifierBroker.cs
@@ -12,6 +12,6 @@ public sealed class NotConfiguredVerifierBroker : IVerifierBroker
     private static readonly string PassingScore =
         (1.0).ToString(CultureInfo.InvariantCulture);
 
-    public async ValueTask<string> VerifyAsync(string candidate) =>
+    public async ValueTask<string> VerifyAsync(string task, string candidate) =>
         PassingScore;
 }

--- a/Standard.Agents/Brokers/Verifiers/RuleVerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/RuleVerifierBroker.cs
@@ -14,7 +14,7 @@ public sealed class RuleVerifierBroker : IVerifierBroker
     public RuleVerifierBroker(IEnumerable<string> requiredPatterns) =>
         this.requiredPatterns = requiredPatterns.ToList();
 
-    public async ValueTask<string> VerifyAsync(string candidate)
+    public async ValueTask<string> VerifyAsync(string task, string candidate)
     {
         await Task.CompletedTask;
 

--- a/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
+++ b/Standard.Agents/Brokers/Verifiers/VerifierBroker.cs
@@ -52,14 +52,16 @@ public sealed class VerifierBroker : IVerifierBroker
         this.systemPrompt = systemPrompt;
     }
 
-    public async ValueTask<string> VerifyAsync(string candidate)
+    public async ValueTask<string> VerifyAsync(string task, string candidate)
     {
         ChatCompletionRequest chatCompletionRequest = new(
             Model: this.model,
             Messages:
             [
                 new ChatMessage(Role: "system", Content: this.systemPrompt),
-                new ChatMessage(Role: "user", Content: candidate)
+                new ChatMessage(
+                    Role: "user",
+                    Content: FunctionVerifierBroker.FormatVerdictRequest(task, candidate))
             ],
             Stream: false,
             Temperature: this.temperature,

--- a/Standard.Agents/Prompts/Guardians/judge.policy.md
+++ b/Standard.Agents/Prompts/Guardians/judge.policy.md
@@ -3,5 +3,8 @@ You are the Judge — the conscience that reviews the Brain's answer before it i
 You are not the Brain. You do not rewrite, improve, or continue the answer. Your only job is
 to score how well the candidate answer addresses the task it was given, and to say briefly why.
 
+You are shown both. The input carries the task on a `TASK:` line and the answer on an `ANSWER:`
+line. Score the answer against that task — not against how well written it is on its own.
+
 Consider correctness, completeness, and relevance. A confident but wrong answer scores low. When
 you score below a passing mark, your reason must name the specific gap so the answer can be fixed.

--- a/Standard.Agents/Services/Foundations/Judges/IJudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Judges/IJudgeService.cs
@@ -9,5 +9,5 @@ namespace Standard.Agents.Services.Foundations.Judges;
 
 public interface IJudgeService
 {
-    ValueTask<Judgement> EvaluateAsync(string candidate);
+    ValueTask<Judgement> EvaluateAsync(string task, string candidate);
 }

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
@@ -22,12 +22,12 @@ public partial class JudgeService : IJudgeService
         this.loggingBroker = loggingBroker;
     }
 
-    public ValueTask<Judgement> EvaluateAsync(string candidate) =>
+    public ValueTask<Judgement> EvaluateAsync(string task, string candidate) =>
     TryCatch(async () =>
     {
         ValidateEvaluate(candidate);
 
-        string verdict = await this.verifierBroker.VerifyAsync(candidate);
+        string verdict = await this.verifierBroker.VerifyAsync(string.Empty, candidate);
 
         Judgement judgement = ParseJudgement(verdict);
 

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
@@ -27,7 +27,7 @@ public partial class JudgeService : IJudgeService
     {
         ValidateEvaluate(candidate);
 
-        string verdict = await this.verifierBroker.VerifyAsync(string.Empty, candidate);
+        string verdict = await this.verifierBroker.VerifyAsync(task, candidate);
 
         Judgement judgement = ParseJudgement(verdict);
 

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -107,7 +107,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
         }
 
         Judgement judgement =
-            await this.judgeService.EvaluateAsync(candidate: decided.Payload);
+            await this.judgeService.EvaluateAsync(task: context.Prompt, candidate: decided.Payload);
 
         if (judgement.Score < MinimumAcceptableScore)
         {
@@ -262,7 +262,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
             yield break;
         }
 
-        Judgement judgement = await this.judgeService.EvaluateAsync(candidate: decided.Payload);
+        Judgement judgement = await this.judgeService.EvaluateAsync(task: context.Prompt, candidate: decided.Payload);
 
         string judgeOutcome = judgement.Score < MinimumAcceptableScore
             ? $"REJECT: {judgement.Reason}".TrimEnd(':', ' ')

--- a/conformance/vectors/13-judge-receives-the-task.json
+++ b/conformance/vectors/13-judge-receives-the-task.json
@@ -1,0 +1,11 @@
+{
+  "name": "judge-receives-the-task",
+  "description": "SPEC.md 4.2: the Judge MUST receive the task it is scoring against, not the candidate alone. An answer is good or bad for a question, so a Judge shown only the answer is scoring a fit it cannot see. The vector drives a prompt to a judged final answer and requires the task to have reached the verifier.",
+  "generatorReplies": ["FINAL: 4183"],
+  "tools": {},
+  "prompt": "what is 47 multiplied by 89",
+  "expect": {
+    "result": "4183",
+    "judgeSawTask": true
+  }
+}


### PR DESCRIPTION
First of three defects in Guardian Integrity. Spec first: implements SPEC.md §4.1/§4.2, merged as The-Standard-Agent-Specs#12.

## The defect

`judge.policy.md` told the Judge to score *"how well the candidate answer addresses the task it was given"* — and the task was never sent. `VerifyAsync(candidate)` passed the answer alone.

Correctness, completeness and relevance are all judgments about the **fit** between a task and an answer. The Judge was being asked to score a fit it could not see.

The spec now makes this a MUST rather than a SHOULD, because the failure is **silent**: a blind Judge still returns a plausible number, still rejects, and still spends a turn of the loop's budget on a revision it could not have reasoned about.

## The change

The task travels with the candidate — `IVerifierBroker.VerifyAsync(task, candidate)`, `IJudgeService.EvaluateAsync(task, candidate)` — and the rubric says so: the input carries a `TASK:` line and an `ANSWER:` line.

Conformance vector 13 certifies it, and the runner gained what that needs: a vector can now assert **what a guardian was allowed to see**.

**Verified non-vacuous:** dropping the task again fails vector 13; restoring it passes.

Closes one of Reliable's five gaps — `--profile Reliable` now reports four.

317 unit tests · 13/13 vectors · 0 warnings.