### PR TITLE
MAJOR INFRA: Supply Chain And Support

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -48,8 +48,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # Full history: the secret scan diffs a commit against its parent, and the default shallow
+    # clone has no parent to diff against — it fails to scan rather than finding nothing, which
+    # is the failure mode a security check must never have.
     - name: Pulling Code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Installing .NET
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,14 +14,17 @@ jobs:
     - name: Pulling Code
       uses: actions/checkout@v4
 
+    # No dotnet-version here on purpose: global.json pins the SDK, so CI and a developer's
+    # machine compile with the same one. A version named in two places drifts in one of them.
     - name: Installing .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 10.0.x
+        global-json-file: global.json
 
     - name: Restoring Packages
       run: dotnet restore
 
+    # Warnings are errors (Directory.Build.props), so this step is also the zero-warning gate.
     - name: Building Solution
       run: dotnet build --no-restore --configuration Release
 
@@ -33,3 +36,45 @@ jobs:
     # breaks it rather than on the next release.
     - name: Certifying Conformance
       run: dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
+
+    # The readiness level the package claims. SPEC.md §1.1: a claim whose evidence has not been
+    # run is not a claim. This is what makes the badge in the README checkable by anyone.
+    - name: Certifying Enterprise Profile
+      run: >
+        dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
+        -- --profile Enterprise
+
+  supply-chain:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Pulling Code
+      uses: actions/checkout@v4
+
+    - name: Installing .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Restoring Packages
+      run: dotnet restore
+
+    # A known-vulnerable transitive dependency is a finding whether or not anyone looked, so
+    # look on every change rather than at release time when it is expensive to act on.
+    - name: Auditing Dependencies For Vulnerabilities
+      run: |
+        dotnet list package --vulnerable --include-transitive 2>&1 | tee audit.txt
+        if grep -q "has the following vulnerable packages" audit.txt; then
+          echo "::error::Vulnerable packages found — see the listing above."
+          exit 1
+        fi
+
+    - name: Listing Dependency Licenses
+      run: dotnet list package --include-transitive
+
+    # Secrets that reach a public repository are already leaked; the value of this check is
+    # catching the commit that would have done it.
+    - name: Scanning For Secrets
+      uses: gitleaks/gitleaks-action@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,22 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    # Provenance attestation needs to write an attestation and read the workflow identity.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
     steps:
     - name: Pulling Code
       uses: actions/checkout@v4
 
+    # The SDK comes from global.json, so the package is built with the same compiler a
+    # developer used. Reproducibility starts with agreeing on the toolchain.
     - name: Installing .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 10.0.x
+        global-json-file: global.json
 
     - name: Restoring Packages
       run: dotnet restore
@@ -41,6 +49,30 @@ jobs:
         --no-build
         --configuration Release
         --output ${{ github.workspace }}/artifacts
