### PR TITLE
MAJOR ORCHESTRATIONS: The Perimeter Pipeline

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/PerimeterTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/PerimeterTests.cs
@@ -1,0 +1,142 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Models.Orchestrations.Effects;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// The perimeter end to end (SPEC.md §4.9): authorize, record intent, approve, run at most once,
+// record outcome. These pin the guarantees a bank actually asks about.
+public class PerimeterTests
+{
+    private sealed class CountingTool : ITool
+    {
+        public string Name => "wire_transfer";
+        public string Description => "Moves money.";
+        public string Parameters => "{}";
+
+        public int ExecutionCount { get; private set; }
+
+        public ValueTask<string> ExecuteAsync(string input)
+        {
+            ExecutionCount++;
+
+            return ValueTask.FromResult("transfer complete");
+        }
+    }
+
+    private static StandardAgent AgentThatCallsTheTool(CountingTool tool, params string[] replies)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+
+        skillBroker.Setup(broker => broker.SelectSkillsAsync())
+            .ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        var scriptedReplies = new Queue<string>(replies);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .Tool(tool)
+            .OnBrain(async (systemPrompt, userPrompt) =>
+                scriptedReplies.Count > 0 ? scriptedReplies.Dequeue() : "FINAL: done");
+    }
+
+    [Fact]
+    public async Task ShouldNotRunAnIrreversibleToolWithoutApprovalAsync()
+    {
+        // given
+        var tool = new CountingTool();
+
+        StandardAgent agent =
+            AgentThatCallsTheTool(tool, "ACTION: wire_transfer: 10000")
+                .RequireApproval("wire_transfer");
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "pay the invoice");
+
+        // then — waiting is not consent
+        tool.ExecutionCount.Should().Be(0);
+        actualResult.Should().Contain("waiting for approval");
+    }
+
+    [Fact]
+    public async Task ShouldRunAnIrreversibleToolOnceApprovedAsync()
+    {
+        // given
+        var tool = new CountingTool();
+
+        StandardAgent agent =
+            AgentThatCallsTheTool(tool, "ACTION: wire_transfer: 10000", "FINAL: paid")
+                .RequireApproval("wire_transfer")
+                .OnApproval(effect => ValueTask.FromResult(ApprovalDecision.Approved));
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "pay the invoice");
+
+        // then
+        tool.ExecutionCount.Should().Be(1);
+        actualResult.Should().Be("paid");
+    }
+
+    [Fact]
+    public async Task ShouldRunTheSameEffectOnlyOnceWithinARunAsync()
+    {
+        // given — the Brain proposes the identical transfer three times, as a looping model does
+        var tool = new CountingTool();
+
+        StandardAgent agent = AgentThatCallsTheTool(
+            tool,
+            "ACTION: wire_transfer: 10000",
+            "ACTION: wire_transfer: 10000",
+            "ACTION: wire_transfer:  10000",
+            "FINAL: paid");
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "pay the invoice");
+
+        // then — one act, however many times it is proposed
+        tool.ExecutionCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ShouldDenyAnUnauthorizedEffectWithoutEndingTheRunAsync()
+    {
+        // given
+        var tool = new CountingTool();
+
+        StandardAgent agent = AgentThatCallsTheTool(
+            tool,
+            "ACTION: wire_transfer: 10000",
+            "FINAL: I could not do that")
+                .OnPolicy(effect => ValueTask.FromResult(
+                    AuthorizationDecision.Deny("wire transfers are not permitted for this user")));
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "pay the invoice");
+
+        // then — denial is non-terminal: the agent is told, and answers anyway
+        tool.ExecutionCount.Should().Be(0);
+        actualResult.Should().Be("I could not do that");
+    }
+}

--- a/Standard.Agents/Brokers/Effects/IEffectLedgerBroker.cs
+++ b/Standard.Agents/Brokers/Effects/IEffectLedgerBroker.cs
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Brokers.Effects;
+
+public interface IEffectLedgerBroker
+{
+    /// <summary>
+    /// Records that this effect is about to run, and reports whether it already has. Intent is
+    /// written <b>before</b> the act, never after: an effect that executed but was never
+    /// recorded is indistinguishable from one that never ran (SPEC.md §4.9).
+    /// </summary>
+    /// <returns>
+    /// The outcome of the first execution when this key has run before; <c>null</c> when this is
+    /// the first time and the caller should proceed.
+    /// </returns>
+    ValueTask<string?> SelectOutcomeAsync(AgentEffect effect);
+
+    /// <summary>Records what the effect produced, before the loop advances.</summary>
+    ValueTask InsertOutcomeAsync(AgentEffect effect, string outcome);
+}

