### PR TITLE
SESSIONS: Conversation That Survives The Instance

### DIFF
--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -56,4 +56,7 @@ public sealed record Vector(
     Dictionary<string, string>? Knowledge = null,
     string? FallbackReply = null,
     int FailuresBeforeOpen = 3,
-    int KnowledgeMaxResults = 3);
+    int KnowledgeMaxResults = 3,
+
+    // Sessions (SPEC.md 4.11). When set, every prompt in the vector runs in this conversation.
+    string? SessionId = null);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -281,6 +281,21 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         agent.Budget(maxWallClock: TimeSpan.FromSeconds(seconds));
     }
 
+    // A real session store, in a folder unique to this vector, so conversation is certified
+    // against something that actually persists rather than an in-memory stand-in that could
+    // never demonstrate resumption.
+    if (vector.SessionId is not null)
+    {
+        string sessionsPath = Path.Combine(AppContext.BaseDirectory, $"sessions-{vector.Name}");
+
+        if (Directory.Exists(sessionsPath))
+        {
+            Directory.Delete(sessionsPath, recursive: true);
+        }
+
+        agent.Sessions(sessionsPath);
+    }
+
     if (vector.FallbackReply is string fallbackReply)
     {
         agent.Fallback(
@@ -351,7 +366,8 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
 
         foreach (string prompt in prompts)
         {
-            result = await agent.ProcessPromptAsync(prompt, runCancellation.Token);
+            result = await agent.ProcessPromptAsync(
+                prompt, vector.SessionId ?? string.Empty, runCancellation.Token);
         }
     }
 

--- a/Standard.Agents.Tests.Unit/Acceptance/SessionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/SessionTests.cs
@@ -1,0 +1,178 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Foundations.Skills;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// Conversation and resumption (SPEC.md §4.11).
+//
+// Invariant 4 says the agent INSTANCE is stateless across prompts. It does not say the
+// conversation is. These pin that distinction: the same session continues across two separate
+// agent instances, which is the property that makes resumption real rather than incidental.
+public class SessionTests : IDisposable
+{
+    private readonly string sessionsPath =
+        Path.Combine(Path.GetTempPath(), $"sessions-{Guid.NewGuid():n}");
+
+    private StandardAgent NewAgent(Func<string, string> answerFor, Action<string>? capture = null)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .OnBrain(async (systemPrompt, userPrompt) =>
+            {
+                capture?.Invoke(userPrompt);
+
+                return answerFor(userPrompt);
+            })
+            .Sessions(this.sessionsPath);
+    }
+
+    [Fact]
+    public async Task ShouldCarryConversationAcrossPromptsAsync()
+    {
+        // given
+        string capturedSecondPrompt = string.Empty;
+        int calls = 0;
+
+        StandardAgent agent = NewAgent(
+            answerFor: _ => ++calls == 1 ? "FINAL: Paris" : "FINAL: about 2.1 million",
+            capture: userPrompt =>
+            {
+                if (calls == 1)
+                {
+                    capturedSecondPrompt = userPrompt;
+                }
+            });
+
+        // when
+        await agent.ProcessPromptAsync("what is the capital of France?", sessionId: "user-42");
+        await agent.ProcessPromptAsync("and its population?", sessionId: "user-42");
+
+        // then — the follow-up carries what came before
+        capturedSecondPrompt.Should().Contain("capital of France");
+        capturedSecondPrompt.Should().Contain("Paris");
+    }
+
+    // The property that makes resumption real: the session is the state, the instance is not.
+    // An implementation whose continuity depends on the original instance still being alive has
+    // not implemented this (SPEC.md §4.11).
+    [Fact]
+    public async Task ShouldResumeAConversationOnADifferentAgentInstanceAsync()
+    {
+        // given — the first agent answers, then is discarded entirely
+        StandardAgent firstAgent = NewAgent(_ => "FINAL: Paris");
+        await firstAgent.ProcessPromptAsync("what is the capital of France?", sessionId: "user-7");
+
+        string capturedPrompt = string.Empty;
+
+        StandardAgent secondAgent = NewAgent(
+            answerFor: _ => "FINAL: about 2.1 million",
+            capture: userPrompt => capturedPrompt = userPrompt);
+
+        // when — a different instance picks the conversation up
+        await secondAgent.ProcessPromptAsync("and its population?", sessionId: "user-7");
+
+        // then
+        capturedPrompt.Should().Contain("Paris");
+    }
+
+    [Fact]
+    public async Task ShouldKeepSessionsSeparateAsync()
+    {
+        // given
+        string capturedPrompt = string.Empty;
+
+        StandardAgent agent = NewAgent(
+            answerFor: _ => "FINAL: Paris",
+            capture: userPrompt => capturedPrompt = userPrompt);
+
+        await agent.ProcessPromptAsync("what is the capital of France?", sessionId: "alice");
+
+        // when — a different conversation entirely
+        await agent.ProcessPromptAsync("what is the capital of Japan?", sessionId: "bob");
+
+        // then — bob never sees alice's exchange
+        capturedPrompt.Should().NotContain("France");
+    }
+
+    [Fact]
+    public async Task ShouldNotRecordACancelledRunAsAnAnswerAsync()
+    {
+        // given
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        StandardAgent agent = NewAgent(_ => "FINAL: Paris");
+
+        await agent.ProcessPromptAsync(
+            "what is the capital of France?", sessionId: "user-9", cancellation.Token);
+
+        string capturedPrompt = string.Empty;
+
+        StandardAgent nextAgent = NewAgent(
+            answerFor: _ => "FINAL: anything",
+            capture: userPrompt => capturedPrompt = userPrompt);
+
+        // when
+        await nextAgent.ProcessPromptAsync("follow up", sessionId: "user-9");
+
+        // then — the next prompt is never told the agent said something it never said
+        capturedPrompt.Should().NotContain("cancelled");
+        capturedPrompt.Should().NotContain("Paris");
+    }
+
+    [Fact]
+    public async Task ShouldStayStatelessWithoutASessionAsync()
+    {
+        // given
+        string capturedPrompt = string.Empty;
+        int calls = 0;
+
+        StandardAgent agent = NewAgent(
+            answerFor: _ => ++calls == 1 ? "FINAL: Paris" : "FINAL: anything",
+            capture: userPrompt =>
+            {
+                if (calls == 1)
+                {
+                    capturedPrompt = userPrompt;
+                }
+            });
+
+        // when — no session id at all
+        await agent.ProcessPromptAsync("what is the capital of France?");
+        await agent.ProcessPromptAsync("and its population?");
+
+        // then — absent a session the agent is exactly as stateless as it always was
+        capturedPrompt.Should().NotContain("Paris");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this.sessionsPath))
+        {
+            Directory.Delete(this.sessionsPath, recursive: true);
+        }
+    }
+}

