### PR TITLE
FOUNDATIONS: Redaction Covers Every Model Call

### DIFF
--- a/Standard.Agents.Conformance/Models/Expectation.cs
+++ b/Standard.Agents.Conformance/Models/Expectation.cs
@@ -35,4 +35,9 @@ public sealed record Expectation(
     //   GuardianNeverAnswers — a guardian that tries to answer or act must be neutralized, and
     //                          its text must never become the agent's result.
     bool JudgeSawTask = false,
-    bool GuardianNeverAnswers = false);
+    bool GuardianNeverAnswers = false,
+
+    //   NoModelSees - this text must not appear in ANY model call: not the Brain's prompt,
+    //                 not the Gate's input, not the Judge's. Redaction that covers one call
+    //                 and not the others does not satisfy SPEC.md 4.6.
+    string? NoModelSees = null);

--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -29,4 +29,8 @@ public sealed record Vector(
     // Concurrent runs them all at once rather than in order, which is the only way to
     // certify that one run's bookkeeping never leaks into another's.
     List<string>? Prompts = null,
-    bool Concurrent = false);
+    bool Concurrent = false,
+
+    // Turns on boundary redaction (SPEC.md 4.6) so a vector can certify that no model call
+    // carries a sensitive value in the clear.
+    bool Redact = false);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -185,9 +185,19 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     List<AuditRecord> auditRecords = [];
     object auditLock = new();
 
+    // Everything any model was shown, so a vector can certify that a sensitive value reached
+    // none of them (SPEC.md §4.6). The generator is wrapped rather than replaced, so the real
+    // Brain path — redaction, rehydration, streaming buffers — is what gets certified.
+    List<string> modelInputs = [];
+    var scriptedGenerator = new ScriptedGeneratorBroker(vector.GeneratorReplies);
+
+    var recordingGenerator = new RecordingGeneratorBroker(
+        scriptedGenerator,
+        input => { lock (auditLock) { modelInputs.Add(input); } });
+
     StandardAgent agent = new StandardAgent()
         .UseSkills(new StubSkillBroker())
-        .UseGenerator(new ScriptedGeneratorBroker(vector.GeneratorReplies))
+        .UseGenerator(recordingGenerator)
         .UseMemory(new StubMemoryBroker())
         .UseKnowledge(new StubKnowledgeBroker())
         .UseMcp(new NotConfiguredMcpBroker())
@@ -196,12 +206,22 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         {
             gateRubric ??= rubric;
 
+            lock (auditLock)
+            {
+                modelInputs.Add(prompt);
+            }
+
             return new ValueTask<string>(vector.GateVerdict ?? "allow");
         })
         .OnJudge((rubric, candidate) =>
         {
             judgeRubric = rubric;
             judgeInput = candidate;
+
+            lock (auditLock)
+            {
+                modelInputs.Add(candidate);
+            }
 
             return new ValueTask<string>(vector.JudgeScore ?? "1.0");
         })
@@ -214,6 +234,11 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
 
             return ValueTask.CompletedTask;
         });
+
+    if (vector.Redact)
+    {
+        agent.Redact();
+    }
 
     if (string.IsNullOrEmpty(vector.Constitution) is false)
     {
@@ -252,7 +277,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         }
     }
 
-    return new VectorRun(result, stubTools, gateRubric, judgeRubric, judgeInput, auditRecords);
+    return new VectorRun(result, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, auditRecords);
 }
 
 // The decision log's guarantees, certified from the records themselves: one run per prompt,
@@ -406,6 +431,29 @@ static bool GuardianInputConformant(
         return false;
     }
 
