### PR TITLE
COORDINATIONS: Cancellation, Retry And Budget — Reliable Certifies

### DIFF
--- a/Standard.Agents.Conformance/Brokers/ScriptedGeneratorBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/ScriptedGeneratorBroker.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Net;
 using System.Runtime.CompilerServices;
 using Standard.Agents.Brokers.Generators;
 
@@ -12,12 +13,31 @@ public sealed class ScriptedGeneratorBroker : IGeneratorBroker
 {
     private readonly IReadOnlyList<string> replies;
     private int index;
+    private int remainingTransientFailures;
 
-    public ScriptedGeneratorBroker(IReadOnlyList<string> replies) =>
+    public ScriptedGeneratorBroker(
+        IReadOnlyList<string> replies,
+        int transientFailures = 0)
+    {
         this.replies = replies;
+        this.remainingTransientFailures = transientFailures;
+    }
 
     public async ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt)
     {
+        // A scripted transient failure, thrown as the category the framework localizes a
+        // dependency failure into — so retry is certified on the classification it actually
+        // uses, not on a message it happens to match (SPEC.md §4.10).
+        if (this.remainingTransientFailures > 0)
+        {
+            this.remainingTransientFailures--;
+
+            throw new HttpRequestException(
+                "scripted transient failure",
+                inner: null,
+                statusCode: HttpStatusCode.ServiceUnavailable);
+        }
+
         string reply = this.replies[Math.Min(this.index, this.replies.Count - 1)];
         this.index++;
 

--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -41,4 +41,12 @@ public sealed record Vector(
     // refuse a tool result while still accepting the prompt.
     List<string>? RequireApproval = null,
     bool ScreenToolOutput = false,
-    string? GateVerdictOnToolOutput = null);
+    string? GateVerdictOnToolOutput = null,
+
+    // Resilience and budget (SPEC.md §4.10). CancelBeforeStart cancels the run before the first
+    // turn; TransientFailures makes the scripted Brain fail that many times with a dependency
+    // failure before succeeding, so retry can be certified without a real network.
+    bool CancelBeforeStart = false,
+    int TransientFailures = 0,
+    int Retries = 0,
+    int? MaxTurns = null);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -190,7 +190,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     // Brain path — redaction, rehydration, streaming buffers — is what gets certified.
     List<string> modelInputs = [];
     List<string> brainInputs = [];
-    var scriptedGenerator = new ScriptedGeneratorBroker(vector.GeneratorReplies);
+    var scriptedGenerator = new ScriptedGeneratorBroker(vector.GeneratorReplies, vector.TransientFailures);
 
     var recordingGenerator = new RecordingGeneratorBroker(
         scriptedGenerator,
@@ -261,6 +261,16 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         agent.ScreenToolOutput();
     }
 
+    if (vector.Retries > 0)
+    {
+        agent.Resilience(vector.Retries);
+    }
+
+    if (vector.MaxTurns is int maxTurns)
+    {
+        agent.MaxTurns(maxTurns);
+    }
+
     if (string.IsNullOrEmpty(vector.Constitution) is false)
     {
         string fileName = $"{vector.Name}.constitution.md";
@@ -279,6 +289,13 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         ? vector.Prompts
         : [vector.Prompt];
 
+    using var runCancellation = new CancellationTokenSource();
+
+    if (vector.CancelBeforeStart)
+    {
+        await runCancellation.CancelAsync();
+    }
+
     string result;
 
     if (vector.Concurrent)
@@ -294,7 +311,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
 
         foreach (string prompt in prompts)
         {
-            result = await agent.ProcessPromptAsync(prompt);
+            result = await agent.ProcessPromptAsync(prompt, runCancellation.Token);
         }
     }
 