--- a/Standard.Agents/Brokers/Sessions/FileSessionBroker.cs
+++ b/Standard.Agents/Brokers/Sessions/FileSessionBroker.cs
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Standard.Agents.Models.Brokers.Sessions;
+
+namespace Standard.Agents.Brokers.Sessions;
+
+// The Local mode: one JSON file per session in a folder.
+//
+// Written to a temporary file and moved into place, so a crash mid-write leaves the previous
+// session intact rather than a half-written one. A session is the thing resumption depends on;
+// corrupting it while saving it would defeat the feature at exactly the moment it is needed.
+//
+// It is a real store rather than an in-memory one on purpose: SPEC.md §4.11 requires resumption
+// to work from a DIFFERENT process, and an in-memory session cannot demonstrate that.
+public sealed class FileSessionBroker : ISessionBroker
+{
+    private static readonly JsonSerializerOptions jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        WriteIndented = true
+    };
+
+    private readonly string sessionsPath;
+    private readonly SemaphoreSlim writeLock = new(initialCount: 1, maxCount: 1);
+
+    public FileSessionBroker(string sessionsPath) =>
+        this.sessionsPath = Path.GetFullPath(sessionsPath);
+
+    public async ValueTask<AgentSession?> SelectSessionAsync(string sessionId)
+    {
+        string sessionFile = FileFor(sessionId);
+
+        if (File.Exists(sessionFile) is false)
+        {
+            return null;
+        }
+
+        string json = await File.ReadAllTextAsync(sessionFile);
+
+        return JsonSerializer.Deserialize<AgentSession>(json, jsonOptions);
+    }
+
+    public async ValueTask UpsertSessionAsync(AgentSession session)
+    {
+        await this.writeLock.WaitAsync();
+
+        try
+        {
+            Directory.CreateDirectory(this.sessionsPath);
+
+            string sessionFile = FileFor(session.Id);
+            string temporaryFile = $"{sessionFile}.writing";
+
+            await File.WriteAllTextAsync(
+                temporaryFile,
+                JsonSerializer.Serialize(session, jsonOptions));
+
+            File.Move(temporaryFile, sessionFile, overwrite: true);
+        }
+        finally
+        {
+            this.writeLock.Release();
+        }
+    }
+
+    // A session id comes from the host and may be anything — an email, a ticket reference, a
+    // path fragment. Hashing it keeps it off the filesystem's grammar entirely rather than
+    // trying to sanitize a name that could escape the folder.
+    private string FileFor(string sessionId)
+    {
+        string safeName = Convert.ToHexStringLower(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(sessionId)))[..32];
+
+        return Path.Combine(this.sessionsPath, $"{safeName}.json");
+    }
+}

