### PR TITLE
PERIMETER: The Effect Envelope And Its Brokers

### DIFF
--- a/Standard.Agents/Brokers/Approvals/FunctionApprovalBroker.cs
+++ b/Standard.Agents/Brokers/Approvals/FunctionApprovalBroker.cs
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Brokers.Approvals;
+
+// The Custom mode's substrate: a host-supplied approver standing in for a broker — a console
+// prompt, an internal service call, a test double.
+public sealed class FunctionApprovalBroker : IApprovalBroker
+{
+    private readonly Func<AgentEffect, ValueTask<ApprovalDecision>> request;
+
+    public FunctionApprovalBroker(Func<AgentEffect, ValueTask<ApprovalDecision>> request) =>
+        this.request = request;
+
+    public ValueTask<ApprovalDecision> RequestAsync(AgentEffect effect) =>
+        this.request(effect);
+}

--- a/Standard.Agents/Brokers/Approvals/IApprovalBroker.cs
+++ b/Standard.Agents/Brokers/Approvals/IApprovalBroker.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Brokers.Approvals;
+
+public enum ApprovalDecision
+{
+    /// <summary>Proceed — the act was authorized by a human or a trusted authority.</summary>
+    Approved,
+
+    /// <summary>Do not proceed. Non-terminal: the agent may choose another path.</summary>
+    Denied,
+
+    /// <summary>
+    /// No answer yet. The turn stops with <c>AwaitingApproval</c> and the act does not run —
+    /// waiting is not consent (SPEC.md §4.9).
+    /// </summary>
+    Pending
+}
+
+public interface IApprovalBroker
+{
+    ValueTask<ApprovalDecision> RequestAsync(AgentEffect effect);
+}

--- a/Standard.Agents/Brokers/Approvals/NotConfiguredApprovalBroker.cs
+++ b/Standard.Agents/Brokers/Approvals/NotConfiguredApprovalBroker.cs
@@ -1,0 +1,16 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Brokers.Approvals;
+
+// The default. SPEC.md §4.9: absent the control, behavior is exactly as if the section did not
+// exist — nothing is held for approval.
+public sealed class NotConfiguredApprovalBroker : IApprovalBroker
+{
+    public ValueTask<ApprovalDecision> RequestAsync(AgentEffect effect) =>
+        ValueTask.FromResult(ApprovalDecision.Approved);
+}

--- a/Standard.Agents/Brokers/Approvals/RequireApprovalBroker.cs
+++ b/Standard.Agents/Brokers/Approvals/RequireApprovalBroker.cs
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Brokers.Approvals;
+
+// The Local mode: a list of tool names that always need someone else to say yes. With no
+// approver wired in, the honest answer is Pending — the act is held, not performed. An agent
+// that treated "nobody answered" as consent would be worse than one with no approval at all,
+// because the control would read as present while granting everything.
+public sealed class RequireApprovalBroker : IApprovalBroker
+{
+    private readonly HashSet<string> toolNamesRequiringApproval;
+
+    public RequireApprovalBroker(IEnumerable<string> toolNamesRequiringApproval) =>
+        this.toolNamesRequiringApproval =
+            new HashSet<string>(toolNamesRequiringApproval, StringComparer.OrdinalIgnoreCase);
+
+    public async ValueTask<ApprovalDecision> RequestAsync(AgentEffect effect)
+    {
+        await Task.CompletedTask;
+
+        return this.toolNamesRequiringApproval.Contains(effect.ToolName)
+            ? ApprovalDecision.Pending
+            : ApprovalDecision.Approved;
+    }
+}

--- a/Standard.Agents/Brokers/Policies/AllowListPolicyBroker.cs
+++ b/Standard.Agents/Brokers/Policies/AllowListPolicyBroker.cs
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Brokers.Policies;
+
+// The Local mode: least privilege as a list of names, which is what .AllowTools() has always
+// meant. It becomes a policy broker so that the simple answer and an external policy engine
+// travel the same seam, and so a denial carries a reason from the very first release.
+public sealed class AllowListPolicyBroker : IPolicyBroker
+{
+    private readonly HashSet<string> allowedToolNames;
+
+    public AllowListPolicyBroker(IEnumerable<string> allowedToolNames) =>
+        this.allowedToolNames =
+            new HashSet<string>(allowedToolNames, StringComparer.OrdinalIgnoreCase);
+
+    public async ValueTask<AuthorizationDecision> AuthorizeAsync(AgentEffect effect)
+    {
+        await Task.CompletedTask;
+
+        return this.allowedToolNames.Contains(effect.ToolName)
+            ? AuthorizationDecision.Allow()
+            : AuthorizationDecision.Deny(
+                $"tool '{effect.ToolName}' is not permitted");
+    }
+}