+
+    # A software bill of materials: what is actually inside the package, transitively. Most
+    # regulated procurement asks for one, and generating it at release time means it describes
+    # the artifact that shipped rather than the repository at some later date.
+    - name: Generating Software Bill Of Materials
+      run: |
+        dotnet tool install --global CycloneDX
+        dotnet CycloneDX Standard.Agents/Standard.Agents.csproj \
+          --out ${{ github.workspace }}/artifacts --json
+
+    # Signed provenance: a verifiable statement of which workflow, from which commit, produced
+    # these bytes. It is not a code-signing certificate — see docs/support.md — but it is the
+    # part a consumer can check without trusting us.
+    - name: Attesting Build Provenance
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: ${{ github.workspace }}/artifacts/*.nupkg
+
+    - name: Attaching Artifacts To The Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          ${{ github.workspace }}/artifacts/*.nupkg
+          ${{ github.workspace }}/artifacts/*.json
 
     - name: Publishing To NuGet
       run: >

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,26 @@
+<Project>
+
+  <!-- Applies to every project in the repository, so the bar cannot be met in one project and
+       quietly missed in another. -->
+  <PropertyGroup>
+    <!-- A zero-warning bar that isn't enforced isn't a bar. The tree has built clean for some
+         time; this is what keeps it that way when someone is in a hurry. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!-- Analyzer findings count too: xUnit's analyzers caught a real nullability defect in this
+         suite once already, and a warning nobody has to act on is a warning nobody reads. -->
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+
+    <!-- Deterministic output for a given input, so a build is reproducible off this machine.
+         Paired with the pinned SDK in global.json: same compiler, same sources, same bytes. -->
+    <Deterministic>true</Deterministic>
+
+    <!-- Ship the symbols and the sources they point at, so a consumer can step into a failure
+         in this library rather than guessing at it from a stack trace. -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+</Project>

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,128 @@
+# Support, Compatibility and Supply Chain
+
+What you need in order to depend on `Standard.Agents` — thread safety, what is stable, how
+deprecation works, and what ships with each release. SPEC.md §1.1 requires an implementation to
+publish this; a conformance claim without it is a claim a consumer cannot act on.
+
+---
+
+## Readiness
+
+The package claims a **readiness profile**, per version, and the claim is checkable by anyone:
+
+```bash
+dotnet run --project Standard.Agents.Conformance -- --profile Enterprise
+```
+
+Exit `0` means certified. It runs the same vectors CI runs, from a clone, with no access to
+anything we hold privately.
+
+| Profile | What an agent at this level has | Status |
+|---|---|---|
+| **Core** | conversation, skills, knowledge, memory, simple tools | certified |
+| **Reliable** | guardians that see what they guard, durable decision log, run isolation, cancellation, timeouts | certified |
+| **Enterprise** | identity-aware authorization, approval before irreversible acts, run-once effects, budgets, ranked retrieval | certified |
+| **Critical** | conversation across processes, compensation, adversarial evaluation | not yet |
+
+---
+
+## Thread safety and lifetime
+
+**One `StandardAgent` instance is safe to use concurrently, and is the intended shape.** Register
+it as a singleton; do not build one per request.
+
+- Composition is guarded, so concurrent first calls build one graph rather than several.
+- Run state — identity, counters, timing, guardian verdicts — is **per invocation, never per
+  instance** (SPEC.md §4.4), so two prompts in flight cannot corrupt each other's records.
+- The trace and decision log serialize their own writes.
+- **Verified**, not asserted: 64 concurrent prompts on one instance with both sinks configured, in
+  `DecisionLogTests`, plus conformance vector `12-concurrent-runs-are-isolated`.
+
+Builder methods are **not** safe to call while prompts are in flight. Configure the agent, then
+serve with it. Calling a builder method mid-flight invalidates the cached composition and races
+against readers of it.
+
+`StandardAgent` holds no unmanaged resources and does not need disposing. Brokers you supply are
+yours to manage.
+
+---
+
+## What is stable
+
+| Surface | Stability |
+|---|---|
+| `StandardAgent` builder methods | **Stable.** Removed only through deprecation (below). |
+| `IAgent` | **Stable.** |
+| Broker interfaces (`IGeneratorBroker`, `ISkillBroker`, …) | **Stable within a major version.** These are what provider packages implement, so a change here is a change to everyone's packages. |
+| `AgentContext`, `AgentStatus`, and the models in `Models/` | **Stable within a major version.** New fields may be added; existing ones are not repurposed. |
+| Service classes (`*Service`) and their constructors | **Not a public contract.** They are composed for you by `Compose()`; construct them directly at your own risk. |
+| Anything under `Prompts/` | **Data, not API.** The built-in rubrics may be reworded in any release. Supply your own via `.Constitution(...)` / `.Consumption(...)` if you need them fixed. |
+
+Version segments say what kind of change happened — `model . service/routine . fix/config . build`
+— so a model change can never hide in the service segment. A change to a broker interface will
+always move segment 1 or 2, never 3.
+
+---
+
+## Deprecation
+
+Nothing is removed without warning:
+
+1. The replacement ships first, alongside the old member.
+2. The old member is marked `[Obsolete]` with a message naming the replacement, so you find out at
+   **compile time**, not at runtime.
+3. It keeps working, and its behavior stays pinned by a test, for at least **one minor version**.
+4. Only then may it be removed, in a release whose segment reflects it.
+
+The live example: `.LocalBrain` / `.LocalGate` / `.LocalJudge` became `.OnBrain` / `.OnGate` /
+`.OnJudge` in 0.18.0.0 — a delegate you write is the *Custom* mode, not the *Local* one. The old
+names still work and are held to the new ones by
+`ShouldKeepObsoleteLocalAliasesBehavingLikeTheCustomVerbsAsync`.
+
+---
+
+## Upgrading
+
+- Read the release notes; each release states what kind of change it was and why.
+- Build with warnings visible. Deprecations arrive as compiler warnings naming the replacement,
+  which is the cheapest possible upgrade signal.
+- Re-run certification for the profile you depend on. It is the same command as above, and it
+  answers the only question that matters: does the level I relied on still hold?
+
+**Rolling back** is a version pin. Packages are never unlisted or overwritten, so an older version
+remains installable; provider packages are versioned independently and are not required to move
+with the core.
+
+---
+
+## Supply chain
+
+Every change on `main` and every pull request runs:
+
+- **Build with warnings as errors**, on the SDK pinned in `global.json` — the same compiler
+  locally and in CI, because a version named in two places drifts in one of them.
+- **The full unit suite and the conformance vectors**, plus certification of the claimed profile.
+- **Dependency vulnerability audit**, transitively, failing the build on a finding.
+- **Dependency licence listing**, transitively.
+- **Secret scanning** over the diff.
+
+Every release additionally publishes:
+
+- A **software bill of materials** (CycloneDX JSON), generated at release time so it describes the
+  artifact that shipped.
+- **Signed build provenance** — a verifiable statement of which workflow, at which commit,
+  produced those exact bytes.
+- **Symbols and embedded sources** (`snupkg`), so you can step into a failure here rather than
+  guess at it from a stack trace.
+
+### What is not there
+
+**The package is not Authenticode-signed.** That needs a code-signing certificate, which is an
+organisational decision and a purchase, not a build setting. Provenance attestation covers the
+"did this come from that source, unmodified" question; it does not cover "is the publisher who
+they say they are." If your procurement requires a signed binary, that is the gap, and it is a
+certificate away rather than a code change.
+
+**The licence is TSSL, not an SPDX identifier.** Automated licence scanners will flag it as
+unrecognised rather than as a problem. The full text is in `LICENSE.txt`; expect to route it
+through legal review rather than through a scanner allow-list.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
The release that has nothing to do with agents and decides whether a review board says yes. Spec first: implements SPEC.md §1.1, merged as The-Standard-Agent-Specs#16.

## Build

- **`global.json`** pins the SDK to a stable `10.0.1xx` band. Both workflows now install *from it* rather than naming a version of their own — a version named in two places drifts in one of them.
- **Warnings are errors**, repo-wide via `Directory.Build.props`, so the bar can't be met in one project and quietly missed in another. Plus deterministic builds, symbols and embedded sources.
- **Verified the bar bites:** an unused private field now fails with `error CS0169`.

## CI

New supply-chain job: transitive **vulnerability audit** (fails on a finding), transitive **licence listing**, **secret scanning** over the diff. The build job now also runs `--profile Enterprise`, so the readiness claim is checked on every change rather than asserted in prose.

## Release

- **CycloneDX SBOM**, generated at release time so it describes the artifact that shipped rather than the repo at some later date.
- **Signed build provenance** — which workflow, at which commit, produced those exact bytes.
- Symbols + embedded sources attached.

## `docs/support.md`

Thread safety and lifetime (**one instance is safe concurrently and is the intended shape** — verified at 64 concurrent prompts, not asserted), what's stable versus what isn't, how deprecation works and how long it lasts, upgrade and rollback.

## Two gaps stated rather than glossed

**Not Authenticode-signed.** That needs a certificate — a purchase and an organisational decision, not a build setting. Provenance answers *"did this come from that source, unmodified"*; it does not answer *"is the publisher who they say they are."* If procurement requires a signed binary, that's the gap, and it's a certificate away rather than a code change.

**TSSL is not an SPDX identifier.** Licence scanners will flag it as unrecognised rather than as a problem. Expect legal review rather than a scanner allow-list.

336 tests · 24/24 vectors · 0 warnings · Enterprise certified.