--- a/Standard.Agents/Brokers/Sessions/FunctionSessionBroker.cs
+++ b/Standard.Agents/Brokers/Sessions/FunctionSessionBroker.cs
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Sessions;
+
+namespace Standard.Agents.Brokers.Sessions;
+
+// The Custom mode's substrate: host-supplied read and write, for a store the host already has.
+public sealed class FunctionSessionBroker : ISessionBroker
+{
+    private readonly Func<string, ValueTask<AgentSession?>> select;
+    private readonly Func<AgentSession, ValueTask> upsert;
+
+    public FunctionSessionBroker(
+        Func<string, ValueTask<AgentSession?>> select,
+        Func<AgentSession, ValueTask> upsert)
+    {
+        this.select = select;
+        this.upsert = upsert;
+    }
+
+    public ValueTask<AgentSession?> SelectSessionAsync(string sessionId) =>
+        this.select(sessionId);
+
+    public ValueTask UpsertSessionAsync(AgentSession session) =>
+        this.upsert(session);
+}

--- a/Standard.Agents/Brokers/Sessions/ISessionBroker.cs
+++ b/Standard.Agents/Brokers/Sessions/ISessionBroker.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Sessions;
+
+namespace Standard.Agents.Brokers.Sessions;
+
+public interface ISessionBroker
+{
+    ValueTask<AgentSession?> SelectSessionAsync(string sessionId);
+
+    ValueTask UpsertSessionAsync(AgentSession session);
+}

--- a/Standard.Agents/Brokers/Sessions/NotConfiguredSessionBroker.cs
+++ b/Standard.Agents/Brokers/Sessions/NotConfiguredSessionBroker.cs
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Sessions;
+
+namespace Standard.Agents.Brokers.Sessions;
+
+// The default. SPEC.md §4.11: absent a session, behavior is exactly as if the section did not
+// exist — nothing is loaded, nothing is written, and the agent is stateless prompt to prompt.
+public sealed class NotConfiguredSessionBroker : ISessionBroker
+{
+    public ValueTask<AgentSession?> SelectSessionAsync(string sessionId) =>
+        ValueTask.FromResult<AgentSession?>(null);
+
+    public ValueTask UpsertSessionAsync(AgentSession session) =>
+        ValueTask.CompletedTask;
+}