--- a/Standard.Agents/Brokers/Policies/FunctionPolicyBroker.cs
+++ b/Standard.Agents/Brokers/Policies/FunctionPolicyBroker.cs
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Brokers.Policies;
+
+// The Custom mode's substrate: a host-supplied function standing in for a broker.
+public sealed class FunctionPolicyBroker : IPolicyBroker
+{
+    private readonly Func<AgentEffect, ValueTask<AuthorizationDecision>> authorize;
+
+    public FunctionPolicyBroker(Func<AgentEffect, ValueTask<AuthorizationDecision>> authorize) =>
+        this.authorize = authorize;
+
+    public ValueTask<AuthorizationDecision> AuthorizeAsync(AgentEffect effect) =>
+        this.authorize(effect);
+}

--- a/Standard.Agents/Brokers/Policies/IPolicyBroker.cs
+++ b/Standard.Agents/Brokers/Policies/IPolicyBroker.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Brokers.Policies;
+
+public interface IPolicyBroker
+{
+    ValueTask<AuthorizationDecision> AuthorizeAsync(AgentEffect effect);
+}

--- a/Standard.Agents/Brokers/Policies/NotConfiguredPolicyBroker.cs
+++ b/Standard.Agents/Brokers/Policies/NotConfiguredPolicyBroker.cs
@@ -1,0 +1,16 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Brokers.Policies;
+
+// The default. SPEC.md §4.9: absent every perimeter control, behavior is exactly as if the
+// section did not exist — so with no policy configured, every registered tool is runnable.
+public sealed class NotConfiguredPolicyBroker : IPolicyBroker
+{
+    public ValueTask<AuthorizationDecision> AuthorizeAsync(AgentEffect effect) =>
+        ValueTask.FromResult(AuthorizationDecision.Allow());
+}