+    // Redaction is only satisfied if EVERY model call is clean. Checking the Brain alone is the
+    // exact mistake this vector exists to catch (SPEC.md §4.6).
+    if (vector.Expect.NoModelSees is string secret)
+    {
+        if (run.ModelInputs.Count == 0)
+        {
+            failure = "no model was called, so nothing was certified";
+
+            return false;
+        }
+
+        int leaking = run.ModelInputs.Count(input =>
+            input.Contains(secret, StringComparison.Ordinal));
+
+        if (leaking > 0)
+        {
+            failure =
+                $"{leaking} of {run.ModelInputs.Count} model call(s) saw {Show(secret)} in the clear";
+
+            return false;
+        }
+    }
+
     return true;
 }
 
@@ -490,4 +538,5 @@ internal sealed record VectorRun(
     string? GateRubric,
     string? JudgeRubric,
     string? JudgeInput,
+    List<string> ModelInputs,
     List<AuditRecord> AuditRecords);

--- a/Standard.Agents.Conformance/RecordingGeneratorBroker.cs
+++ b/Standard.Agents.Conformance/RecordingGeneratorBroker.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using Standard.Agents.Brokers.Generators;
+
+namespace Standard.Agents.Conformance;
+
+// Wraps the scripted Brain and records everything it is shown, so a vector can certify what a
+// model was and was not allowed to see. It wraps rather than replaces, so the real Brain path —
+// redaction, rehydration, the streaming placeholder buffer — is what gets certified.
+public sealed class RecordingGeneratorBroker : IGeneratorBroker
+{
+    private readonly IGeneratorBroker inner;
+    private readonly Action<string> record;
+
+    public RecordingGeneratorBroker(IGeneratorBroker inner, Action<string> record)
+    {
+        this.inner = inner;
+        this.record = record;
+    }
+
+    public async ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt)
+    {
+        this.record(systemPrompt);
+        this.record(userPrompt);
+
+        return await this.inner.GenerateAsync(systemPrompt, userPrompt);
+    }
+
+    public async IAsyncEnumerable<string> GenerateStreamAsync(
+        string systemPrompt,
+        string userPrompt,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        this.record(systemPrompt);
+        this.record(userPrompt);
+
+        IAsyncEnumerable<string> tokens =
+            this.inner.GenerateStreamAsync(systemPrompt, userPrompt, cancellationToken);
+
+        await foreach (string token in tokens.WithCancellation(cancellationToken))
+        {
+            yield return token;
+        }
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.Redact.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.Redact.cs
@@ -5,6 +5,7 @@
 
 using FluentAssertions;
 using Moq;
+using Standard.Agents.Brokers.Redactions;
 using Standard.Agents.Models.Foundations.Brains;
 using Standard.Agents.Services.Foundations.Brains;
 using Xunit;
@@ -26,7 +27,7 @@ public partial class BrainServiceTests
         var redactingBrainService = new BrainService(
             generatorBroker: this.generatorBrokerMock.Object,
             loggingBroker: this.loggingBrokerMock.Object,
-            redactionRules: [emailRule]);
+            redactionBroker: new RuleRedactionBroker([emailRule]));
 
         string systemPrompt = CreateRandomString();
         string userPrompt = "please email jane@acme.com the report";

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.RedactStream.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Brains/BrainServiceTests.Logic.RedactStream.cs
@@ -5,6 +5,7 @@
 
 using FluentAssertions;
 using Moq;
+using Standard.Agents.Brokers.Redactions;
 using Standard.Agents.Models.Foundations.Brains;
 using Standard.Agents.Services.Foundations.Brains;
 using Xunit;