--- a/Standard.Agents/Models/Brokers/Sessions/AgentSession.cs
+++ b/Standard.Agents/Models/Brokers/Sessions/AgentSession.cs
@@ -1,0 +1,34 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Agents;
+
+namespace Standard.Agents.Models.Brokers.Sessions;
+
+/// <summary>
+/// One conversation: what was said, and what it was left in the middle of.
+/// </summary>
+/// <remarks>
+/// Invariant 4 says the agent <i>instance</i> is stateless across prompts. It does not say the
+/// conversation is (SPEC.md §4.11). The session is where continuity lives — outside the agent, in
+/// a broker — which is what lets a pause be resumed by a different process, or by a different
+/// machine, long after the instance that created it is gone.
+/// </remarks>
+public sealed record AgentSession
+{
+    public string Id { get; init; } = "";
+
+    /// <summary>What was said before, oldest first.</summary>
+    public IReadOnlyList<AgentTurn> History { get; init; } = [];
+
+    /// <summary>What the session was left in the middle of, if anything.</summary>
+    public AgentStatus Status { get; init; }
+
+    /// <summary>The question the agent asked and is waiting on, when awaiting input.</summary>
+    public string PendingQuestion { get; init; } = "";
+}
+
+/// <summary>One exchange: what was asked, and what came back.</summary>
+public sealed record AgentTurn(string Prompt, string Answer);

