### PR TITLE
FOUNDATIONS: Ranked Retrieval, Screen-Once And Degradation — Enterprise Certifies

### DIFF
--- a/Standard.Agents.Conformance/Models/Expectation.cs
+++ b/Standard.Agents.Conformance/Models/Expectation.cs
@@ -50,4 +50,10 @@ public sealed record Expectation(
     //   BrainNeverSees  — this text must never reach the Brain, however it entered as Data.
     List<string>? ToolNeverRan = null,
     Dictionary<string, int>? ToolRunCount = null,
-    string? BrainNeverSees = null);
+    string? BrainNeverSees = null,
+
+    //   BrainSees                — this text must have reached the Brain, which is how retrieval
+    //                              is certified: the passage that answers the question got there.
+    //   GateScreenedPromptTimes  — exactly how many times the Gate was asked about the prompt.
+    string? BrainSees = null,
+    int? GateScreenedPromptTimes = null);

--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -49,4 +49,11 @@ public sealed record Vector(
     bool CancelBeforeStart = false,
     int TransientFailures = 0,
     int Retries = 0,
-    int? MaxTurns = null);
+    int? MaxTurns = null,
+
+    // Budget, retrieval and degradation (SPEC.md §4.2, §4.10).
+    double? BudgetMaxWallClockSeconds = null,
+    Dictionary<string, string>? Knowledge = null,
+    string? FallbackReply = null,
+    int FailuresBeforeOpen = 3,
+    int KnowledgeMaxResults = 3);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -190,6 +190,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     // Brain path — redaction, rehydration, streaming buffers — is what gets certified.
     List<string> modelInputs = [];
     List<string> brainInputs = [];
+    int promptScreenings = 0;
     var scriptedGenerator = new ScriptedGeneratorBroker(vector.GeneratorReplies, vector.TransientFailures);
 
     var recordingGenerator = new RecordingGeneratorBroker(
@@ -200,7 +201,6 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         .UseSkills(new StubSkillBroker())
         .UseGenerator(recordingGenerator)
         .UseMemory(new StubMemoryBroker())
-        .UseKnowledge(new StubKnowledgeBroker())
         .UseMcp(new NotConfiguredMcpBroker())
         .Tools(stubTools.Values)
         .OnGate((rubric, prompt) =>
@@ -210,6 +210,11 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
             lock (auditLock)
             {
                 modelInputs.Add(prompt);
+
+                if (prompt.Equals(vector.Prompt, StringComparison.Ordinal))
+                {
+                    promptScreenings++;
+                }
             }
 
             // Screening reuses the Gate, so the same scripted guardian answers for the prompt
@@ -271,6 +276,41 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         agent.MaxTurns(maxTurns);
     }
 
+    if (vector.BudgetMaxWallClockSeconds is double seconds)
+    {
+        agent.Budget(maxWallClock: TimeSpan.FromSeconds(seconds));
+    }
+
+    if (vector.FallbackReply is string fallbackReply)
+    {
+        agent.Fallback(
+            fallback: () => new ValueTask<string>(fallbackReply),
+            failuresBeforeOpen: vector.FailuresBeforeOpen);
+    }
+
+    // A real knowledge folder, so the ranked retriever is certified against files rather than a
+    // stub that could agree with any implementation. A vector without knowledge keeps the empty
+    // stub, so nothing is retrieved and no vector is disturbed by this one existing.
+    string? knowledgePath = null;
+
+    if (vector.Knowledge is not { Count: > 0 })
+    {
+        agent.UseKnowledge(new StubKnowledgeBroker());
+    }
+    else
+    {
+        knowledgePath = Path.Combine(AppContext.BaseDirectory, $"knowledge-{vector.Name}");
+        Directory.CreateDirectory(knowledgePath);
+
+        foreach (KeyValuePair<string, string> document in vector.Knowledge)
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(knowledgePath, document.Key), document.Value);
+        }
+
+        agent.Knowledge(knowledgePath, maxResults: vector.KnowledgeMaxResults);
+    }
+
     if (string.IsNullOrEmpty(vector.Constitution) is false)
     {
         string fileName = $"{vector.Name}.constitution.md";
@@ -315,7 +355,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         }
     }
 
-    return new VectorRun(result, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, auditRecords);
+    return new VectorRun(result, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, promptScreenings, auditRecords);
 }
 
 // The decision log's guarantees, certified from the records themselves: one run per prompt,
@@ -507,6 +547,26 @@ static bool GuardianInputConformant(
         return false;
     }
 