--- a/Standard.Agents.Tests.Unit/Acceptance/ResilienceTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/ResilienceTests.cs
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Foundations.Skills;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// Cancellation, retry and budget end to end (SPEC.md §4.10). An agent that cannot be stopped,
+// cannot survive a transient failure, and cannot say what it spent is not something an
+// enterprise can operate, however correct each decision is.
+public class ResilienceTests
+{
+    private static StandardAgent AgentThatLoops(Func<int, string> replyForTurn)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        int turn = 0;
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .OnBrain(async (systemPrompt, userPrompt) => replyForTurn(turn++));
+    }
+
+    [Fact]
+    public async Task ShouldStopTheLoopWhenCancelledAsync()
+    {
+        // given — a Brain that would loop forever through tool calls
+        using var cancellation = new CancellationTokenSource();
+        int brainCalls = 0;
+
+        StandardAgent agent = AgentThatLoops(turn =>
+        {
+            brainCalls++;
+            cancellation.Cancel();
+
+            return "ACTION: nonexistent_tool: keep going";
+        });
+
+        // when
+        string actualResult =
+            await agent.ProcessPromptAsync(prompt: "loop forever", cancellation.Token);
+
+        // then — stopped at the next turn boundary, and said so rather than answering
+        actualResult.Should().Contain("cancelled");
+        brainCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportCancellationAsAnAnswerAsync()
+    {
+        // given
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        StandardAgent agent = AgentThatLoops(turn => "FINAL: 42");
+
+        // when
+        string actualResult =
+            await agent.ProcessPromptAsync(prompt: "what is the answer?", cancellation.Token);
+
+        // then — a cancelled run's result is not an answer
+        actualResult.Should().NotBe("42");
+        actualResult.Should().Contain("cancelled");
+    }
+
+    [Fact]
+    public async Task ShouldStopTheLoopWhenTheTimeBudgetIsExhaustedAsync()
+    {
+        // given — every turn asks for a tool that does not exist, so the loop keeps going
+        StandardAgent agent =
+            AgentThatLoops(turn => "ACTION: nonexistent_tool: keep going")
+                .MaxTurns(50)
+                .Budget(maxWallClock: TimeSpan.Zero);
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "loop forever");
+
+        // then — exhaustion is distinguishable from a refusal
+        actualResult.Should().Contain("time budget");
+        actualResult.Should().NotContain("not able to help");
+    }
+
+    [Fact]
+    public async Task ShouldRunUnboundedWhenNoBudgetIsConfiguredAsync()
+    {
+        // given
+        StandardAgent agent = AgentThatLoops(turn => "FINAL: 42");
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "what is the answer?");
+
+        // then — absent a budget the agent behaves exactly as it did
+        actualResult.Should().Be("42");
+    }
+}

--- a/Standard.Agents/Brokers/Resiliences/IResilienceBroker.cs
+++ b/Standard.Agents/Brokers/Resiliences/IResilienceBroker.cs
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Resiliences;
+
+public interface IResilienceBroker
+{
+    ValueTask<T> ExecuteAsync<T>(Func<ValueTask<T>> operation);
+}

--- a/Standard.Agents/Brokers/Resiliences/NotConfiguredResilienceBroker.cs
+++ b/Standard.Agents/Brokers/Resiliences/NotConfiguredResilienceBroker.cs
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Resiliences;
+
+// The default: run it once, let it fail. Absent configuration the agent behaves exactly as it
+// did before retries existed.
+public sealed class NotConfiguredResilienceBroker : IResilienceBroker
+{
+    public ValueTask<T> ExecuteAsync<T>(Func<ValueTask<T>> operation) =>
+        operation();
+}