--- a/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
@@ -3,11 +3,19 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using Standard.Agents.Models.Brokers.Sessions;
+
 namespace Standard.Agents.Models.Orchestrations.Agents;
 
 public sealed record AgentContext
 {
     public string Prompt { get; init; } = "";
+
+    // The conversation this prompt belongs to, and what was said before (SPEC.md §3.2, §4.11).
+    // Empty when no session is configured, which is exactly the stateless agent that existed
+    // before sessions did.
+    public string SessionId { get; init; } = "";
+    public IReadOnlyList<AgentTurn> History { get; init; } = [];
 
     public string SystemPrompt { get; init; } = "";
     public IReadOnlyList<string> Observations { get; init; } = [];

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Sessions.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Sessions.cs
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Orchestrations.Agents;
+
+namespace Standard.Agents.Services.Coordinations;
+
+// Conversation and resumption (SPEC.md §4.11).
+//
+// Invariant 4 still holds: the instance is stateless across prompts. What persists is the
+// session, and it lives in a broker outside the agent — which is what lets a pause be resumed by
+// a different process, long after the instance that created it is gone.
+public partial class AgentCoordinationService
+{
+    private async ValueTask<AgentContext> LoadSessionAsync(AgentContext context)
+    {
+        if (string.IsNullOrEmpty(context.SessionId))
+        {
+            return context;
+        }
+
+        AgentSession? session =
+            await this.sessionBroker.SelectSessionAsync(context.SessionId);
+
+        if (session is null)
+        {
+            return context;
+        }
+
+        // Bounded, oldest first. An unbounded history makes every prompt in a long conversation
+        // cost more than the last, without limit — the bill grows on its own.
+        IReadOnlyList<AgentTurn> history = session.History.Count > this.maxHistoryTurns
+            ? [.. session.History.Skip(session.History.Count - this.maxHistoryTurns)]
+            : session.History;
+
+        await this.loggingBroker.LogProcessAsync(
+            "Data", $"Recalled {history.Count} conversation turn(s)");
+
+        return context with { History = history };
+    }
+
+    // Only a completed prompt is recorded. A cancelled or budget-stopped run must never be
+    // written back as an answer: the next prompt would then be told the agent said something it
+    // never said, and the conversation would be quietly wrong from that point on.
+    private async ValueTask SaveSessionAsync(AgentContext context, bool completed)
+    {
+        if (string.IsNullOrEmpty(context.SessionId) || completed is false)
+        {
+            return;
+        }
+
+        AgentSession? existing =
+            await this.sessionBroker.SelectSessionAsync(context.SessionId);
+
+        IReadOnlyList<AgentTurn> history = existing?.History ?? [];
+
+        var session = new AgentSession
+        {
+            Id = context.SessionId,
+            History = [.. history, new AgentTurn(context.Prompt, context.Result)],
+            Status = context.Status,
+
+            // What the agent is waiting on, so a later prompt can see it was mid-question
+            // rather than mid-nothing.
+            PendingQuestion = context.Status is AgentStatus.AwaitingInput
+                or AgentStatus.AwaitingApproval
+                    ? context.Result
+                    : string.Empty
+        };
+
+        await this.sessionBroker.UpsertSessionAsync(session);
+    }
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -5,6 +5,7 @@
 
 using System.Runtime.CompilerServices;
 using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Sessions;
 using Standard.Agents.Brokers.Times;
 using Standard.Agents.Models.Coordinations.Agents;
 using Standard.Agents.Models.Clients.Agents;
@@ -29,6 +30,8 @@ public partial class AgentCoordinationService : IAgentCoordinationService
     private readonly ILoggingBroker loggingBroker;
     private readonly ITimeBroker timeBroker;
     private readonly AgentBudget? budget;
+    private readonly ISessionBroker sessionBroker;
+    private readonly int maxHistoryTurns;
     private readonly int maxTurns;
 
     public AgentCoordinationService(
@@ -38,7 +41,9 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         ILoggingBroker loggingBroker,
         int maxTurns = DefaultMaxTurns,
         ITimeBroker? timeBroker = null,
-        AgentBudget? budget = null)
+        AgentBudget? budget = null,
+        ISessionBroker? sessionBroker = null,
+        int maxHistoryTurns = 20)
     {
         this.dataOrchestrationService = dataOrchestrationService;
         this.decisionOrchestrationService = decisionOrchestrationService;
@@ -47,13 +52,21 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         this.maxTurns = maxTurns;
         this.timeBroker = timeBroker ?? new TimeBroker();
         this.budget = budget;
+        this.sessionBroker = sessionBroker ?? new NotConfiguredSessionBroker();
+        this.maxHistoryTurns = maxHistoryTurns;
     }
 
     public ValueTask<string> ProcessPromptAsync(string prompt) =>
-        ProcessPromptAsync(prompt, CancellationToken.None);
+        ProcessPromptAsync(prompt, string.Empty, CancellationToken.None);
 
     public ValueTask<string> ProcessPromptAsync(
         string prompt,
+        CancellationToken cancellationToken) =>
+        ProcessPromptAsync(prompt, string.Empty, cancellationToken);
+
+    public ValueTask<string> ProcessPromptAsync(
+        string prompt,
+        string sessionId,
         CancellationToken cancellationToken) =>
     TryCatch(async () =>
     {
@@ -66,7 +79,10 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
         await this.loggingBroker.LogResetAsync();
 
-        AgentContext context = new() { Prompt = prompt };
+        AgentContext context = new() { Prompt = prompt, SessionId = sessionId };
+
+        // What was said before, loaded before Decision runs so the Brain sees it (SPEC.md §4.11).
+        context = await LoadSessionAsync(context);
 
         // Budgets and cancellation are both checked at the turn boundary (SPEC.md §4.10): a turn
         // is the smallest unit the loop can stop between without abandoning work mid-flight —
@@ -129,6 +145,9 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         {
             await this.dataOrchestrationService.RememberAsync(context.Remember);
         }
+
+        // Appended before the call returns, so the next prompt sees it (SPEC.md §4.11).
+        await SaveSessionAsync(context, completed: true);
 
         return context.Result;
     });

--- a/Standard.Agents/Services/Coordinations/IAgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/IAgentCoordinationService.cs
@@ -13,6 +13,11 @@ public interface IAgentCoordinationService
 
     ValueTask<string> ProcessPromptAsync(string prompt, CancellationToken cancellationToken);
 
+    ValueTask<string> ProcessPromptAsync(
+        string prompt,
+        string sessionId,
+        CancellationToken cancellationToken);
+
     IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
         string prompt,
         CancellationToken cancellationToken = default);

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Brokers.Sessions;
 using Standard.Agents.Models.Foundations.Gates;
 using Standard.Agents.Models.Foundations.Judges;
 using Standard.Agents.Models.Orchestrations.Agents;