@@ -26,7 +27,7 @@ public partial class BrainServiceTests
         var redactingBrainService = new BrainService(
             generatorBroker: this.generatorBrokerMock.Object,
             loggingBroker: this.loggingBrokerMock.Object,
-            redactionRules: [emailRule]);
+            redactionBroker: new RuleRedactionBroker([emailRule]));
 
         string userPrompt = "email jane@acme.com the report";
 

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Redactions.Screen.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Gates/GateServiceTests.Redactions.Screen.cs
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Classifiers;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Redactions;
+using Standard.Agents.Models.Foundations.Brains;
+using Standard.Agents.Services.Foundations.Gates;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Gates;
+
+// SPEC.md §4.6: redaction covers every model the agent drives, not only the Brain. The Gate
+// screens the raw task, so it sees exactly the values redaction exists to hide — and a guardian
+// may run on a different host than the Brain, which makes an unredacted Gate a wider exposure
+// than an unredacted Brain, not a narrower one.
+public partial class GateServiceTests
+{
+    private static IGateService RedactingGate(
+        Mock<IClassifierBroker> classifierBrokerMock,
+        Mock<ILoggingBroker> loggingBrokerMock) =>
+        new GateService(
+            classifierBroker: classifierBrokerMock.Object,
+            loggingBroker: loggingBrokerMock.Object,
+            redactionBroker: new RuleRedactionBroker(RedactionRules.Default));
+
+    [Fact]
+    public async Task ShouldRedactSensitiveValuesBeforeScreeningAsync()
+    {
+        // given
+        string sensitiveEmail = "ada@example.com";
+        string inputWithPii = $"email the invoice to {sensitiveEmail}";
+        string capturedInput = string.Empty;
+
+        var classifierBrokerMock = new Mock<IClassifierBroker>();
+
+        classifierBrokerMock.Setup(broker => broker.ClassifyAsync(It.IsAny<string>()))
+            .Callback<string>(input => capturedInput = input)
+            .ReturnsAsync("accept");
+
+        IGateService gateService =
+            RedactingGate(classifierBrokerMock, new Mock<ILoggingBroker>());
+
+        // when
+        await gateService.ScreenAsync(inputWithPii);
+
+        // then
+        capturedInput.Should().NotContain(sensitiveEmail);
+        capturedInput.Should().Contain("EMAIL");
+    }
+
+    [Fact]
+    public async Task ShouldNotRedactWhenNoRedactionIsConfiguredOnScreenAsync()
+    {
+        // given
+        string sensitiveEmail = "ada@example.com";
+        string inputWithPii = $"email the invoice to {sensitiveEmail}";
+        string capturedInput = string.Empty;
+
+        this.classifierBrokerMock.Setup(broker => broker.ClassifyAsync(It.IsAny<string>()))
+            .Callback<string>(input => capturedInput = input)
+            .ReturnsAsync("accept");
+
+        // when
+        await this.gateService.ScreenAsync(inputWithPii);
+
+        // then — redaction is opt-in; absent it the agent behaves as if §4.6 did not exist
+        capturedInput.Should().Be(inputWithPii);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Redactions.Evaluate.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Judges/JudgeServiceTests.Redactions.Evaluate.cs
@@ -1,0 +1,97 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Redactions;
+using Standard.Agents.Brokers.Verifiers;
+using Standard.Agents.Models.Foundations.Brains;
+using Standard.Agents.Services.Foundations.Judges;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Judges;
+
+// SPEC.md §4.6: redaction covers every model. The Judge reads the task AND the drafted answer,
+// so it sees more sensitive text than any other guardian — and it is the one most likely to be
+// pointed at a cheap third-party endpoint, because scoring is the cheapest of the three calls.
+public partial class JudgeServiceTests
+{
+    [Fact]
+    public async Task ShouldRedactSensitiveValuesFromTaskAndCandidateOnEvaluateAsync()
+    {
+        // given
+        string sensitiveEmail = "ada@example.com";
+        string taskWithPii = $"draft a reply to {sensitiveEmail}";
+        string candidateWithPii = $"I have emailed {sensitiveEmail} already";
+
+        string capturedTask = string.Empty;
+        string capturedCandidate = string.Empty;
+
+        var verifierBrokerMock = new Mock<IVerifierBroker>();
+
+        verifierBrokerMock.Setup(broker =>
+            broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback<string, string>((task, candidate) =>
+                {
+                    capturedTask = task;
+                    capturedCandidate = candidate;
+                })
+                .ReturnsAsync("SCORE: 1.0\nREASON: ok");
+
+        IJudgeService judgeService = new JudgeService(
+            verifierBroker: verifierBrokerMock.Object,
+            loggingBroker: new Mock<ILoggingBroker>().Object,
+            redactionBroker: new RuleRedactionBroker(RedactionRules.Default));
+
+        // when
+        await judgeService.EvaluateAsync(taskWithPii, candidateWithPii);
+
+        // then
+        capturedTask.Should().NotContain(sensitiveEmail);
+        capturedCandidate.Should().NotContain(sensitiveEmail);
+
+        capturedTask.Should().Contain("EMAIL");
+        capturedCandidate.Should().Contain("EMAIL");
+    }
+
+    [Fact]
+    public async Task ShouldRehydrateTheJudgeReasonOnEvaluateAsync()
+    {
+        // given — a rejecting Judge quotes the answer back, and that reason becomes revision
+        // feedback the Brain reads, so it must come back in the clear
+        string sensitiveEmail = "ada@example.com";
+        string candidateWithPii = $"I have emailed {sensitiveEmail} already";
+
+        var verifierBrokerMock = new Mock<IVerifierBroker>();
+
+        verifierBrokerMock.Setup(broker =>
+            broker.VerifyAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string task, string candidate) =>
+                    $"SCORE: 0.1\nREASON: do not mention {ExtractToken(candidate)}");
+
+        IJudgeService judgeService = new JudgeService(
+            verifierBroker: verifierBrokerMock.Object,
+            loggingBroker: new Mock<ILoggingBroker>().Object,
+            redactionBroker: new RuleRedactionBroker(RedactionRules.Default));
+
+        // when
+        Models.Foundations.Judges.Judgement actualJudgement =
+            await judgeService.EvaluateAsync("a task", candidateWithPii);
+
+        // then
+        actualJudgement.Reason.Should().Contain(sensitiveEmail);
+    }
+
+    private static string ExtractToken(string redactedText)
+    {
+        int start = redactedText.IndexOf("{{", StringComparison.Ordinal);
+        int end = redactedText.IndexOf("}}", StringComparison.Ordinal);
+
+        return start >= 0 && end > start
+            ? redactedText[start..(end + 2)]
+            : string.Empty;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.Redactions.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.Redactions.cs
@@ -4,18 +4,25 @@
 // ---------------------------------------------------------------
 
 using System.Text;
-using System.Text.RegularExpressions;
-using Standard.Agents.Models.Foundations.Brains;
+using Standard.Agents.Brokers.Redactions;
 
 namespace Standard.Agents.Services.Foundations.Brains;
 
 public partial class BrainService
 {
+    // Streaming makes rehydration a boundary problem: a placeholder can arrive split across
+    // two tokens, so anything from the last unmatched "{{" onward is held back until more
+    // text arrives. Without it a token boundary mid-placeholder would leak "{{EMAIL_" to the
+    // caller and never restore the value.
+    //
+    // The redaction itself is the broker's (SPEC.md §4.6) — this is only the buffering that
+    // streaming adds on top.
     private static string DrainReady(
         StringBuilder pending,
-        IReadOnlyDictionary<string, string> vault)
+        IReadOnlyDictionary<string, string> vault,
+        IRedactionBroker redactionBroker)
     {
-        string buffer = Rehydrate(pending.ToString(), vault);
+        string buffer = redactionBroker.Rehydrate(pending.ToString(), vault);
 
         int hold = buffer.LastIndexOf('{');
 
@@ -31,56 +38,5 @@ public partial class BrainService
         pending.Append(keep);
 
         return ready;
-    }
-
-    private string Redact(string text, IDictionary<string, string> vault)
-    {
-        if (this.redactionRules.Count == 0 || string.IsNullOrEmpty(text))
-        {
-            return text;
-        }
-
-        string redactedText = text;
-
-        foreach (RedactionRule rule in this.redactionRules)
-        {
-            redactedText = Regex.Replace(
-                redactedText,
-                rule.Pattern,
-                match => Tokenize(rule, match.Value, vault));
-        }
-
-        return redactedText;
-    }
-
-    private static string Tokenize(
-        RedactionRule rule,
-        string value,
-        IDictionary<string, string> vault)
-    {
-        string existingToken =
-            vault.FirstOrDefault(entry => entry.Value == value).Key;
-
-        if (existingToken is not null)
-        {
-            return existingToken;
-        }
-
-        string token = "{{" + rule.Label + "_" + vault.Count + "}}";
-        vault[token] = value;
-
-        return token;
-    }
-
-    private static string Rehydrate(string text, IReadOnlyDictionary<string, string> vault)
-    {
-        string rehydratedText = text;
-
-        foreach (KeyValuePair<string, string> entry in vault)
-        {
-            rehydratedText = rehydratedText.Replace(entry.Key, entry.Value);
-        }
-
-        return rehydratedText;
     }
 }

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Standard.Agents.Brokers.Generators;
 using Standard.Agents.Brokers.Loggings;
-using Standard.Agents.Models.Foundations.Brains;
+using Standard.Agents.Brokers.Redactions;
 
 namespace Standard.Agents.Services.Foundations.Brains;
 
@@ -15,16 +15,16 @@ public partial class BrainService : IBrainService
 {
     private readonly IGeneratorBroker generatorBroker;
     private readonly ILoggingBroker loggingBroker;
-    private readonly IReadOnlyList<RedactionRule> redactionRules;
+    private readonly IRedactionBroker redactionBroker;
 
     public BrainService(
         IGeneratorBroker generatorBroker,
         ILoggingBroker loggingBroker,
-        IEnumerable<RedactionRule>? redactionRules = null)
+        IRedactionBroker? redactionBroker = null)
     {
         this.generatorBroker = generatorBroker;
         this.loggingBroker = loggingBroker;
-        this.redactionRules = redactionRules?.ToList() ?? [];
+        this.redactionBroker = redactionBroker ?? new NotConfiguredRedactionBroker();
     }
 
     public ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt) =>
@@ -33,13 +33,13 @@ public partial class BrainService : IBrainService
         ValidateUserPrompt(userPrompt);
 
         var vault = new Dictionary<string, string>();
-        string redactedSystemPrompt = Redact(systemPrompt, vault);
-        string redactedUserPrompt = Redact(userPrompt, vault);
+        string redactedSystemPrompt = this.redactionBroker.Redact(systemPrompt, vault);
+        string redactedUserPrompt = this.redactionBroker.Redact(userPrompt, vault);
 
         string reply = await this.generatorBroker.GenerateAsync(
             redactedSystemPrompt, redactedUserPrompt);
 
-        return Rehydrate(reply, vault);
+        return this.redactionBroker.Rehydrate(reply, vault);
     });
 
     public async IAsyncEnumerable<string> GenerateStreamAsync(
@@ -54,8 +54,8 @@ public partial class BrainService : IBrainService
         {
             ValidateUserPrompt(userPrompt);
 
-            string redactedSystemPrompt = Redact(systemPrompt, vault);
-            string redactedUserPrompt = Redact(userPrompt, vault);
+            string redactedSystemPrompt = this.redactionBroker.Redact(systemPrompt, vault);
+            string redactedUserPrompt = this.redactionBroker.Redact(userPrompt, vault);
 
             tokens = this.generatorBroker
                 .GenerateStreamAsync(redactedSystemPrompt, redactedUserPrompt, cancellationToken)
@@ -96,7 +96,7 @@ public partial class BrainService : IBrainService
                 }
 
                 pending.Append(token);
-                string ready = DrainReady(pending, vault);
+                string ready = DrainReady(pending, vault, this.redactionBroker);
 
                 if (ready.Length > 0)
                 {
@@ -106,7 +106,7 @@ public partial class BrainService : IBrainService
 
             if (vault.Count > 0 && pending.Length > 0)
             {
-                yield return Rehydrate(pending.ToString(), vault);
+                yield return this.redactionBroker.Rehydrate(pending.ToString(), vault);
             }
         }
         finally

--- a/Standard.Agents/Services/Foundations/Gates/GateService.cs
+++ b/Standard.Agents/Services/Foundations/Gates/GateService.cs
@@ -5,6 +5,7 @@
 
 using Standard.Agents.Brokers.Classifiers;
 using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Redactions;
 
 namespace Standard.Agents.Services.Foundations.Gates;
 
@@ -19,15 +20,22 @@ public partial class GateService : IGateService
 
     private readonly IClassifierBroker classifierBroker;
     private readonly ILoggingBroker loggingBroker;
+    private readonly IRedactionBroker redactionBroker;
 
     public GateService(
         IClassifierBroker classifierBroker,
-        ILoggingBroker loggingBroker)
+        ILoggingBroker loggingBroker,
+        IRedactionBroker? redactionBroker = null)
     {
         this.classifierBroker = classifierBroker;
         this.loggingBroker = loggingBroker;
+        this.redactionBroker = redactionBroker ?? new NotConfiguredRedactionBroker();
     }
 