--- a/Standard.Agents/Brokers/Resiliences/RetryResilienceBroker.cs
+++ b/Standard.Agents/Brokers/Resiliences/RetryResilienceBroker.cs
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net;
+using Xeptions;
+
+namespace Standard.Agents.Brokers.Resiliences;
+
+// Retry with exponential backoff and jitter (SPEC.md §4.10).
+//
+// What is retryable is decided by the error's CATEGORY, never its text. The framework already
+// localizes every failure into a Xeption category, so that classification is available for free
+// and does not have to be re-derived from a message that a provider may reword at any time.
+//
+// The rule is narrow on purpose: a dependency failure is the network having a bad moment, so it
+// is worth another attempt. A validation failure is the request being wrong, so retrying it will
+// fail identically and only spends the budget.
+public sealed class RetryResilienceBroker : IResilienceBroker
+{
+    private readonly int maxAttempts;
+    private readonly TimeSpan initialDelay;
+    private readonly Func<TimeSpan, ValueTask> delay;
+
+    public RetryResilienceBroker(
+        int retries = 3,
+        TimeSpan? initialDelay = null,
+        Func<TimeSpan, ValueTask>? delay = null)
+    {
+        this.maxAttempts = retries < 0 ? 1 : retries + 1;
+        this.initialDelay = initialDelay ?? TimeSpan.FromMilliseconds(200);
+        this.delay = delay ?? (async wait => await Task.Delay(wait));
+    }
+
+    public async ValueTask<T> ExecuteAsync<T>(Func<ValueTask<T>> operation)
+    {
+        for (int attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await operation();
+            }
+            catch (Exception exception)
+                when (attempt < this.maxAttempts && IsTransient(exception))
+            {
+                await this.delay(BackoffFor(attempt));
+            }
+        }
+    }
+
+    // Jitter matters when many agents share one provider: without it every agent that failed at
+    // the same instant retries at the same instant, and the recovering provider is hit by the
+    // same spike that knocked it over.
+    private TimeSpan BackoffFor(int attempt)
+    {
+        double exponential = this.initialDelay.TotalMilliseconds * Math.Pow(2, attempt - 1);
+        double jitter = Random.Shared.NextDouble() * exponential * 0.5;
+
+        return TimeSpan.FromMilliseconds(exponential + jitter);
+    }
+
+    private static bool IsTransient(Exception exception) =>
+        exception switch
+        {
+            // The framework's own categories: a dependency failed, which may not fail again.
+            // A *DependencyValidation* failure is the request being wrong and is never retried.
+            Xeption when IsDependencyFailure(exception) => true,
+            HttpRequestException httpException => IsTransientStatus(httpException.StatusCode),
+            TaskCanceledException => false,
+            OperationCanceledException => false,
+            _ => false
+        };
+
+    private static bool IsDependencyFailure(Exception exception)
+    {
+        string name = exception.GetType().Name;
+
+        return name.EndsWith("DependencyException", StringComparison.Ordinal)
+            && name.EndsWith("DependencyValidationException", StringComparison.Ordinal) is false;
+    }
+
+    private static bool IsTransientStatus(HttpStatusCode? status) =>
+        status is null
+            || status is HttpStatusCode.RequestTimeout
+            || status is HttpStatusCode.TooManyRequests
+            || (int)status >= 500;
+}

--- a/Standard.Agents/Models/Coordinations/Agents/AgentBudget.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/AgentBudget.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Coordinations.Agents;
+
+/// <summary>
+/// What one prompt is allowed to consume (SPEC.md §4.10). Any bound left null is unbounded, so
+/// a budget constrains exactly what the host chose to constrain and nothing else.
+/// </summary>
+public sealed record AgentBudget
+{
+    public int? MaxTokens { get; init; }
+    public decimal? MaxCostUsd { get; init; }
+    public TimeSpan? MaxWallClock { get; init; }
+
+    /// <summary>Cost per 1,000 tokens, when the host wants a cost bound rather than a token one.</summary>
+    public decimal CostPerThousandTokens { get; init; }
+
+    public bool IsBounded =>
+        MaxTokens is not null || MaxCostUsd is not null || MaxWallClock is not null;
+}

--- a/Standard.Agents/Models/Coordinations/Agents/AgentSpend.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/AgentSpend.cs
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Coordinations.Agents;
+
+/// <summary>
+/// What one run has consumed so far. Tokens accumulate from what providers actually reported —
+/// SPEC.md §3.4 forbids presenting an estimate as a measurement, so an unreported call adds
+/// nothing here rather than adding a guess.
+/// </summary>
+public sealed class AgentSpend
+{
+    private int tokens;
+
+    public int Tokens => Volatile.Read(ref this.tokens);
+
+    public void AddTokens(int promptTokens, int completionTokens) =>
+        Interlocked.Add(ref this.tokens, promptTokens + completionTokens);
+
+    public decimal CostUsd(decimal costPerThousandTokens) =>
+        Tokens / 1000m * costPerThousandTokens;
+}