--- a/Standard.Agents/Brokers/Effects/InMemoryEffectLedgerBroker.cs
+++ b/Standard.Agents/Brokers/Effects/InMemoryEffectLedgerBroker.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Brokers.Effects;
+
+// Run-once within one agent instance. That is the whole scope, and saying so is the point:
+// it covers a retry inside a run and a repeat proposal across turns, which is where duplicate
+// effects actually come from today. It does NOT survive a process restart — cross-process
+// run-once needs a durable ledger, which arrives with the session store.
+//
+// A host that needs the stronger guarantee now swaps this broker for one over its own store;
+// that is what the seam is for (SPEC.md §4.1).
+public sealed class InMemoryEffectLedgerBroker : IEffectLedgerBroker
+{
+    private readonly ConcurrentDictionary<string, string?> outcomesByKey = new();
+
+    public ValueTask<string?> SelectOutcomeAsync(AgentEffect effect)
+    {
+        // Claim the key and report the prior outcome in one step, so two concurrent runs
+        // proposing the same act cannot both decide they are the first.
+        bool isFirst = this.outcomesByKey.TryAdd(effect.IdempotencyKey, null);
+
+        if (isFirst)
+        {
+            return ValueTask.FromResult<string?>(null);
+        }
+
+        this.outcomesByKey.TryGetValue(effect.IdempotencyKey, out string? outcome);
+
+        return ValueTask.FromResult<string?>(outcome ?? "effect already in progress");
+    }
+
+    public ValueTask InsertOutcomeAsync(AgentEffect effect, string outcome)
+    {
+        this.outcomesByKey[effect.IdempotencyKey] = outcome;
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Standard.Agents/Models/Orchestrations/Agents/AgentStatus.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentStatus.cs
@@ -12,5 +12,10 @@ public enum AgentStatus
     AwaitingInput = 2,
     Refused = 3,
     Failed = 4,
-    Revising = 5
+    Revising = 5,
+
+    // Terminal for the turn: an effect is proposed but not performed, because an authority has
+    // not answered yet (SPEC.md §3.1, §4.9). Distinct from AwaitingInput — the agent is not
+    // asking the user a question, it is asking for permission, and waiting is not consent.
+    AwaitingApproval = 6
 }

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
@@ -1,0 +1,147 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Models.Loggings;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Services.Orchestrations.Direction;
+
+// The perimeter (SPEC.md §4.9). Direction already owned the boundary; this is enforcement at
+// it, in the order the spec fixes and forbids reordering:
+//
+//   authorize → record the intent → approve → execute at most once → record the outcome
+//
+// The order is the control. Authorizing after execution audits a fait accompli; recording the
+// intent after execution loses the effects that crashed mid-flight; and approving after
+// execution is not approval at all.
+public partial class DirectionOrchestrationService
+{
+    private async ValueTask<AgentContext> ActOnEffectAsync(AgentContext context)
+    {
+        AgentEffect effect = AgentEffect.For(
+            runId: AgentRun.Current?.Id ?? string.Empty,
+            toolName: context.DirectionType,
+            arguments: context.Payload,
+            riskLevel: RiskLevelFor(context.DirectionType),
+            approvalRequired: RequiresApproval(context.DirectionType),
+            principal: null);
+
+        // 1 — authorize
+        AuthorizationDecision decision = await this.policyBroker.AuthorizeAsync(effect);
+
+        if (decision.Permitted is false)
+        {
+            await this.loggingBroker.LogProcessAsync(
+                "Direction",
+                $"Policy → DENIED '{effect.ToolName}': {decision.Reason}");
+
+            return Denied(context, decision.Reason);
+        }
+
+        // 2 — record the intent, and learn whether this act already happened
+        string? priorOutcome = await this.effectLedgerBroker.SelectOutcomeAsync(effect);
+
+        if (priorOutcome is not null)
+        {
+            await this.loggingBroker.LogProcessAsync(
+                "Direction",
+                $"Run-once → '{effect.ToolName}' already ran; replaying its outcome");
+
+            return Observed(context, priorOutcome);
+        }
+
+        // 3 — approve, if required
+        if (effect.ApprovalRequired)
+        {
+            ApprovalDecision approval = await this.approvalBroker.RequestAsync(effect);
+
+            if (approval is not ApprovalDecision.Approved)
+            {
+                return await HandleUnapprovedAsync(context, effect, approval);
+            }
+
+            await this.loggingBroker.LogProcessAsync(
+                "Direction", $"Approval → APPROVED '{effect.ToolName}'");
+        }
+
+        // 4 — execute
+        string output = await RunToolAsync(context);
+
+        // 5 — record the outcome, before the loop advances
+        await this.effectLedgerBroker.InsertOutcomeAsync(effect, output);
+
+        await this.loggingBroker.LogProcessAsync(
+            "Direction", $"Tool '{effect.ToolName}' ← {context.Payload}", detail: true);
+
+        await this.loggingBroker.LogProcessAsync(
+            "Direction", $"Tool '{effect.ToolName}' → {output}");
+
+        return Observed(context, output);
+    }
+
+    private async ValueTask<AgentContext> HandleUnapprovedAsync(
+        AgentContext context,
+        AgentEffect effect,
+        ApprovalDecision approval)
+    {
+        if (approval is ApprovalDecision.Denied)
+        {
+            string denial = $"approval denied for '{effect.ToolName}'";
+
+            await this.loggingBroker.LogProcessAsync(
+                "Direction", $"Approval → DENIED '{effect.ToolName}'");
+
+            return Denied(context, denial);
+        }
+
+        // Pending. The act is held, not performed — waiting is not consent (SPEC.md §4.9).
+        await this.loggingBroker.LogProcessAsync(
+            "Direction",
+            $"Approval → PENDING '{effect.ToolName}'; the effect was not performed");
+
+        return context with
+        {
+            Result = $"'{effect.ToolName}' is waiting for approval before it can run.",
+            Status = AgentStatus.AwaitingApproval
+        };
+    }
+
+    private async ValueTask<string> RunToolAsync(AgentContext context)
+    {
+        bool isLocalTool = await this.internalToolService.HandlesAsync(context.DirectionType);
+
+        return isLocalTool
+            ? await this.internalToolService.RunAsync(context.DirectionType, context.Payload)
+            : await this.externalToolService.CallAsync(context.DirectionType, context.Payload);
+    }
+
+    // A denial is non-terminal: the agent is told and may choose a permitted path on the next
+    // turn, exactly as it recovers from a malformed call (SPEC.md §4.6, §4.9).
+    private static AgentContext Denied(AgentContext context, string reason) =>
+        context with
+        {
+            Result = reason,
+            Observations = [.. context.Observations, $"{context.DirectionType}: {reason}"],
+            Status = AgentStatus.Working
+        };
+
+    private static AgentContext Observed(AgentContext context, string output) =>
+        context with
+        {
+            Result = output,
+            Observations = [.. context.Observations, $"{context.DirectionType}: {output}"],
+            Status = AgentStatus.Working
+        };
+
+    private RiskLevel RiskLevelFor(string toolName) =>
+        this.irreversibleToolNames.Contains(toolName)
+            ? RiskLevel.Irreversible
+            : RiskLevel.Safe;
+
+    private bool RequiresApproval(string toolName) =>
+        this.irreversibleToolNames.Contains(toolName);
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -3,7 +3,10 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Brokers.Effects;
 using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Policies;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Foundations.ExternalTools;
 using Standard.Agents.Services.Foundations.InternalTools;
@@ -21,27 +24,40 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
     private readonly IExternalToolService externalToolService;
     private readonly IReturnService returnService;
     private readonly ILoggingBroker loggingBroker;
-    private readonly HashSet<string> allowedToolNames;
+    private readonly IPolicyBroker policyBroker;
+    private readonly IApprovalBroker approvalBroker;
+    private readonly IEffectLedgerBroker effectLedgerBroker;
+    private readonly HashSet<string> irreversibleToolNames;
 
     public DirectionOrchestrationService(
         IInternalToolService internalToolService,
         IExternalToolService externalToolService,
         IReturnService returnService,
         ILoggingBroker loggingBroker,
-        IEnumerable<string>? allowedTools = null)
+        IEnumerable<string>? allowedTools = null,
+        IPolicyBroker? policyBroker = null,
+        IApprovalBroker? approvalBroker = null,
+        IEffectLedgerBroker? effectLedgerBroker = null,
+        IEnumerable<string>? irreversibleTools = null)
     {
         this.internalToolService = internalToolService;
         this.externalToolService = externalToolService;
         this.returnService = returnService;
         this.loggingBroker = loggingBroker;
 
-        this.allowedToolNames =
-            new HashSet<string>(allowedTools ?? [], StringComparer.OrdinalIgnoreCase);
-    }
+        // The allow-list is now expressed as a policy, so the simple answer and an external
+        // policy engine travel one seam and a denial carries a reason either way (SPEC.md §4.9).
+        this.policyBroker = policyBroker
+            ?? (allowedTools is null
+                ? new NotConfiguredPolicyBroker()
+                : new AllowListPolicyBroker(allowedTools));
 
-    private bool IsToolForbidden(string toolName) =>
-        this.allowedToolNames.Count > 0
-            && this.allowedToolNames.Contains(toolName) is false;
+        this.approvalBroker = approvalBroker ?? new NotConfiguredApprovalBroker();
+        this.effectLedgerBroker = effectLedgerBroker ?? new InMemoryEffectLedgerBroker();
+
+        this.irreversibleToolNames =
+            new HashSet<string>(irreversibleTools ?? [], StringComparer.OrdinalIgnoreCase);
+    }
 
     public ValueTask<AgentContext> ActAsync(AgentContext context) =>
     TryCatch(async () =>
@@ -62,40 +78,7 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
             };
         }
 