+    // Retrieval is certified by what reached the Brain: the passage that answers the question
+    // has to actually get there (SPEC.md §4.2).
+    if (vector.Expect.BrainSees is string required
+        && run.BrainInputs.Any(input => input.Contains(required, StringComparison.Ordinal)) is false)
+    {
+        failure = $"the Brain was never shown the retrieved text: {Show(required)}";
+
+        return false;
+    }
+
+    if (vector.Expect.GateScreenedPromptTimes is int expectedScreenings
+        && run.PromptScreenings != expectedScreenings)
+    {
+        failure =
+            $"the Gate screened the prompt {run.PromptScreenings} time(s), "
+                + $"expected {expectedScreenings}";
+
+        return false;
+    }
+
     // Redaction is only satisfied if EVERY model call is clean. Checking the Brain alone is the
     // exact mistake this vector exists to catch (SPEC.md §4.6).
     if (vector.Expect.NoModelSees is string secret)
@@ -616,4 +676,5 @@ internal sealed record VectorRun(
     string? JudgeInput,
     List<string> ModelInputs,
     List<string> BrainInputs,
+    int PromptScreenings,
     List<AuditRecord> AuditRecords);

--- a/Standard.Agents.Tests.Unit/Acceptance/RetrievalTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/RetrievalTests.cs
@@ -1,0 +1,106 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Files;
+using Standard.Agents.Services.Foundations.Knowledges;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// SPEC.md §4.2: retrieval answers "what is relevant to this task", not "what exists".
+//
+// The regression this pins is the one that made the feature look configured and return nothing:
+// matching the whole prompt literally against whole documents. A natural question never appears
+// verbatim inside its own answer, so the old implementation retrieved zero results for exactly
+// the queries a user asks.
+public class RetrievalTests : IDisposable
+{
+    private readonly string knowledgePath =
+        Path.Combine(Path.GetTempPath(), $"knowledge-{Guid.NewGuid():n}");
+
+    private IKnowledgeService KnowledgeOver(params (string Name, string Body)[] documents)
+    {
+        Directory.CreateDirectory(this.knowledgePath);
+
+        foreach ((string name, string body) in documents)
+        {
+            File.WriteAllText(Path.Combine(this.knowledgePath, name), body);
+        }
+
+        return new KnowledgeService(
+            fileBroker: new FileBroker(),
+            knowledgePath: this.knowledgePath,
+            searchPattern: "*.md",
+            maxResults: 1,
+            loggingBroker: new Mock<ILoggingBroker>().Object);
+    }
+
+    [Fact]
+    public async Task ShouldRetrieveThePassageThatAnswersANaturalQuestionAsync()
+    {
+        // given
+        IKnowledgeService knowledgeService = KnowledgeOver(
+            ("refunds.md",
+                "Refund policy. Enterprise customers may request a refund within 90 days of "
+                    + "purchase. Refunds are issued to the original payment method."),
+            ("shipping.md",
+                "Shipping policy. Orders ship within two business days. Expedited shipping is "
+                    + "available for an additional fee."),
+            ("holidays.md",
+                "The office is closed on public holidays and reopens the next business day."));
+
+        // when — a question, phrased as a person would phrase it
+        IReadOnlyList<string> actualPassages = await knowledgeService.RetrieveKnowledgeAsync(
+            query: "what is our refund policy for enterprise customers?");
+
+        // then
+        actualPassages.Should().ContainSingle();
+        actualPassages[0].Should().Contain("90 days");
+    }
+
+    [Fact]
+    public async Task ShouldPreferTheRarerTermWhenRankingAsync()
+    {
+        // given — "policy" is in every document, so it says nothing; "refund" singles one out
+        IKnowledgeService knowledgeService = KnowledgeOver(
+            ("a.md", "Shipping policy. This policy covers delivery."),
+            ("b.md", "Returns policy. This policy covers refund requests and their handling."),
+            ("c.md", "Privacy policy. This policy covers data."));
+
+        // when
+        IReadOnlyList<string> actualPassages =
+            await knowledgeService.RetrieveKnowledgeAsync(query: "refund policy");
+
+        // then
+        actualPassages.Should().ContainSingle();
+        actualPassages[0].Should().Contain("refund");
+    }
+
+    [Fact]
+    public async Task ShouldRetrieveNothingWhenNothingIsRelevantAsync()
+    {
+        // given
+        IKnowledgeService knowledgeService = KnowledgeOver(
+            ("a.md", "Shipping policy. Orders ship within two business days."));
+
+        // when
+        IReadOnlyList<string> actualPassages =
+            await knowledgeService.RetrieveKnowledgeAsync(query: "quantum chromodynamics");
+
+        // then — silence is the right answer when nothing matches
+        actualPassages.Should().BeEmpty();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this.knowledgePath))
+        {
+            Directory.Delete(this.knowledgePath, recursive: true);
+        }
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Logic.RetrieveKnowledgeFromFiles.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Knowledges/KnowledgeServiceTests.Logic.RetrieveKnowledgeFromFiles.cs
@@ -47,8 +47,12 @@ public partial class KnowledgeServiceTests
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
 