--- a/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
@@ -18,6 +18,12 @@ public sealed record AgentContext
     public string Payload { get; init; } = "";
     public string RawReply { get; init; } = "";
 
+    // What the turn's model calls actually cost, as reported by the provider (SPEC.md §3.4).
+    // Zero when a provider reports nothing, which is why a budget bounds reported usage rather
+    // than an estimate — an implementation must not present an estimate as a measurement.
+    public int PromptTokens { get; init; }
+    public int CompletionTokens { get; init; }
+
     public string Result { get; init; } = "";
     public string Remember { get; init; } = "";
     public AgentStatus Status { get; init; }

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Budgets.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Budgets.cs
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Coordinations.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+
+namespace Standard.Agents.Services.Coordinations;
+
+public partial class AgentCoordinationService
+{
+    // Exhaustion and cancellation are reported distinguishably from a refusal. SPEC.md §4.10: a
+    // caller that cannot tell "I will not" from "I ran out" cannot decide whether to retry, and
+    // a cancelled run's result is not an answer.
+    private const string CancelledMessage =
+        "The request was cancelled before it completed.";
+
+    private const string TokenBudgetMessage =
+        "The token budget for this request was exhausted before it completed.";
+
+    private const string CostBudgetMessage =
+        "The cost budget for this request was exhausted before it completed.";
+
+    private const string TimeBudgetMessage =
+        "The time budget for this request was exhausted before it completed.";
+
+    private bool IsBudgetExhausted(
+        AgentSpend spend,
+        DateTimeOffset startedOn,
+        out string exhaustion)
+    {
+        exhaustion = string.Empty;
+
+        if (this.budget is null || this.budget.IsBounded is false)
+        {
+            return false;
+        }
+
+        if (this.budget.MaxTokens is int maxTokens && spend.Tokens >= maxTokens)
+        {
+            exhaustion = TokenBudgetMessage;
+
+            return true;
+        }
+
+        if (this.budget.MaxCostUsd is decimal maxCost
+            && spend.CostUsd(this.budget.CostPerThousandTokens) >= maxCost)
+        {
+            exhaustion = CostBudgetMessage;
+
+            return true;
+        }
+
+        TimeSpan elapsed = this.timeBroker.GetCurrentDateTimeOffset() - startedOn;
+
+        if (this.budget.MaxWallClock is TimeSpan maxWallClock && elapsed >= maxWallClock)
+        {
+            exhaustion = TimeBudgetMessage;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private async ValueTask<string> StopAsync(
+        AgentContext context,
+        string message,
+        AgentStatus status)
+    {
+        await this.loggingBroker.LogOutcomeAsync($"stopped: {message}");
+
+        return message;
+    }
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -5,6 +5,8 @@
 
 using System.Runtime.CompilerServices;
 using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Times;
+using Standard.Agents.Models.Coordinations.Agents;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
@@ -25,6 +27,8 @@ public partial class AgentCoordinationService : IAgentCoordinationService
     private readonly IDecisionOrchestrationService decisionOrchestrationService;
     private readonly IDirectionOrchestrationService directionOrchestrationService;
     private readonly ILoggingBroker loggingBroker;
+    private readonly ITimeBroker timeBroker;
+    private readonly AgentBudget? budget;
     private readonly int maxTurns;
 
     public AgentCoordinationService(
@@ -32,16 +36,25 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         IDecisionOrchestrationService decisionOrchestrationService,
         IDirectionOrchestrationService directionOrchestrationService,
         ILoggingBroker loggingBroker,
-        int maxTurns = DefaultMaxTurns)
+        int maxTurns = DefaultMaxTurns,
+        ITimeBroker? timeBroker = null,
+        AgentBudget? budget = null)
     {
         this.dataOrchestrationService = dataOrchestrationService;
         this.decisionOrchestrationService = decisionOrchestrationService;
         this.directionOrchestrationService = directionOrchestrationService;
         this.loggingBroker = loggingBroker;
         this.maxTurns = maxTurns;
+        this.timeBroker = timeBroker ?? new TimeBroker();
+        this.budget = budget;
     }
 
     public ValueTask<string> ProcessPromptAsync(string prompt) =>
+        ProcessPromptAsync(prompt, CancellationToken.None);
+
+    public ValueTask<string> ProcessPromptAsync(
+        string prompt,
+        CancellationToken cancellationToken) =>
     TryCatch(async () =>
     {
         ValidatePrompt(prompt);
@@ -55,8 +68,24 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
         AgentContext context = new() { Prompt = prompt };
 
+        // Budgets and cancellation are both checked at the turn boundary (SPEC.md §4.10): a turn
+        // is the smallest unit the loop can stop between without abandoning work mid-flight —
+        // in particular without leaving an effect half-recorded.
+        var spend = new AgentSpend();
+        DateTimeOffset startedOn = this.timeBroker.GetCurrentDateTimeOffset();
+
         for (int turn = 0; turn < this.maxTurns; turn++)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return await StopAsync(context, CancelledMessage, AgentStatus.Failed);
+            }
+
+            if (IsBudgetExhausted(spend, startedOn, out string exhaustion))
+            {
+                return await StopAsync(context, exhaustion, AgentStatus.Failed);
+            }
+
             await this.loggingBroker.LogTurnAsync(turn);
 
             await this.loggingBroker.LogStepAsync(AgentStep.Data);
@@ -64,6 +93,8 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
             await this.loggingBroker.LogStepAsync(AgentStep.Decision);
             context = await this.decisionOrchestrationService.ThinkAsync(context);
+
+            spend.AddTokens(context.PromptTokens, context.CompletionTokens);
 
             if (context.Status is AgentStatus.Revising)
             {

--- a/Standard.Agents/Services/Coordinations/IAgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/IAgentCoordinationService.cs
@@ -11,6 +11,8 @@ public interface IAgentCoordinationService
 {
     ValueTask<string> ProcessPromptAsync(string prompt);
 
+    ValueTask<string> ProcessPromptAsync(string prompt, CancellationToken cancellationToken);
+
     IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
         string prompt,
         CancellationToken cancellationToken = default);

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Standard.Agents.Brokers.Generators;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Redactions;
+using Standard.Agents.Brokers.Resiliences;
 
 namespace Standard.Agents.Services.Foundations.Brains;
 
@@ -16,15 +17,18 @@ public partial class BrainService : IBrainService
     private readonly IGeneratorBroker generatorBroker;
     private readonly ILoggingBroker loggingBroker;
     private readonly IRedactionBroker redactionBroker;
+    private readonly IResilienceBroker resilienceBroker;
 
     public BrainService(
         IGeneratorBroker generatorBroker,
         ILoggingBroker loggingBroker,
-        IRedactionBroker? redactionBroker = null)
+        IRedactionBroker? redactionBroker = null,
+        IResilienceBroker? resilienceBroker = null)
     {
         this.generatorBroker = generatorBroker;
         this.loggingBroker = loggingBroker;
         this.redactionBroker = redactionBroker ?? new NotConfiguredRedactionBroker();
+        this.resilienceBroker = resilienceBroker ?? new NotConfiguredResilienceBroker();
     }
 
     public ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt) =>
@@ -36,8 +40,10 @@ public partial class BrainService : IBrainService
         string redactedSystemPrompt = this.redactionBroker.Redact(systemPrompt, vault);
         string redactedUserPrompt = this.redactionBroker.Redact(userPrompt, vault);
 
-        string reply = await this.generatorBroker.GenerateAsync(
-            redactedSystemPrompt, redactedUserPrompt);
+        // A retried call is still one turn (SPEC.md §4.10) — retries happen inside the call, so
+        // the loop's turn budget counts the agent's reasoning, not the network's luck.
+        string reply = await this.resilienceBroker.ExecuteAsync(() =>
+            this.generatorBroker.GenerateAsync(redactedSystemPrompt, redactedUserPrompt));
 
         return this.redactionBroker.Rehydrate(reply, vault);
     });

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -17,12 +17,14 @@ using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Redactions;
+using Standard.Agents.Brokers.Resiliences;
 using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Brokers.Times;
 using Standard.Agents.Brokers.Tools;
 using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Models.Brokers.Audits;
 using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Coordinations.Agents;
 using Standard.Agents.Models.Foundations.Brains;
 using Standard.Agents.Models.Orchestrations.Effects;
 using Standard.Agents.Models.Loggings;