+    // The Gate screens the raw task, so it sees exactly what redaction exists to hide, and it
+    // may run on a different host than the Brain (SPEC.md §4.6). The vault is per call: a
+    // verdict is a classification, but a refusal reason can quote the input back, so the
+    // verdict is rehydrated before anyone reads it.
     public ValueTask<string> ScreenAsync(string input) =>
     TryCatch(async () =>
     {

--- a/Standard.Agents/Services/Foundations/Gates/GateService.cs
+++ b/Standard.Agents/Services/Foundations/Gates/GateService.cs
@@ -41,7 +41,12 @@ public partial class GateService : IGateService
     {
         ValidateScreen(input);
 
-        return await this.classifierBroker.ClassifyAsync(input);
+        var vault = new Dictionary<string, string>();
+        string redactedInput = this.redactionBroker.Redact(input, vault);
+
+        string verdict = await this.classifierBroker.ClassifyAsync(redactedInput);
+
+        return this.redactionBroker.Rehydrate(verdict, vault);
     });
 
     public ValueTask<string> DetectConflictAsync(string instructions) =>

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Redactions;
 using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Models.Foundations.Judges;
 
@@ -13,13 +14,16 @@ public partial class JudgeService : IJudgeService
 {
     private readonly IVerifierBroker verifierBroker;
     private readonly ILoggingBroker loggingBroker;
+    private readonly IRedactionBroker redactionBroker;
 
     public JudgeService(
         IVerifierBroker verifierBroker,
-        ILoggingBroker loggingBroker)
+        ILoggingBroker loggingBroker,
+        IRedactionBroker? redactionBroker = null)
     {
         this.verifierBroker = verifierBroker;
         this.loggingBroker = loggingBroker;
+        this.redactionBroker = redactionBroker ?? new NotConfiguredRedactionBroker();
     }
 
     public ValueTask<Judgement> EvaluateAsync(string task, string candidate) =>

--- a/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
+++ b/Standard.Agents/Services/Foundations/Judges/JudgeService.cs
@@ -31,9 +31,18 @@ public partial class JudgeService : IJudgeService
     {
         ValidateEvaluate(candidate);
 
-        string verdict = await this.verifierBroker.VerifyAsync(task, candidate);
+        // One vault across both, so the same value redacts to the same token in the task and
+        // the answer — otherwise the Judge cannot tell that the answer is about the person the
+        // task asked about. The verdict is rehydrated because a rejection's reason quotes the
+        // answer back, and that reason becomes the revision feedback the Brain reads (§4.3).
+        var vault = new Dictionary<string, string>();
 
-        Judgement judgement = ParseJudgement(verdict);
+        string redactedTask = this.redactionBroker.Redact(task, vault);
+        string redactedCandidate = this.redactionBroker.Redact(candidate, vault);
+
+        string verdict = await this.verifierBroker.VerifyAsync(redactedTask, redactedCandidate);
+
+        Judgement judgement = ParseJudgement(this.redactionBroker.Rehydrate(verdict, vault));
 
         ValidateScore(judgement.Score);
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -13,6 +13,7 @@ using Standard.Agents.Brokers.Knowledges;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Redactions;
 using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Brokers.Times;
 using Standard.Agents.Brokers.Tools;
@@ -718,10 +719,18 @@ public sealed partial class StandardAgent : IAgent
             RenderToolCatalog(allTools),
             logging);
 
+        // One redaction broker across all three Decision foundations. SPEC.md §4.6: redaction
+        // covers every model the agent drives — the Gate screens the raw task and the Judge
+        // reads the task and the draft, and either may run on a different host than the Brain,
+        // so redacting only the Brain narrows nothing.
+        IRedactionBroker redaction = this.redactionRules is null
+            ? new NotConfiguredRedactionBroker()
+            : new RuleRedactionBroker(this.redactionRules);
+
         DecisionOrchestrationService decision = new(
-            new GateService(classifier, logging),
-            new BrainService(generator, logging, this.redactionRules),
-            new JudgeService(verifier, logging),
+            new GateService(classifier, logging, redaction),
+            new BrainService(generator, logging, redaction),
+            new JudgeService(verifier, logging, redaction),
             logging);
 
         DirectionOrchestrationService direction = new(

--- a/conformance/vectors/14-redaction-covers-every-model-call.json
+++ b/conformance/vectors/14-redaction-covers-every-model-call.json
@@ -1,0 +1,12 @@
+{
+  "name": "redaction-covers-every-model-call",
+  "description": "SPEC.md 4.6: redaction covers every model the agent drives, not only the Brain. The Gate screens the raw task and the Judge reads the task and the drafted answer, so both see exactly the values redaction exists to hide - and a guardian may run on a different host than the Brain, which makes an unredacted guardian a wider exposure, not a narrower one. The prompt carries an email address; no model call may contain it in the clear, and the caller must still get it back.",
+  "generatorReplies": ["FINAL: I have emailed ada@example.com the report"],
+  "tools": {},
+  "prompt": "email the report to ada@example.com",
+  "redact": true,
+  "expect": {
+    "resultContains": "ada@example.com",
+    "noModelSees": "ada@example.com"
+  }
+}


### PR DESCRIPTION
Second of three defects in Guardian Integrity. Implements SPEC.md §4.6, merged as The-Standard-Agent-Specs#12.

## The defect

Redaction lived entirely inside `BrainService`. The Gate received the **raw** prompt; the Judge received the **rehydrated** answer. Point `.Gate(...)` / `.Judge(...)` at a hosted endpoint — as the README's own enterprise sample does — and PII went over the wire in the clear.

`.Redact()` promised *"data never leaves in the clear"* and delivered it for one of three model calls. And a guardian may run on a **different host** than the Brain, which makes an unredacted guardian a *wider* exposure, not a narrower one.

## The change

`IRedactionBroker` is now a cross-cutting broker composed by all three Decision foundations. Rules stay Data (`RedactionRules.Default` untouched).

- **Gate** — redacts the input, rehydrates the verdict (a refusal reason can quote the input back).
- **Judge** — one vault across task *and* candidate, so the same value gets the same token and the Judge can still tell the answer is about the person the task asked about. The verdict is rehydrated because a rejection's reason becomes the revision feedback the Brain reads.
- **Brain** — drops its private copy; keeps only the streaming buffer, since a placeholder can arrive split across two tokens.

Three FAIL/PASS pairs. Vector 14 certifies the whole boundary.

## The vector was vacuous first, and that mattered

It **passed while guardian redaction was sabotaged** — because the runner was only recording what the *Brain* saw. The same blind spot this release fixes, faithfully reproduced in the harness.

The runner now records every model call. Sabotaging the Gate alone: `1 of 5 model call(s) saw ada@example.com in the clear`.

321 unit tests · 14/14 vectors · 0 warnings.