-        if (IsToolForbidden(context.DirectionType))
-        {
-            string denial = $"tool '{context.DirectionType}' is not permitted";
-
-            await this.loggingBroker.LogProcessAsync(
-                "Direction",
-                $"RBAC → DENIED '{context.DirectionType}' (not in the allow-list)");
-
-            return context with
-            {
-                Result = denial,
-                Observations = [.. context.Observations, $"{context.DirectionType}: {denial}"],
-                Status = AgentStatus.Working
-            };
-        }
-
-        bool isLocalTool = await this.internalToolService.HandlesAsync(context.DirectionType);
-
-        string output = isLocalTool
-? await this.internalToolService.RunAsync(context.DirectionType, context.Payload)
-: await this.externalToolService.CallAsync(context.DirectionType, context.Payload);
-
-        await this.loggingBroker.LogProcessAsync(
-            "Direction", $"Tool '{context.DirectionType}' ← {context.Payload}", detail: true);
-
-        await this.loggingBroker.LogProcessAsync(
-            "Direction", $"Tool '{context.DirectionType}' → {output}");
-
-        return context with
-        {
-            Result = output,
-            Observations = [.. context.Observations, $"{context.DirectionType}: {output}"],
-            Status = AgentStatus.Working
-        };
+        return await ActOnEffectAsync(context);
     });
 
     private static bool IsTerminal(string directionType) =>

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -6,7 +6,10 @@
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging.Abstractions;
 using Standard.Agents.Brokers.Audits;