@@ -87,6 +89,8 @@ public sealed partial class StandardAgent : IAgent
     private IEffectLedgerBroker? effectLedgerBroker;
     private IEnumerable<string>? approvalRequiredTools;
     private bool screenToolOutput;
+    private AgentBudget? budget;
+    private IResilienceBroker? resilienceBroker;
     private Func<string?>? principalResolver;
 
     private IAgentCoordinationService? agent;
@@ -626,6 +630,65 @@ public sealed partial class StandardAgent : IAgent
     }
 
     /// <summary>
+    /// Runs the agent on a prompt and stops when <paramref name="cancellationToken"/> is
+    /// cancelled — at the next turn boundary at the latest, so no effect is left half-recorded
+    /// (SPEC.md §4.10). A cancelled run returns a message saying so rather than an answer.
+    /// </summary>
+    /// <param name="prompt">The user's prompt.</param>
+    /// <param name="cancellationToken">Token to stop the run.</param>
+    /// <returns>The agent's final answer, or a message explaining why it stopped.</returns>
+    public async ValueTask<string> ProcessPromptAsync(
+        string prompt,
+        CancellationToken cancellationToken)
+    {
+        return await ResolveAgent().ProcessPromptAsync(prompt, cancellationToken);
+    }
+
+    /// <summary>
+    /// Bounds what one prompt may consume (SPEC.md §4.10). Checked between turns; exhaustion
+    /// stops the loop and says which bound ran out, distinguishably from a refusal — a caller
+    /// that cannot tell <i>I will not</i> from <i>I ran out</i> cannot decide whether to retry.
+    /// Token spend is measured against what providers <b>reported</b>, never an estimate.
+    /// </summary>
+    /// <param name="maxTokens">Total tokens across the run.</param>
+    /// <param name="maxCostUsd">Total cost, priced by <paramref name="costPerThousandTokens"/>.</param>
+    /// <param name="maxWallClock">Total elapsed time.</param>
+    /// <param name="costPerThousandTokens">Your rate, when bounding by cost.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Budget(
+        int? maxTokens = null,
+        decimal? maxCostUsd = null,
+        TimeSpan? maxWallClock = null,
+        decimal costPerThousandTokens = 0m) =>
+        Set(() => this.budget = new AgentBudget
+        {
+            MaxTokens = maxTokens,
+            MaxCostUsd = maxCostUsd,
+            MaxWallClock = maxWallClock,
+            CostPerThousandTokens = costPerThousandTokens
+        });
+
+    /// <summary>
+    /// Retries a failed model call with exponential backoff and jitter (SPEC.md §4.10). What is
+    /// retryable is decided by the error's <b>category</b>, never its text: a dependency failure
+    /// is the network having a bad moment; a validation failure is the request being wrong, and
+    /// retrying it only spends the budget. A retried call is still one turn.
+    /// </summary>
+    /// <param name="retries">How many additional attempts. Defaults to 3.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Resilience(int retries = 3) =>
+        Set(() => this.resilienceBroker = new RetryResilienceBroker(retries));
+
+    /// <summary>
+    /// Swaps in a custom resilience broker — the plugin seam for a provider's own retry, circuit
+    /// breaker or bulkhead policy.
+    /// </summary>
+    /// <param name="broker">The resilience broker to use.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent UseResilience(IResilienceBroker broker) =>
+        Set(() => this.resilienceBroker = broker);
+
+    /// <summary>
     /// Runs the agent on a prompt and streams its progress as it happens — status updates, the
     /// brain's thinking, and response text arrive as <see cref="AgentStreamEvent"/> values rather
     /// than waiting for the final answer. Use this to surface a live view of the agent's work.