@@ -449,6 +450,22 @@ verdict.TrimStart().StartsWith(RefuseVerdict, StringComparison.OrdinalIgnoreCase
     private static string BuildUserMessage(AgentContext context)
     {
         StringBuilder userMessage = new();
+
+        // What was said before, oldest first, so a follow-up resolves against it rather than
+        // starting from nothing (SPEC.md §4.11). Absent a session this is empty and the message
+        // is exactly what it always was.
+        if (context.History.Count > 0)
+        {
+            userMessage.AppendLine("Conversation so far:").AppendLine();
+
+            foreach (AgentTurn turn in context.History)
+            {
+                userMessage.Append("User: ").AppendLine(turn.Prompt);
+                userMessage.Append("You: ").AppendLine(turn.Answer);
+            }
+
+            userMessage.AppendLine();
+        }
 
         userMessage.Append("Task: ").Append(context.Prompt);
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -18,11 +18,13 @@ using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Redactions;
 using Standard.Agents.Brokers.Resiliences;
+using Standard.Agents.Brokers.Sessions;
 using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Brokers.Times;
 using Standard.Agents.Brokers.Tools;
 using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Models.Brokers.Audits;
+using Standard.Agents.Models.Brokers.Sessions;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Coordinations.Agents;
 using Standard.Agents.Models.Foundations.Brains;
@@ -92,6 +94,8 @@ public sealed partial class StandardAgent : IAgent
     private bool screenToolOutput;
     private AgentBudget? budget;
     private IResilienceBroker? resilienceBroker;
+    private ISessionBroker? sessionBroker;
+    private int maxHistoryTurns = 20;
     private Func<string?>? principalResolver;
 
     private IAgentCoordinationService? agent;
@@ -651,6 +655,66 @@ public sealed partial class StandardAgent : IAgent
     }
 
     /// <summary>
+    /// Runs the agent as part of a <b>conversation</b>. What was said before is loaded before the
+    /// brain thinks, and this exchange is appended when it answers — so a follow-up resolves
+    /// against what came before instead of starting from nothing (SPEC.md §4.11).
+    /// </summary>
+    /// <remarks>
+    /// The conversation lives in the session store, not in this instance, so it survives a
+    /// restart and can be continued by a different process. Invariant 4 is intact: the agent is
+    /// still stateless across prompts; the session is not part of the agent.
+    /// <para>A cancelled or budget-stopped run is never recorded as an answer — the next prompt
+    /// would otherwise be told the agent said something it never said.</para>
+    /// </remarks>
+    /// <param name="prompt">The user's prompt.</param>
+    /// <param name="sessionId">Which conversation this belongs to.</param>
+    /// <param name="cancellationToken">Token to stop the run.</param>
+    /// <returns>The agent's final answer.</returns>
+    public async ValueTask<string> ProcessPromptAsync(
+        string prompt,
+        string sessionId,
+        CancellationToken cancellationToken = default)
+    {
+        return await ResolveAgent().ProcessPromptAsync(prompt, sessionId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Keeps conversations in a folder, one file per session — the <b>Local</b> mode of sessions.
+    /// </summary>
+    /// <param name="path">Folder to keep sessions in.</param>
+    /// <param name="maxHistoryTurns">
+    /// How many past exchanges to recall. Bounded on purpose: an unbounded history makes every
+    /// prompt in a long conversation cost more than the last, without limit.
+    /// </param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Sessions(string path, int maxHistoryTurns = 20) =>
+    Set(() =>
+    {
+        this.sessionBroker = new FileSessionBroker(path);
+        this.maxHistoryTurns = maxHistoryTurns;
+    });
+
+    /// <summary>
+    /// Keeps conversations in a provider — the <b>External</b> mode (Redis, Postgres, your own
+    /// store). This is what makes resumption work across machines, not just across processes.
+    /// </summary>
+    /// <param name="broker">The session broker to use.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent UseSessions(ISessionBroker broker) =>
+        Set(() => this.sessionBroker = broker);
+
+    /// <summary>
+    /// Keeps conversations wherever your own code puts them — the <b>Custom</b> mode.
+    /// </summary>
+    /// <param name="select">Reads a session by id, or returns null when there is none.</param>
+    /// <param name="upsert">Writes a session back.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent OnSessions(
+        Func<string, ValueTask<AgentSession?>> select,
+        Func<AgentSession, ValueTask> upsert) =>
+        Set(() => this.sessionBroker = new FunctionSessionBroker(select, upsert));
+
+    /// <summary>
     /// Bounds what one prompt may consume (SPEC.md §4.10). Checked between turns; exhaustion
     /// stops the loop and says which bound ran out, distinguishably from a refusal — a caller
     /// that cannot tell <i>I will not</i> from <i>I ran out</i> cannot decide whether to retry.
@@ -919,7 +983,8 @@ public sealed partial class StandardAgent : IAgent
             this.screenToolOutput ? gate : null);
 
         return new AgentCoordinationService(
-            data, decision, direction, logging, this.maxTurns, new TimeBroker(), this.budget);
+            data, decision, direction, logging, this.maxTurns, new TimeBroker(), this.budget,
+            this.sessionBroker, this.maxHistoryTurns);
     }
 
     // The catalog a "{{tools}}" marker in the agent's Data expands into. Only tools that