+using Standard.Agents.Brokers.Approvals;
 using Standard.Agents.Brokers.Classifiers;
+using Standard.Agents.Brokers.Effects;
+using Standard.Agents.Brokers.Policies;
 using Standard.Agents.Brokers.Files;
 using Standard.Agents.Brokers.Generators;
 using Standard.Agents.Brokers.Knowledges;
@@ -21,6 +24,7 @@ using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Models.Brokers.Audits;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Foundations.Brains;
+using Standard.Agents.Models.Orchestrations.Effects;
 using Standard.Agents.Models.Loggings;
 using Standard.Agents.Prompts;
 using Standard.Agents.Services.Coordinations;
@@ -78,6 +82,10 @@ public sealed partial class StandardAgent : IAgent
     private IMcpBroker? mcpBroker;
     private ILoggingBroker? loggingBroker;
     private IAuditBroker? auditBroker;
+    private IPolicyBroker? policyBroker;
+    private IApprovalBroker? approvalBroker;
+    private IEffectLedgerBroker? effectLedgerBroker;
+    private IEnumerable<string>? approvalRequiredTools;
     private Func<string?>? principalResolver;
 
     private IAgentCoordinationService? agent;
@@ -451,6 +459,65 @@ public sealed partial class StandardAgent : IAgent
         Set(() => this.allowedTools = toolNames);
 
     /// <summary>