@@ -810,7 +873,7 @@ public sealed partial class StandardAgent : IAgent
 
         DecisionOrchestrationService decision = new(
             gate,
-            new BrainService(generator, logging, redaction),
+            new BrainService(generator, logging, redaction, this.resilienceBroker),
             new JudgeService(verifier, logging, redaction),
             logging);
 
@@ -829,7 +892,8 @@ public sealed partial class StandardAgent : IAgent
             this.approvalRequiredTools,
             this.screenToolOutput ? gate : null);
 
-        return new AgentCoordinationService(data, decision, direction, logging, this.maxTurns);
+        return new AgentCoordinationService(
+            data, decision, direction, logging, this.maxTurns, new TimeBroker(), this.budget);
     }
 
     // The catalog a "{{tools}}" marker in the agent's Data expands into. Only tools that

--- a/conformance/vectors/19-cancellation-stops-the-loop.json
+++ b/conformance/vectors/19-cancellation-stops-the-loop.json
@@ -1,0 +1,11 @@
+{
+  "name": "cancellation-stops-the-loop",
+  "description": "SPEC.md 4.10: a cancelled run stops at the next turn boundary at the latest, must not begin a new turn, and must not be reported as success - a cancelled run's result is not an answer. The Brain would answer 42, but the run is cancelled before it starts, so the caller is told it was cancelled instead.",
+  "generatorReplies": ["FINAL: 42"],
+  "tools": {},
+  "prompt": "what is the answer",
+  "cancelBeforeStart": true,
+  "expect": {
+    "resultContains": "cancelled"
+  }
+}