--- a/conformance/vectors/25-conversation-carries-history.json
+++ b/conformance/vectors/25-conversation-carries-history.json
@@ -1,0 +1,13 @@
+{
+  "name": "conversation-carries-history",
+  "description": "SPEC.md 4.11: Invariant 4 says the agent instance is stateless across prompts; it does not say the conversation is. When a session is supplied, what was said before is loaded before Decision runs, so a follow-up resolves against it rather than starting from nothing. Two prompts share a session; the second must reach the Brain carrying the first exchange.",
+  "generatorReplies": ["FINAL: Paris", "FINAL: about 2.1 million"],
+  "tools": {},
+  "prompt": "what is the capital of France",
+  "prompts": ["what is the capital of France", "and its population"],
+  "sessionId": "conformance-session",
+  "expect": {
+    "result": "about 2.1 million",
+    "brainSees": "Paris"
+  }
+}


### PR DESCRIPTION
First slice of the Enterprise Model. Spec first: implements SPEC.md §3.2/§4.1/§4.11, merged as The-Standard-Agent-Specs#17.

## The gap

Invariant 4 says the agent **instance** is stateless across prompts. It does not say the **conversation** is — but the implementation treated them as the same thing. Every prompt started from nothing, *"and what about Paris?"* had no idea what came before, and `AwaitingInput` was a dead end: the agent asked a clarifying question, then discarded the context needed to use the answer.

## What it is now

Continuity lives **outside the agent**, in a broker, recalled the way memory and knowledge are. Invariant 4 is intact — the instance is still stateless; the session simply isn't part of it.

- History loads before Decision runs, **bounded** to 20 exchanges by default. An unbounded history makes every prompt in a long conversation cost more than the last, without limit.
- A completed prompt is appended before the call returns.
- **A cancelled or budget-stopped run is never recorded as an answer** — the next prompt would otherwise be told the agent said something it never said, and the conversation would be quietly wrong from there on.

## The file store's two careful bits

**Write-then-move**, so a crash mid-write leaves the previous session intact rather than a half-written one. A session is the thing resumption depends on; corrupting it while saving it would defeat the feature exactly when it's needed.

**Session ids are hashed, not sanitized** — a host id that looks like a path cannot escape the folder.

It is a real file store rather than in-memory because the spec requires resumption **from a different process**, and an in-memory session cannot demonstrate that.

## Verified

Five acceptance tests, including the one that matters: **a conversation started on one agent instance continues on a different instance entirely.** Plus sessions stay separate, cancelled runs aren't recorded, and absent a session the agent is exactly as stateless as before.

Vector 25 certifies it and **fails when history is not loaded**.

341 tests · 25/25 vectors · 0 warnings · Enterprise still certified.