+    // Ranking replaced first-N-found (SPEC.md §4.2), and the difference is visible here: every
+    // document is read, because relevance is relative — a term's weight depends on how rare it
+    // is across the corpus, which is not knowable from a prefix of it. The old contract stopped
+    // reading once it had enough matches, and so could only ever return the first ones found.
     [Fact]
-    public async Task ShouldRetrieveMatchingKnowledgeFromOrderedFilesUpToMaxResultsAsync()
+    public async Task ShouldRetrieveTheMostRelevantKnowledgeUpToMaxResultsAsync()
     {
         // given
         string knowledgePath = CreateRandomString();
@@ -62,12 +66,10 @@ public partial class KnowledgeServiceTests
         string fourthPath = "d.md";
         List<string> unorderedPaths = [thirdPath, firstPath, fourthPath, secondPath];
 
-        string firstDocument = "alpha needle";        // matches
-        string secondDocument = "beta";               // no match, skipped
-        string thirdDocument = "gamma NEEDLE";         // matches (case-insensitive) -> reaches maxResults
-        string fourthDocument = "delta needle";        // matches but never read (max already reached)
-
-        IReadOnlyList<string> expectedDocuments = [firstDocument, thirdDocument];
+        string firstDocument = "alpha needle";
+        string secondDocument = "beta";                // carries no query term, scores zero
+        string thirdDocument = "gamma NEEDLE";          // case-insensitive
+        string fourthDocument = "delta needle";
 
         var fileKnowledgeService = new KnowledgeService(
             fileBroker: this.fileBrokerMock.Object,
@@ -104,8 +106,12 @@ public partial class KnowledgeServiceTests
         IReadOnlyList<string> actualDocuments =
             await fileKnowledgeService.RetrieveKnowledgeAsync(query);
 
-        // then
-        actualDocuments.Should().Equal(expectedDocuments);
+        // then — the best matches, capped, and never the document carrying no query term
+        actualDocuments.Should().HaveCount(maxResults);
+        actualDocuments.Should().NotContain(secondDocument);
+
+        actualDocuments.Should().OnlyContain(document =>
+            document.Contains("needle", StringComparison.OrdinalIgnoreCase));
 
         this.fileBrokerMock.Verify(broker =>
             broker.DirectoryExists(knowledgePath),
@@ -129,7 +135,7 @@ public partial class KnowledgeServiceTests
 
         this.fileBrokerMock.Verify(broker =>
             broker.ReadFileAsync(fourthPath),
-                Times.Never);
+                Times.Once);
 
         this.fileBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents/Brokers/Resiliences/FallbackResilienceBroker.cs
+++ b/Standard.Agents/Brokers/Resiliences/FallbackResilienceBroker.cs
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Resiliences;
+
+// Degradation before failure (SPEC.md §4.10). After enough consecutive failures the primary is
+// judged unhealthy and the circuit opens: calls stop going to something that is not answering
+// and go to the alternative instead. A degraded answer is worth more than no answer.
+//
+// It refuses to pretend. With no alternative configured this broker fails rather than returning
+// an empty result, because a caller cannot tell fabricated silence from a real one.
+//
+// The circuit closes again after a cool-down, so a provider that recovers is used again without
+// anyone restarting anything.
+public sealed class FallbackResilienceBroker : IResilienceBroker
+{
+    private readonly IResilienceBroker primary;
+    private readonly Func<ValueTask<string>>? alternative;
+    private readonly int failuresBeforeOpen;
+    private readonly TimeSpan coolDown;
+    private readonly Func<DateTimeOffset> now;
+
+    private readonly Lock circuitLock = new();
+    private int consecutiveFailures;
+    private DateTimeOffset openedOn;
+
+    public FallbackResilienceBroker(
+        IResilienceBroker primary,
+        Func<ValueTask<string>>? alternative = null,
+        int failuresBeforeOpen = 3,
+        TimeSpan? coolDown = null,
+        Func<DateTimeOffset>? now = null)
+    {
+        this.primary = primary;
+        this.alternative = alternative;
+        this.failuresBeforeOpen = failuresBeforeOpen;
+        this.coolDown = coolDown ?? TimeSpan.FromSeconds(30);
+        this.now = now ?? (() => DateTimeOffset.UtcNow);
+    }
+
+    public bool IsOpen
+    {
+        get
+        {
+            lock (this.circuitLock)
+            {
+                return IsOpenNow();
+            }
+        }
+    }
+
+    public async ValueTask<T> ExecuteAsync<T>(Func<ValueTask<T>> operation)
+    {
+        if (IsOpen)
+        {
+            return await FallBackAsync<T>();
+        }
+
+        try
+        {
+            T result = await this.primary.ExecuteAsync(operation);
+
+            lock (this.circuitLock)
+            {
+                this.consecutiveFailures = 0;
+            }
+
+            return result;
+        }
+        catch (Exception)
+        {
+            bool nowOpen;
+
+            lock (this.circuitLock)
+            {
+                this.consecutiveFailures++;
+
+                nowOpen = this.consecutiveFailures >= this.failuresBeforeOpen;
+
+                if (nowOpen)
+                {
+                    this.openedOn = this.now();
+                }
+            }
+
+            if (nowOpen && this.alternative is not null)
+            {
+                return await FallBackAsync<T>();
+            }
+
+            throw;
+        }
+    }
+
+    private bool IsOpenNow()
+    {
+        if (this.consecutiveFailures < this.failuresBeforeOpen)
+        {
+            return false;
+        }
+
+        // Cool-down elapsed: close the circuit and let the primary prove itself again.
+        if (this.now() - this.openedOn >= this.coolDown)
+        {
+            this.consecutiveFailures = 0;
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private async ValueTask<T> FallBackAsync<T>()
+    {
+        if (this.alternative is null)
+        {
+            throw new InvalidOperationException(
+                "The provider is unhealthy and no alternative is configured. Failing rather "
+                    + "than returning a fabricated result (SPEC.md §4.10).");
+        }
+
+        string answer = await this.alternative();
+
+        return (T)(object)answer;
+    }
+}

--- a/Standard.Agents/Models/Loggings/AgentRun.cs
+++ b/Standard.Agents/Models/Loggings/AgentRun.cs
@@ -32,6 +32,8 @@ public sealed class AgentRun
 {
     private static readonly AsyncLocal<AgentRun?> current = new();
 
+    private readonly Dictionary<string, string> verdicts = [];
+
     private int sequence;
     private int processIndex;
 
@@ -73,6 +75,27 @@ public sealed class AgentRun
     /// <summary>The next process number within the current step.</summary>
     public int NextProcessIndex() =>
         Interlocked.Increment(ref this.processIndex) - 1;
+
+    /// <summary>
+    /// Remembers a guardian verdict for the life of this run, so an unchanged prompt is screened
+    /// once rather than once per turn (SPEC.md §4.10). It lives on the run rather than in a
+    /// service-level cache so it is evicted by the run ending, with nothing to remember to clear.
+    /// </summary>
+    public bool TryGetVerdict(string prompt, out string verdict)
+    {
+        lock (this.verdicts)
+        {
+            return this.verdicts.TryGetValue(prompt, out verdict!);
+        }
+    }
+
+    public void RememberVerdict(string prompt, string verdict)
+    {
+        lock (this.verdicts)
+        {
+            this.verdicts[prompt] = verdict;
+        }
+    }
 
     /// <summary>Restarts process numbering, called when a step begins.</summary>
     public void ResetProcessIndex() =>

--- a/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.Ranking.cs
+++ b/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.Ranking.cs
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Foundations.Knowledges;
+
+// Retrieval answers "what is relevant to this task", not "what exists" (SPEC.md §4.2).
+//
+// What was here before matched the WHOLE prompt literally against WHOLE documents. A natural
+// question never appears verbatim inside its own answer, so it retrieved nothing for exactly the
+// queries a user asks — the feature looked configured and returned empty every time.
+//
+// This is lexical scoring: terms in common, rarer terms worth more, shorter passages preferred
+// so a long document cannot win by being long. It is deliberately dependency-free, because it is
+// the Local mode; a broker backed by full-text search or embeddings is the External one, and the
+// contract above it does not change either way (§9).
+public partial class KnowledgeService
+{
+    private const int PassageWordCount = 120;
+    private const int PassageStrideWords = 60;
+
+    private static readonly char[] TermSeparators =
+        [' ', '\t', '\n', '\r', '.', ',', ';', ':', '!', '?', '"', '\'', '(', ')', '[', ']', '-', '/'];
+
+    // Words too common to say anything about relevance. Kept short on purpose: a longer list is
+    // a language model of its own, and this is meant to stay readable.
+    private static readonly HashSet<string> NoiseTerms =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "a", "an", "and", "are", "as", "at", "be", "but", "by", "can", "did", "do", "does",
+            "for", "from", "had", "has", "have", "how", "i", "in", "is", "it", "its", "me", "my",
+            "of", "on", "or", "our", "so", "that", "the", "their", "them", "then", "there",
+            "these", "they", "this", "to", "was", "we", "what", "when", "where", "which", "who",
+            "why", "will", "with", "you", "your"
+        };
+
+    private static string[] Terms(string text) =>
+        [.. text
+            .Split(TermSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .Select(term => term.ToLowerInvariant())
+            .Where(term => term.Length > 1 && NoiseTerms.Contains(term) is false)];
+
+    // Overlapping windows, so an answer that straddles a boundary is still found whole by one of
+    // them. The cost is that two neighbouring passages may both match; the ranking then picks
+    // whichever carries more of the query.
+    private static IEnumerable<string> Passages(string document)
+    {
+        string[] words = document.Split(
+            (char[]?)null,
+            StringSplitOptions.RemoveEmptyEntries);
+
+        if (words.Length <= PassageWordCount)
+        {
+            yield return document.Trim();
+
+            yield break;
+        }
+
+        for (int start = 0; start < words.Length; start += PassageStrideWords)
+        {
+            yield return string.Join(' ', words.Skip(start).Take(PassageWordCount));
+
+            if (start + PassageWordCount >= words.Length)
+            {
+                break;
+            }
+        }
+    }
+
+    // Score = how many query terms appear, each weighted by how rare it is across the corpus,
+    // divided by the square root of the passage length. Rarity is what makes "refund" count for
+    // more than "policy" when every document mentions policy; the length penalty is what stops a
+    // long passage winning simply by containing more words.
+    private static double Score(
+        string[] queryTerms,
+        string passage,
+        IReadOnlyDictionary<string, int> documentFrequency,
+        int documentCount)
+    {
+        string[] passageTerms = Terms(passage);
+
+        if (passageTerms.Length == 0)
+        {
+            return 0;
+        }
+
+        var passageTermSet = new HashSet<string>(passageTerms, StringComparer.OrdinalIgnoreCase);
+        double score = 0;
+
+        foreach (string queryTerm in queryTerms.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (passageTermSet.Contains(queryTerm) is false)
+            {
+                continue;
+            }
+
+            int seenIn = documentFrequency.TryGetValue(queryTerm, out int frequency)
+                ? frequency
+                : 1;
+
+            score += Math.Log(1 + ((double)documentCount / seenIn));
+        }
+
+        return score / Math.Sqrt(passageTerms.Length);
+    }
+}

--- a/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.cs
+++ b/Standard.Agents/Services/Foundations/Knowledges/KnowledgeService.cs
@@ -16,6 +16,7 @@ public partial class KnowledgeService : IKnowledgeService
     private readonly string knowledgePath;
     private readonly string searchPattern;
     private readonly int maxResults;
+    private readonly double minimumScore;
     private readonly ILoggingBroker loggingBroker;
 
     public KnowledgeService(
@@ -33,13 +34,15 @@ public partial class KnowledgeService : IKnowledgeService
         string knowledgePath,
         string searchPattern,
         int maxResults,
-        ILoggingBroker loggingBroker)
+        ILoggingBroker loggingBroker,
+        double minimumScore = 0.0)
     {
         this.fileBroker = fileBroker;
         this.knowledgePath = knowledgePath;
         this.searchPattern = searchPattern;
         this.maxResults = maxResults;
         this.loggingBroker = loggingBroker;
+        this.minimumScore = minimumScore;
     }
 
     public ValueTask<IReadOnlyList<string>> RetrieveKnowledgeAsync(string query) =>
@@ -52,9 +55,18 @@ public partial class KnowledgeService : IKnowledgeService
             : await this.knowledgeBroker!.SelectKnowledgeAsync(query);
     });
 
-    private async ValueTask<IReadOnlyList<string>> SelectKnowledgeFromFilesAsync(IFileBroker fileBroker, string query)
+    private async ValueTask<IReadOnlyList<string>> SelectKnowledgeFromFilesAsync(
+        IFileBroker fileBroker,
+        string query)
     {
         if (fileBroker.DirectoryExists(this.knowledgePath) is false)
+        {
+            return [];
+        }
+
+        string[] queryTerms = Terms(query);
+
+        if (queryTerms.Length == 0)
         {
             return [];
         }
@@ -63,23 +75,42 @@ public partial class KnowledgeService : IKnowledgeService
             fileBroker.SelectFiles(this.knowledgePath, this.searchPattern, SearchOption.AllDirectories)
                 .OrderBy(documentPath => documentPath, StringComparer.Ordinal);
 
-        List<string> matches = [];
+        List<string> documents = [];
 
         foreach (string documentPath in documentPaths)
         {
-            string document = await fileBroker.ReadFileAsync(documentPath);
+            documents.Add(await fileBroker.ReadFileAsync(documentPath));
+        }
 
-            if (document.Contains(query, StringComparison.OrdinalIgnoreCase))
-            {
-                matches.Add(document);
-            }
+        // How many documents each term appears in, so a term common to the whole corpus counts
+        // for less than one that singles a document out.
+        Dictionary<string, int> documentFrequency = new(StringComparer.OrdinalIgnoreCase);
 
-            if (matches.Count == this.maxResults)
+        foreach (string document in documents)
+        {
+            foreach (string term in Terms(document).Distinct(StringComparer.OrdinalIgnoreCase))
             {
-                break;
+                documentFrequency[term] =
+                    documentFrequency.TryGetValue(term, out int count) ? count + 1 : 1;
             }
         }
 
-        return matches;
+        return
+        [
+            .. documents
+                .SelectMany(Passages)
+                .Select(passage => new
+                {
+                    Passage = passage,
+                    Score = Score(queryTerms, passage, documentFrequency, documents.Count)
+                })
+                // A zero score means the passage carries no query term at all, so it is never a
+                // match however low the floor is set. Silence is the right answer when nothing
+                // is relevant — returning the corpus instead is how a retriever becomes noise.
+                .Where(scored => scored.Score > 0 && scored.Score >= this.minimumScore)
+                .OrderByDescending(scored => scored.Score)
+                .Take(this.maxResults)
+                .Select(scored => scored.Passage)
+        ];
     }
 }

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Screening.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Screening.cs
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Loggings;
+
+namespace Standard.Agents.Services.Orchestrations.Decision;
+
+// Screening the same unchanged prompt on every turn is waste, not safety (SPEC.md §4.10).
+//
+// The prompt does not change across the turns of one run — only the observations do — so the
+// Gate was asked the identical question up to MAX_TURNS times and returned the identical verdict,
+// at full model cost each time. A seven-turn prompt paid for seven screenings of one string.
+//
+// This weakens nothing. The guarantee is that the task is screened before the Brain sees it, and
+// it still is. What changes every turn is untrusted inbound (§4.9), and that is screened every
+// time it appears, because it is different text each time.
+//
+// The verdict is remembered on the run, not in a service-level cache, so it is evicted by the
+// run ending — a cache keyed by run in a long-lived service is a leak waiting for a busy day.
+public partial class DecisionOrchestrationService
+{
+    private async ValueTask<string> ScreenOncePerPromptAsync(string prompt)
+    {
+        AgentRun? run = AgentRun.Current;
+
+        if (run is null)
+        {
+            return await this.gateService.ScreenAsync(prompt);
+        }
+
+        if (run.TryGetVerdict(prompt, out string cachedVerdict))
+        {
+            return cachedVerdict;
+        }
+
+        string verdict = await this.gateService.ScreenAsync(prompt);
+        run.RememberVerdict(prompt, verdict);
+
+        return verdict;
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -58,8 +58,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
     {
         ValidateContext(context);
 
-        string verdict =
-            await this.gateService.ScreenAsync(context.Prompt);
+        string verdict = await ScreenOncePerPromptAsync(context.Prompt);
 
         if (IsRefusal(verdict))
         {
@@ -153,7 +152,7 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
         Action<AgentContext> setResult,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        string verdict = await this.gateService.ScreenAsync(context.Prompt);
+        string verdict = await ScreenOncePerPromptAsync(context.Prompt);
 
         if (IsRefusal(verdict))
         {

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -64,6 +64,7 @@ public sealed partial class StandardAgent : IAgent
     private string knowledgePath = "Knowledge";
     private string knowledgePattern = "*.md";
     private int knowledgeMaxResults = 3;
+    private double knowledgeMinScore;
 
     private InferenceSettings? brainSettings;
     private InferenceSettings? gateSettings;
@@ -337,13 +338,18 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="path">Folder holding the knowledge files.</param>
     /// <param name="pattern">Glob for which files to search. Defaults to <c>*.md</c>.</param>
     /// <param name="maxResults">Maximum matches fed in per turn. Defaults to 3.</param>
+    /// <param name="minScore">
+    /// Relevance floor a passage must clear to be injected. Zero admits any passage carrying a
+    /// query term; raise it when weak matches are crowding out good ones.
+    /// </param>
     /// <returns>The same agent, so calls can be chained.</returns>
-    public StandardAgent Knowledge(string path, string pattern = "*.md", int maxResults = 3) =>
+    public StandardAgent Knowledge(string path, string pattern = "*.md", int maxResults = 3, double minScore = 0.0) =>
     Set(() =>
     {
         this.knowledgePath = path;
         this.knowledgePattern = pattern;
         this.knowledgeMaxResults = maxResults;
+        this.knowledgeMinScore = minScore;
     });
 
     /// <summary>
@@ -678,6 +684,26 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent Resilience(int retries = 3) =>
         Set(() => this.resilienceBroker = new RetryResilienceBroker(retries));
+
+    /// <summary>
+    /// Degrades to an alternative when the brain is failing, rather than failing outright
+    /// (SPEC.md §4.10) — a degraded answer is worth more than no answer. After
+    /// <paramref name="failuresBeforeOpen"/> consecutive failures the circuit opens and calls go
+    /// to <paramref name="fallback"/>; it closes again after a cool-down, so a recovered provider
+    /// is used again without a restart. With no fallback the agent fails rather than fabricating.
+    /// </summary>
+    /// <param name="fallback">What to answer with while the primary is unhealthy.</param>
+    /// <param name="retries">Attempts against the primary before a call counts as failed.</param>
+    /// <param name="failuresBeforeOpen">Consecutive failures that open the circuit.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Fallback(
+        Func<ValueTask<string>> fallback,
+        int retries = 0,
+        int failuresBeforeOpen = 3) =>
+        Set(() => this.resilienceBroker = new FallbackResilienceBroker(
+            primary: new RetryResilienceBroker(retries),
+            alternative: fallback,
+            failuresBeforeOpen: failuresBeforeOpen));
 
     /// <summary>
     /// Swaps in a custom resilience broker — the plugin seam for a provider's own retry, circuit

--- a/conformance/vectors/21-budget-stops-the-loop.json
+++ b/conformance/vectors/21-budget-stops-the-loop.json
@@ -1,0 +1,12 @@
+{
+  "name": "budget-stops-the-loop",
+  "description": "SPEC.md 4.10: a budget is checked between turns and stops the loop when exhausted, and exhaustion is reported distinguishably - it is not a refusal and not an answer. A caller that cannot tell I will not from I ran out cannot decide whether to retry. The Brain would loop through tool calls forever; a zero wall-clock budget stops it on the first boundary.",
+  "generatorReplies": ["ACTION: nonexistent_tool: keep going"],
+  "tools": {},
+  "prompt": "loop forever",
+  "maxTurns": 50,
+  "budgetMaxWallClockSeconds": 0,
+  "expect": {
+    "resultContains": "budget"
+  }
+}

--- a/conformance/vectors/22-knowledge-retrieves-by-relevance.json
+++ b/conformance/vectors/22-knowledge-retrieves-by-relevance.json
@@ -1,0 +1,18 @@
+{
+  "name": "knowledge-retrieves-by-relevance",
+  "description": "SPEC.md 4.2: retrieval answers what is relevant to this task, not what exists. A natural question does not appear verbatim inside its own answer, so an implementation matching the whole query literally against whole documents retrieves nothing for exactly the queries a user asks. The knowledge base holds three policies; the question asks about one, and the passage that answers it must reach the Brain.",
+  "generatorReplies": ["FINAL: enterprise customers have 90 days"],
+  "tools": {},
+  "prompt": "what is our refund policy for enterprise customers",
+  "knowledge": {
+    "refunds.md": "Refund policy. Enterprise customers may request a refund within 90 days of purchase.",
+    "shipping.md": "Shipping policy. Orders ship within two business days.",
+    "holidays.md": "The office is closed on public holidays."
+  },
+  "knowledgeMaxResults": 1,
+  "expect": {
+    "resultContains": "90 days",
+    "brainSees": "90 days",
+    "brainNeverSees": "public holidays"
+  }
+}

--- a/conformance/vectors/23-guardian-screens-once-per-prompt.json
+++ b/conformance/vectors/23-guardian-screens-once-per-prompt.json
@@ -1,0 +1,15 @@
+{
+  "name": "guardian-screens-once-per-prompt",
+  "description": "SPEC.md 4.10: screening the same unchanged input on every turn is waste, not safety. The prompt does not change across the turns of one run - only the observations do - so a seven-turn prompt used to pay for seven screenings of one string. The task is still screened before the Brain sees it; it is simply screened once. This run takes three turns and the Gate must be asked about the prompt exactly once.",
+  "generatorReplies": [
+    "ACTION: echo: first",
+    "ACTION: echo: second",
+    "FINAL: done"
+  ],
+  "tools": { "echo": "ok" },
+  "prompt": "do the thing twice",
+  "expect": {
+    "result": "done",
+    "gateScreenedPromptTimes": 1
+  }
+}

--- a/conformance/vectors/24-open-circuit-falls-back-to-secondary.json
+++ b/conformance/vectors/24-open-circuit-falls-back-to-secondary.json
@@ -1,0 +1,13 @@
+{
+  "name": "open-circuit-falls-back-to-secondary",
+  "description": "SPEC.md 4.10: an unhealthy provider degrades to a configured alternative rather than failing outright, because a degraded answer is worth more than no answer. The Brain fails repeatedly; once the circuit opens the agent answers from the fallback instead of throwing. An implementation with no alternative configured must fail rather than fabricate, which is why the fallback here is explicit.",
+  "generatorReplies": ["FINAL: never reached"],
+  "tools": {},
+  "prompt": "what is the answer",
+  "transientFailures": 99,
+  "fallbackReply": "FINAL: answering from the standby model",
+  "failuresBeforeOpen": 1,
+  "expect": {
+    "resultContains": "standby model"
+  }
+}


### PR DESCRIPTION
Completes Data at Scale. Spec first: implements SPEC.md §4.2/§4.10, merged as The-Standard-Agent-Specs#15.

```
--profile Core         CERTIFIED
--profile Reliable     CERTIFIED
--profile Enterprise   CERTIFIED   exit 0
336 unit tests · 24/24 vectors · 0 warnings
```

## Retrieval that can answer a question

The old implementation matched the **whole prompt literally against whole documents**. A natural question never appears verbatim inside its own answer, so it retrieved nothing for exactly the queries a user asks — the feature looked configured and returned empty every time.

Ranking replaces it: terms in common, rarer terms weighted higher, shorter passages preferred so a long document can't win by being long, passages rather than whole files. **A zero score is never a match** however low the floor — silence is the right answer when nothing is relevant.

## Screen once, not once per turn

The prompt doesn't change across a run's turns; only the observations do. A seven-turn prompt was paying for **seven screenings of one string**. The guarantee is unchanged — the task is still screened before the Brain sees it, and untrusted inbound is still screened every time it appears, because it's different text each time.

The verdict lives **on the run**, not in a service-level cache: a run-keyed cache in a long-lived service is a leak waiting for a busy day.

## Degradation before failure

The circuit opens after consecutive failures and calls go to a configured alternative. **With no alternative the agent fails rather than fabricating** — a caller cannot tell invented silence from real silence.

## Sabotage results — one vector was too weak

| Sabotage | Result |
|---|---|
| Ignore the budget | vector 21 FAILS |
| Disable screen-once | vector 23 FAILS |
| **Invert the ranking** | vector 22 **PASSED** ← too weak |
| Disable fallback | vector 24 FAILS (throws) |

Inverting the ranking passed because with 3 documents and the default cap, every passage was injected regardless of order — the vector proved retrieval *returns* the answer, not that it *ranks*. Capped it to one result and added `brainNeverSees`. It now fails correctly: `the Brain was never shown the retrieved text: 90 days`.

## One contract change

Retrieval now reads every document, because a term's weight depends on how rare it is across the corpus and that isn't knowable from a prefix. The existing test asserted the early-exit that made first-N-found possible; it's updated with the reason recorded.