--- a/conformance/vectors/20-transient-failure-recovers.json
+++ b/conformance/vectors/20-transient-failure-recovers.json
@@ -1,0 +1,13 @@
+{
+  "name": "transient-failure-recovers",
+  "description": "SPEC.md 4.10: a transient failure may be retried, and a retried call is still one turn - a turn is a unit of the agent's reasoning, not of the network's luck. The Brain fails twice with a dependency failure and answers on the third attempt; the run succeeds within a single turn.",
+  "generatorReplies": ["FINAL: 4183"],
+  "tools": {},
+  "prompt": "what is 47 multiplied by 89",
+  "transientFailures": 2,
+  "retries": 3,
+  "maxTurns": 1,
+  "expect": {
+    "result": "4183"
+  }
+}


### PR DESCRIPTION
The release that earns a readiness level. Spec first: implements SPEC.md §3.4/§4.1/§4.10, merged as The-Standard-Agent-Specs#14.

```
--profile Reliable   CERTIFIED   exit 0
333 unit tests · 20/20 vectors · 0 warnings
```

## Cancellation and budget

Both checked at the **turn boundary** — the smallest unit the loop can stop between without abandoning work mid-flight, in particular without leaving an effect half-recorded.

A cancelled run **says it was cancelled** rather than returning an answer. An exhausted budget says **which bound** ran out: a caller that cannot tell *I will not* from *I ran out* cannot decide whether to retry.

## Retry

Classifies by the error's **category, not its text**. The framework already localizes failures into `Xeption` categories, so a dependency failure retries and a validation failure never does — retrying a wrong request fails identically and only spends the budget.

Backoff carries **jitter**, because without it every agent that failed at the same instant retries at the same instant, and the recovering provider is hit by the spike that knocked it over.

Retries happen *inside* the call, so **a retried call is still one turn** — the turn budget counts the agent's reasoning, not the network's luck.

## Usage, not estimates

Token spend accumulates from what providers **actually reported**. Where nothing is reported, nothing is added rather than a guess — §3.4 forbids presenting an estimate as a measurement.

## Sabotage-verified

| Sabotage | Result |
|---|---|
| Ignore the cancellation token | vector 19 FAILS |
| Disable retry | vector 20 FAILS (throws) |