+    /// Authorizes every act against a provider — the <b>External</b> mode of policy (SPEC.md
+    /// §4.8, §4.9). Install a policy package (OPA, Cedar, your own service), pass its broker, and
+    /// each proposed tool call is submitted with its risk and arguments before it runs.
+    /// </summary>
+    /// <param name="broker">The policy broker deciding each effect.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent UsePolicy(IPolicyBroker broker) =>
+        Set(() => this.policyBroker = broker);
+
+    /// <summary>
+    /// Authorizes every act with your own function — the <b>Custom</b> mode of policy. Return
+    /// <see cref="AuthorizationDecision.Deny"/> with a reason; a denial without one cannot be
+    /// audited or appealed.
+    /// </summary>
+    /// <param name="authorize">An <c>effect =&gt; decision</c> delegate.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent OnPolicy(Func<AgentEffect, ValueTask<AuthorizationDecision>> authorize) =>
+        Set(() => this.policyBroker = new FunctionPolicyBroker(authorize));
+
+    /// <summary>
+    /// Holds the named tools until an authority says yes — the <b>Local</b> mode of approval
+    /// (SPEC.md §4.9). A held act stops the turn with <c>AwaitingApproval</c> and <b>does not
+    /// run</b>: with no approver wired in, waiting is not consent. Name the acts you cannot take
+    /// back — a payment, a message sent, a record deleted.
+    /// </summary>
+    /// <param name="toolNames">Tools that may not run unapproved.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent RequireApproval(params string[] toolNames) =>
+        Set(() => this.approvalRequiredTools = toolNames);
+
+    /// <summary>
+    /// Routes approval to a provider — the <b>External</b> mode (a review queue, a chat channel,
+    /// a ticketing system).
+    /// </summary>
+    /// <param name="broker">The approval broker to ask.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent UseApprovals(IApprovalBroker broker) =>
+        Set(() => this.approvalBroker = broker);
+
+    /// <summary>
+    /// Routes approval to your own function — the <b>Custom</b> mode. Return
+    /// <c>ApprovalDecision.Pending</c> to hold the act rather than perform it.
+    /// </summary>
+    /// <param name="request">An <c>effect =&gt; decision</c> delegate.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent OnApproval(Func<AgentEffect, ValueTask<ApprovalDecision>> request) =>
+        Set(() => this.approvalBroker = new FunctionApprovalBroker(request));
+
+    /// <summary>
+    /// Swaps in a custom effect ledger — the record of which acts have already run. The built-in
+    /// ledger gives run-once within one agent instance; a durable ledger extends that across
+    /// processes.
+    /// </summary>
+    /// <param name="broker">The effect ledger broker to use.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent UseEffectLedger(IEffectLedgerBroker broker) =>
+        Set(() => this.effectLedgerBroker = broker);
+
+    /// <summary>
     /// Caps how many Recall→Think→Act turns a single prompt may take before the agent stops —
     /// the shared budget across tool calls and Judge revisions. Defaults to 7. A value below 1
     /// is treated as 1.
@@ -738,7 +805,14 @@ public sealed partial class StandardAgent : IAgent
             new ExternalToolService(mcp, logging),
             new ReturnService(logging),
             logging,
-            this.allowedTools);
+            this.allowedTools,
+            this.policyBroker,
+            this.approvalBroker
+                ?? (this.approvalRequiredTools is null
+                    ? null
+                    : new RequireApprovalBroker(this.approvalRequiredTools)),
+            this.effectLedgerBroker,
+            this.approvalRequiredTools);
 
         return new AgentCoordinationService(data, decision, direction, logging, this.maxTurns);
     }


### PR DESCRIPTION
The effect envelope stops being a model and becomes a guarantee. Implements SPEC.md §3.1/§4.9/§7.7.

Direction now applies the spec's fixed, non-reorderable sequence:

```
authorize → record the intent → approve → execute at most once → record the outcome
```

**The order is the control.** Authorizing after execution audits a fait accompli. Recording intent after execution loses exactly the effects that crashed mid-flight. Approving after execution is not approval.

## What holds now

| Guarantee | Test |
|---|---|
| An irreversible tool does not run unapproved | `ShouldNotRunAnIrreversibleToolWithoutApproval` |
| It runs once approved | `ShouldRunAnIrreversibleToolOnceApproved` |
| It runs **once**, however many times the Brain proposes it | `ShouldRunTheSameEffectOnlyOnceWithinARun` |
| An unauthorized effect is refused **without ending the run** | `ShouldDenyAnUnauthorizedEffectWithoutEndingTheRun` |

A held act stops the turn with `AwaitingApproval` and does not run — **waiting is not consent**. Denials are non-terminal: the agent is told and may choose a permitted path, exactly as it recovers from a malformed call.

## Scope I'm being explicit about

Run-once is enforced through an effect ledger keyed by the derived idempotency key, and **its scope is one agent instance**. That covers a retry inside a run and a repeat proposal across turns — where duplicate effects actually come from today. It does **not** survive a process restart; cross-process run-once needs a durable ledger, which arrives with the session store at 1.0. A host needing it sooner swaps the broker.

The allow-list is now expressed as a policy broker, so the simple answer and an external engine travel one seam and a denial carries a reason either way.

328 unit tests · 15/15 vectors · 0 warnings.