--- a/Standard.Agents/Models/Orchestrations/Effects/AgentEffect.cs
+++ b/Standard.Agents/Models/Orchestrations/Effects/AgentEffect.cs
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Standard.Agents.Models.Orchestrations.Effects;
+
+/// <summary>
+/// A proposed act, described. Direction routes a bare name and payload until a perimeter control
+/// is configured; then the act needs an identity, because authorization, approval and run-once
+/// are all judgments about an act, and an act with no identity cannot be judged the same way
+/// twice (SPEC.md §3.3, §4.9).
+/// </summary>
+public sealed record AgentEffect
+{
+    private const string KeySeparator = "|";
+
+    public string RunId { get; init; } = "";
+    public string? Principal { get; init; }
+
+    public string ToolName { get; init; } = "";
+    public string Arguments { get; init; } = "";
+
+    public RiskLevel RiskLevel { get; init; }
+    public bool ApprovalRequired { get; init; }
+
+    /// <summary>
+    /// Identifies this act, so a repeat of the same intent is recognisable as the same act.
+    /// <b>Derived, never supplied</b> — see <see cref="For"/>.
+    /// </summary>
+    public string IdempotencyKey { get; init; } = "";
+
+    /// <summary>
+    /// Describes an act and derives its key from what the act <i>is</i>: the run, the tool, and a
+    /// canonical form of the arguments.
+    /// </summary>
+    /// <remarks>
+    /// The key is deliberately not a parameter. SPEC.md §4.9: a key the caller or the Brain can
+    /// choose is a key the model can vary, and run-once degrades to advisory — the model retries
+    /// with a nudged argument and the payment goes out twice. Deriving it means the same intent
+    /// produces the same key by construction rather than by anyone remembering to.
+    /// </remarks>
+    public static AgentEffect For(
+        string runId,
+        string toolName,
+        string arguments,
+        RiskLevel riskLevel = RiskLevel.Safe,
+        bool approvalRequired = false,
+        string? principal = null) =>
+        new()
+        {
+            RunId = runId,
+            Principal = principal,
+            ToolName = toolName,
+            Arguments = arguments,
+            RiskLevel = riskLevel,
+            ApprovalRequired = approvalRequired,
+            IdempotencyKey = DeriveKey(runId, toolName, arguments)
+        };
+
+    // Whitespace- and case-insensitive on the tool name, so "calculator: 2 + 2" and
+    // "calculator:2+2" are one act rather than two. Anything more clever belongs to the tool,
+    // which is the only thing that knows what its arguments mean.
+    private static string DeriveKey(string runId, string toolName, string arguments)
+    {
+        string canonicalArguments = string.Join(
+            separator: " ",
+            arguments.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+        string canonical = string.Join(
+            KeySeparator,
+            runId,
+            toolName.Trim().ToLowerInvariant(),
+            canonicalArguments);
+
+        return Convert.ToHexStringLower(
+            SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+    }
+}

--- a/Standard.Agents/Models/Orchestrations/Effects/AuthorizationDecision.cs
+++ b/Standard.Agents/Models/Orchestrations/Effects/AuthorizationDecision.cs
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Orchestrations.Effects;
+
+/// <summary>
+/// Whether an effect may proceed, and why. The reason is not optional: a denial without one
+/// cannot be audited, cannot be appealed, and cannot be told apart from a fault (SPEC.md §4.1).
+/// </summary>
+public sealed record AuthorizationDecision(bool Permitted, string Reason)
+{
+    public static AuthorizationDecision Allow() =>
+        new(Permitted: true, Reason: string.Empty);
+
+    public static AuthorizationDecision Deny(string reason) =>
+        new(Permitted: false, Reason: reason);
+}

--- a/Standard.Agents/Models/Orchestrations/Effects/RiskLevel.cs
+++ b/Standard.Agents/Models/Orchestrations/Effects/RiskLevel.cs
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Orchestrations.Effects;
+
+/// <summary>
+/// How much an act costs to get wrong. <see cref="Safe"/> is the default, so an agent that
+/// adopts effects without classifying its tools behaves exactly as it did before (SPEC.md §3.3).
+/// </summary>
+public enum RiskLevel
+{
+    /// <summary>Reversible and cheap — a calculation, a lookup.</summary>
+    Safe,
+
+    /// <summary>Reversible but consequential — a draft saved, a record updated.</summary>
+    Sensitive,
+
+    /// <summary>Cannot be taken back — a payment, a message sent, a record deleted.</summary>
+    Irreversible
+}


### PR DESCRIPTION
Foundation for 0.22 Perimeter. Spec first: implements SPEC.md §3.1/§3.3/§4.1/§4.9/§7.7, merged as The-Standard-Agent-Specs#13.

Three commits: `DATA: Add Agent Effect Model`, `BROKERS: Select Authorization Decision`.

## The effect envelope

A proposed tool call becomes an `AgentEffect` — because authorization, approval and run-once are all judgments about *an act*, and an act with no identity cannot be judged the same way twice.

**The idempotency key is deliberately not a parameter.** The spec requires it be *derived*, because a key the caller or the Brain can choose is a key the model can vary — the model retries with a nudged argument and the payment goes out twice. `AgentEffect.For(...)` derives it from run + tool + canonical arguments, so the same intent produces the same key by construction rather than by anyone remembering to.

Verified: same intent → same key across whitespace and tool-name casing; different amount or different run → different key.

`RiskLevel` defaults to `Safe` and `ApprovalRequired` to `false`, so adopting effects without classifying tools changes nothing.

## The brokers

**Policy** — *may this act proceed?* The Local mode is the allow-list `.AllowTools()` has always meant, promoted to a broker so the simple answer and an external engine travel one seam, and so a denial carries its reason from the first release rather than being retrofitted.

**Approval** — *should someone else say yes first?* With a tool named but no approver wired in, the honest answer is **Pending**: the act is held, not performed. An agent treating "nobody answered" as consent would be worse than one with no approval control at all — the control would read as present while granting everything.

Both default to permitting everything, so absent the perimeter nothing changes.

324 unit tests · 15/15 vectors · 0 warnings.