### PR TITLE
GENERATORS: Native Tool Calling (V1)

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/NativeToolCallTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/NativeToolCallTests.cs
@@ -1,0 +1,159 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// Native tool calling (SPEC.md §6). The text protocol asks a model to imitate a format; a
+// tool_call is the thing hosted models are actually tuned for. These pin that adopting it changes
+// how a choice is READ, not what the agent is — the same tools, the same perimeter, the same
+// answer at the end.
+public class NativeToolCallTests
+{
+    private sealed class CalculatorTool : ITool
+    {
+        public string Name => "calculator";
+        public string Description => "Evaluates arithmetic.";
+        public string Parameters => """{"type":"object","properties":{"expression":{"type":"string"}}}""";
+
+        public IReadOnlyList<string> ReceivedInputs => this.received;
+        private readonly List<string> received = [];
+
+        public ValueTask<string> ExecuteAsync(string input)
+        {
+            this.received.Add(input);
+
+            return ValueTask.FromResult("4183");
+        }
+    }
+
+    private static StandardAgent AgentWith(
+        CalculatorTool tool,
+        Func<IReadOnlyList<ToolDefinition>, int, GenerationResult> reply)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+
+        skillBroker.Setup(broker => broker.SelectSkillsAsync())
+            .ReturnsAsync(new List<Skill> { new() { Content = "You are a calculator agent." } });
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        int call = 0;
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .Tool(tool)
+            .OnNativeBrain((messages, tools) =>
+                ValueTask.FromResult(reply(tools, call++)));
+    }
+
+    [Fact]
+    public async Task ShouldRoundTripANativeToolCallAsync()
+    {
+        // given — the model asks for the tool, then answers from its result
+        var tool = new CalculatorTool();
+
+        StandardAgent agent = AgentWith(tool, (tools, call) => call == 0
+            ? new GenerationResult
+            {
+                ToolCalls =
+                [
+                    new ModelToolCall(
+                        Id: "call_1",
+                        Name: "calculator",
+                        ArgumentsJson: """{"expression":"47*89"}""")
+                ]
+            }
+            : new GenerationResult { Content = "4183" });
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync("what is 47 times 89?");
+
+        // then
+        tool.ReceivedInputs.Should().ContainSingle();
+        tool.ReceivedInputs[0].Should().Contain("47*89");
+        actualResult.Should().Be("4183");
+    }
+
+    private sealed class UndescribedTool : ITool
+    {
+        public string Name => "secret";
+        public string Description => string.Empty;
+        public string Parameters => "{}";
+
+        public ValueTask<string> ExecuteAsync(string input) =>
+            ValueTask.FromResult("never advertised");
+    }
+
+    [Fact]
+    public async Task ShouldAdvertiseOnlyDescribedToolsNativelyAsync()
+    {
+        // given
+        var tool = new CalculatorTool();
+        IReadOnlyList<ToolDefinition> capturedTools = [];
+
+        StandardAgent agent = AgentWith(tool, (tools, call) =>
+        {
+            capturedTools = tools;
+
+            return new GenerationResult { Content = "done" };
+        })
+            .Tool(new UndescribedTool());
+
+        // when
+        await agent.ProcessPromptAsync("hello");
+
+        // then — a description is the opt-in, natively exactly as in the text catalog: a tool
+        // without one stays callable but is never offered to the model
+        capturedTools.Should().Contain(definition => definition.Name == "calculator");
+        capturedTools.Should().NotContain(definition => definition.Name == "secret");
+
+        capturedTools.Should().OnlyContain(definition =>
+            string.IsNullOrWhiteSpace(definition.Description) == false);
+    }
+
+    [Fact]
+    public async Task ShouldReportNativeUsageForTheBudgetAsync()
+    {
+        // given — a model that reports what it cost, and a budget smaller than that
+        var tool = new CalculatorTool();
+
+        StandardAgent agent = AgentWith(tool, (tools, call) => new GenerationResult
+        {
+            ToolCalls =
+            [
+                new ModelToolCall("call_1", "calculator", """{"expression":"1+1"}""")
+            ],
+
+            PromptTokens = 500,
+            CompletionTokens = 500
+        })
+            .MaxTurns(10)
+            .Budget(maxTokens: 900);
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync("loop");
+
+        // then — reported usage is what the budget measures, not an estimate
+        actualResult.Should().Contain("token budget");
+    }
+}

--- a/Standard.Agents/Brokers/Generators/FunctionGeneratorBrokerV1.cs
+++ b/Standard.Agents/Brokers/Generators/FunctionGeneratorBrokerV1.cs
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Generators.V1;
+
+namespace Standard.Agents.Brokers.Generators;
+
+// The Custom mode for the V1 seam: a host-supplied conversation handler. Also what a test
+// scripts, which is how native tool calling is certified without a provider.
+public sealed class FunctionGeneratorBrokerV1 : IGeneratorBrokerV1
+{
+    private readonly Func<
+        IReadOnlyList<ConversationMessage>,
+        IReadOnlyList<ToolDefinition>,
+        ValueTask<GenerationResult>> generate;
+
+    public FunctionGeneratorBrokerV1(
+        Func<
+            IReadOnlyList<ConversationMessage>,
+            IReadOnlyList<ToolDefinition>,
+            ValueTask<GenerationResult>> generate) =>
+        this.generate = generate;
+
+    public ValueTask<GenerationResult> GenerateAsync(
+        IReadOnlyList<ConversationMessage> messages,
+        IReadOnlyList<ToolDefinition> tools) =>
+        this.generate(messages, tools);
+}

--- a/Standard.Agents/Brokers/Generators/GeneratorBrokerV1.cs
+++ b/Standard.Agents/Brokers/Generators/GeneratorBrokerV1.cs
@@ -1,0 +1,190 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Standard.Agents.Models.Brokers.Generators.V1;
+
+namespace Standard.Agents.Brokers.Generators;
+
+// Native tool calling against an OpenAI-compatible endpoint: tools go out as `tools[]`, the
+// model's choice comes back as `tool_calls`, and usage comes back reported rather than guessed.
+//
+// The request is built as a JSON tree rather than through typed records, because the tool
+// schemas are already JSON the host wrote and re-modelling them would only give us a second
+// place for them to be wrong.
+public sealed class GeneratorBrokerV1 : IGeneratorBrokerV1
+{
+    private const string ChatCompletionsRelativeUrl = "chat/completions";
+    private const string JsonMediaType = "application/json";
+
+    private readonly HttpClient httpClient;
+    private readonly string model;
+    private readonly double temperature;
+    private readonly int maxTokens;
+
+    public GeneratorBrokerV1(
+        string apiUrl,
+        string apiKey,
+        string model,
+        double temperature = 0.7,
+        int maxTokens = 1024,
+        int timeoutSeconds = 120)
+    {
+        this.httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(apiUrl),
+            Timeout = TimeSpan.FromSeconds(timeoutSeconds)
+        };
+
+        this.httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(scheme: "Bearer", parameter: apiKey);
+
+        this.model = model;
+        this.temperature = temperature;
+        this.maxTokens = maxTokens;
+    }
+
+    public async ValueTask<GenerationResult> GenerateAsync(
+        IReadOnlyList<ConversationMessage> messages,
+        IReadOnlyList<ToolDefinition> tools)
+    {
+        JsonObject request = BuildRequest(messages, tools);
+
+        using var content = new StringContent(
+            request.ToJsonString(), Encoding.UTF8, JsonMediaType);
+
+        using HttpResponseMessage response =
+            await this.httpClient.PostAsync(ChatCompletionsRelativeUrl, content);
+
+        response.EnsureSuccessStatusCode();
+
+        JsonNode? body = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+
+        return ReadResult(body);
+    }
+
+    private JsonObject BuildRequest(
+        IReadOnlyList<ConversationMessage> messages,
+        IReadOnlyList<ToolDefinition> tools)
+    {
+        var request = new JsonObject
+        {
+            ["model"] = this.model,
+            ["temperature"] = this.temperature,
+            ["max_tokens"] = this.maxTokens,
+            ["messages"] = new JsonArray([.. messages.Select(ToJson)])
+        };
+
+        // Only advertise when there is something to advertise: an empty tools array is a
+        // different request than no tools at all on some providers.
+        if (tools.Count > 0)
+        {
+            request["tools"] = new JsonArray([.. tools.Select(ToJson)]);
+        }
+
+        return request;
+    }
+
+    private static JsonNode ToJson(ConversationMessage message)
+    {
+        var json = new JsonObject
+        {
+            ["role"] = message.Role.ToString().ToLowerInvariant(),
+            ["content"] = message.Content
+        };
+
+        if (message.Role is MessageRole.Tool)
+        {
+            json["tool_call_id"] = message.ToolCallId;
+        }
+
+        if (message.ToolCalls.Count > 0)
+        {
+            json["tool_calls"] = new JsonArray([.. message.ToolCalls.Select(call =>
+                (JsonNode)new JsonObject
+                {
+                    ["id"] = call.Id,
+                    ["type"] = "function",
+                    ["function"] = new JsonObject
+                    {
+                        ["name"] = call.Name,
+                        ["arguments"] = call.ArgumentsJson
+                    }
+                })]);
+        }
+
+        return json;
+    }
+
+    private static JsonNode ToJson(ToolDefinition tool) =>
+        new JsonObject
+        {
+            ["type"] = "function",
+            ["function"] = new JsonObject
+            {
+                ["name"] = tool.Name,
+                ["description"] = tool.Description,
+                ["parameters"] = ParseParameters(tool.ParametersJson)
+            }
+        };
+
+    // A tool's parameters are the host's JSON schema. If it does not parse, an empty object is
+    // sent rather than a malformed request: the tool is then callable with no arguments instead
+    // of the whole turn failing on one bad schema.
+    private static JsonNode ParseParameters(string parametersJson)
+    {
+        if (string.IsNullOrWhiteSpace(parametersJson))
+        {
+            return new JsonObject { ["type"] = "object" };
+        }
+
+        try
+        {
+            return JsonNode.Parse(parametersJson) ?? new JsonObject { ["type"] = "object" };
+        }
+        catch (JsonException)
+        {
+            return new JsonObject { ["type"] = "object" };
+        }
+    }
+
+    private static GenerationResult ReadResult(JsonNode? body)
+    {
+        JsonNode? message = body?["choices"]?[0]?["message"];
+        JsonNode? usage = body?["usage"];
+
+        List<ModelToolCall> toolCalls = [];
+
+        if (message?["tool_calls"] is JsonArray calls)
+        {
+            foreach (JsonNode? call in calls)
+            {
+                string id = call?["id"]?.GetValue<string>() ?? string.Empty;
+                JsonNode? function = call?["function"];
+
+                string name = function?["name"]?.GetValue<string>() ?? string.Empty;
+
+                string arguments =
+                    function?["arguments"]?.GetValue<string>() ?? "{}";
+
+                if (string.IsNullOrWhiteSpace(name) is false)
+                {
+                    toolCalls.Add(new ModelToolCall(id, name, arguments));
+                }
+            }
+        }
+
+        return new GenerationResult
+        {
+            Content = message?["content"]?.GetValue<string>() ?? string.Empty,
+            ToolCalls = toolCalls,
+            PromptTokens = usage?["prompt_tokens"]?.GetValue<int>() ?? 0,
+            CompletionTokens = usage?["completion_tokens"]?.GetValue<int>() ?? 0
+        };
+    }
+}

--- a/Standard.Agents/Brokers/Generators/IGeneratorBrokerV1.cs
+++ b/Standard.Agents/Brokers/Generators/IGeneratorBrokerV1.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Generators.V1;
+
+namespace Standard.Agents.Brokers.Generators;
+
+/// <summary>
+/// The V1 brain contract: a conversation in, a structured choice out.
+/// </summary>
+/// <remarks>
+/// A sibling of <see cref="IGeneratorBroker"/>, not a replacement (plan §1.3). V0 stays alive and
+/// supported, because the five provider packages implement it and none of them should have to
+/// move on our schedule.
+/// </remarks>
+public interface IGeneratorBrokerV1
+{
+    ValueTask<GenerationResult> GenerateAsync(
+        IReadOnlyList<ConversationMessage> messages,
+        IReadOnlyList<ToolDefinition> tools);
+}

--- a/Standard.Agents/Models/Brokers/Generators/V1/Conversation.cs
+++ b/Standard.Agents/Models/Brokers/Generators/V1/Conversation.cs
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Brokers.Generators.V1;
+
+/// <summary>
+/// The V1 generator contract's shape: a conversation of typed messages, and tools declared as
+/// data rather than described in prose.
+/// </summary>
+/// <remarks>
+/// V0 sends one system prompt and one user prompt, and reads the model's choice out of the first
+/// line of its text (<c>ACTION:</c> / <c>TOOL:</c> / <c>FINAL:</c>). That works everywhere, which
+/// is why it stays the Core contract — but it forfeits what hosted models are actually trained on,
+/// cannot express parallel calls, and has no way to tie a result back to the call that asked for
+/// it. V1 exists for the providers that do better; V0 keeps working untouched, and the five
+/// provider packages compile against it until they choose to move.
+/// </remarks>
+public enum MessageRole
+{
+    System,
+    User,
+    Assistant,
+
+    /// <summary>A tool's result, tied to the call that asked for it by <c>ToolCallId</c>.</summary>
+    Tool
+}
+
+public sealed record ConversationMessage
+{
+    public MessageRole Role { get; init; }
+    public string Content { get; init; } = "";
+
+    /// <summary>Calls the assistant asked for, when it asked for any.</summary>
+    public IReadOnlyList<ModelToolCall> ToolCalls { get; init; } = [];
+
+    /// <summary>Which call this message answers — set on a <see cref="MessageRole.Tool"/> message.</summary>
+    public string ToolCallId { get; init; } = "";
+}
+
+/// <summary>A tool offered to the model, as data rather than as a sentence in a prompt.</summary>
+public sealed record ToolDefinition(string Name, string Description, string ParametersJson);
+
+/// <summary>
+/// One call the model asked for. The id is what makes a result attributable to a request, which
+/// is the thing the text protocol cannot express.
+/// </summary>
+public sealed record ModelToolCall(string Id, string Name, string ArgumentsJson);
+
+/// <summary>
+/// What a V1 generation produced: text, tool calls, or both — and what it cost, when the
+/// provider says (SPEC.md §3.4).
+/// </summary>
+public sealed record GenerationResult
+{
+    public string Content { get; init; } = "";
+    public IReadOnlyList<ModelToolCall> ToolCalls { get; init; } = [];
+
+    public int PromptTokens { get; init; }
+    public int CompletionTokens { get; init; }
+
+    public bool HasToolCalls => ToolCalls.Count > 0;
+}

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.V1.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.V1.cs
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Orchestrations.Agents;
+
+namespace Standard.Agents.Services.Foundations.Brains;
+
+// The V1 path: a conversation of typed messages in, a structured choice out.
+//
+// The whole reason it exists is that the text protocol forfeits what hosted models are trained
+// on. A model asked to emit "ACTION: calculator: 2+2" is being asked to imitate a format; the
+// same model emitting a tool_call is doing the thing it was tuned for. The text protocol stays
+// the Core contract because it works against any endpoint, and because a small local model
+// often does better with it.
+//
+// Redaction applies here exactly as it does on the V0 path (SPEC.md §4.6): every message going
+// out is redacted, and the reply is rehydrated before anyone reads it.
+public partial class BrainService
+{
+    public async ValueTask<GenerationResult> GenerateAsync(
+        AgentContext context,
+        IReadOnlyList<ToolDefinition> tools)
+    {
+        ValidateUserPrompt(context.Prompt);
+
+        var vault = new Dictionary<string, string>();
+
+        IReadOnlyList<ConversationMessage> messages =
+            [.. BuildConversation(context).Select(message => message with
+            {
+                Content = this.redactionBroker.Redact(message.Content, vault)
+            })];
+
+        GenerationResult result = await this.resilienceBroker.ExecuteAsync(() =>
+            this.generatorBrokerV1!.GenerateAsync(messages, tools));
+
+        return result with
+        {
+            Content = this.redactionBroker.Rehydrate(result.Content, vault),
+
+            ToolCalls =
+            [
+                .. result.ToolCalls.Select(call => call with
+                {
+                    ArgumentsJson = this.redactionBroker.Rehydrate(call.ArgumentsJson, vault)
+                })
+            ]
+        };
+    }
+
+    // The conversation the model actually sees: who it is, what was said before, what it has
+    // learned this turn, and the task. Observations are their own message rather than appended
+    // to the task, so a tool result reads as something that happened rather than as part of
+    // what the user asked.
+    private static IEnumerable<ConversationMessage> BuildConversation(AgentContext context)
+    {
+        if (string.IsNullOrWhiteSpace(context.SystemPrompt) is false)
+        {
+            yield return new ConversationMessage
+            {
+                Role = MessageRole.System,
+                Content = context.SystemPrompt
+            };
+        }
+
+        foreach (AgentTurn turn in context.History)
+        {
+            yield return new ConversationMessage
+            {
+                Role = MessageRole.User,
+                Content = turn.Prompt
+            };
+
+            yield return new ConversationMessage
+            {
+                Role = MessageRole.Assistant,
+                Content = turn.Answer
+            };
+        }
+
+        yield return new ConversationMessage
+        {
+            Role = MessageRole.User,
+            Content = context.Prompt
+        };
+
+        if (context.Observations.Count > 0)
+        {
+            yield return new ConversationMessage
+            {
+                Role = MessageRole.Assistant,
+                Content = "Observations so far:\n"
+                    + string.Join('\n', context.Observations.Select(o => $"- {o}"))
+            };
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.cs
@@ -18,17 +18,23 @@ public partial class BrainService : IBrainService
     private readonly ILoggingBroker loggingBroker;
     private readonly IRedactionBroker redactionBroker;
     private readonly IResilienceBroker resilienceBroker;
+    private readonly IGeneratorBrokerV1? generatorBrokerV1;
+
+    /// <summary>True when a V1 brain is configured and native tool calling is available.</summary>
+    public bool SpeaksNatively => this.generatorBrokerV1 is not null;
 
     public BrainService(
         IGeneratorBroker generatorBroker,
         ILoggingBroker loggingBroker,
         IRedactionBroker? redactionBroker = null,
-        IResilienceBroker? resilienceBroker = null)
+        IResilienceBroker? resilienceBroker = null,
+        IGeneratorBrokerV1? generatorBrokerV1 = null)
     {
         this.generatorBroker = generatorBroker;
         this.loggingBroker = loggingBroker;
         this.redactionBroker = redactionBroker ?? new NotConfiguredRedactionBroker();
         this.resilienceBroker = resilienceBroker ?? new NotConfiguredResilienceBroker();
+        this.generatorBrokerV1 = generatorBrokerV1;
     }
 
     public ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt) =>

--- a/Standard.Agents/Services/Foundations/Brains/IBrainService.cs
+++ b/Standard.Agents/Services/Foundations/Brains/IBrainService.cs
@@ -9,6 +9,18 @@ public interface IBrainService
 {
     ValueTask<string> GenerateAsync(string systemPrompt, string userPrompt);
 
+    /// <summary>True when a V1 brain is configured and native tool calling is available.</summary>
+    bool SpeaksNatively => false;
+
+    /// <summary>
+    /// The V1 path: a conversation in, a structured choice out. Only called when
+    /// <see cref="SpeaksNatively"/> — the text protocol remains the Core contract.
+    /// </summary>
+    ValueTask<Models.Brokers.Generators.V1.GenerationResult> GenerateAsync(
+        Models.Orchestrations.Agents.AgentContext context,
+        IReadOnlyList<Models.Brokers.Generators.V1.ToolDefinition> tools) =>
+        throw new NotSupportedException("This brain does not speak natively.");
+
     IAsyncEnumerable<string> GenerateStreamAsync(
         string systemPrompt,
         string userPrompt,

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Native.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Native.cs
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Orchestrations.Agents;
+
+namespace Standard.Agents.Services.Orchestrations.Decision;
+
+// Native tool calling (SPEC.md §6, "via a provider-native tool-call mechanism"). When a V1 brain
+// is configured, the model's choice arrives as structured data rather than as the first line of
+// its text — and the loop below is otherwise identical, because interpretation is the only part
+// that differs. Everything after it — the Judge, the revision loop, Direction's perimeter — sees
+// the same AgentContext it always did.
+//
+// Which is the point of putting the seam here: adopting native calls changes how a choice is
+// read, not what the agent is.
+public partial class DecisionOrchestrationService
+{
+    private async ValueTask<AgentContext> ThinkNativelyAsync(AgentContext context)
+    {
+        GenerationResult result =
+            await this.brainService.GenerateAsync(context, this.toolDefinitions);
+
+        await this.loggingBroker.LogProcessAsync(
+            "Decision",
+            result.HasToolCalls
+                ? $"Brain → {result.ToolCalls.Count} native tool call(s)"
+                : "Brain → answered",
+            detail: true);
+
+        AgentContext measured = context with
+        {
+            PromptTokens = result.PromptTokens,
+            CompletionTokens = result.CompletionTokens
+        };
+
+        if (result.HasToolCalls is false)
+        {
+            return measured with
+            {
+                Intent = RespondIntent,
+                DirectionType = ReturnResponseDirection,
+                Payload = result.Content,
+                RawReply = result.Content
+            };
+        }
+
+        // One call per turn, deliberately. A model may ask for several; Direction performs one
+        // act at a time because authorization, approval and run-once are judgments about a
+        // single act (SPEC.md §4.9). The rest are re-proposed on the next turn if still wanted,
+        // and run-once means a repeat of one already performed costs nothing.
+        ModelToolCall call = result.ToolCalls[0];
+
+        await this.loggingBroker.LogProcessAsync(
+            "Decision", $"Interpreted → {call.Name} (native)");
+
+        return measured with
+        {
+            Intent = call.Name,
+            DirectionType = call.Name,
+            Payload = call.ArgumentsJson,
+            RawReply = result.Content
+        };
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Brokers.Generators.V1;
 using Standard.Agents.Models.Brokers.Sessions;
 using Standard.Agents.Models.Foundations.Gates;
 using Standard.Agents.Models.Foundations.Judges;
@@ -41,17 +42,20 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
     private readonly IBrainService brainService;
     private readonly IJudgeService judgeService;
     private readonly ILoggingBroker loggingBroker;
+    private readonly IReadOnlyList<ToolDefinition> toolDefinitions;
 
     public DecisionOrchestrationService(
         IGateService gateService,
         IBrainService brainService,
         IJudgeService judgeService,
-        ILoggingBroker loggingBroker)
+        ILoggingBroker loggingBroker,
+        IReadOnlyList<ToolDefinition>? toolDefinitions = null)
     {
         this.gateService = gateService;
         this.brainService = brainService;
         this.judgeService = judgeService;
         this.loggingBroker = loggingBroker;
+        this.toolDefinitions = toolDefinitions ?? [];
     }
 
     public ValueTask<AgentContext> ThinkAsync(AgentContext context) =>
@@ -92,12 +96,13 @@ public partial class DecisionOrchestrationService : IDecisionOrchestrationServic
 
         context = resolvedContext;
 
-        string reply =
-            (await this.brainService.GenerateAsync(
-                systemPrompt: context.SystemPrompt,
-                userPrompt: BuildUserMessage(context))).Trim();
-
-        AgentContext decided = Interpret(context, reply);
+        AgentContext decided = this.brainService.SpeaksNatively
+            ? await ThinkNativelyAsync(context)
+            : Interpret(
+                context,
+                (await this.brainService.GenerateAsync(
+                    systemPrompt: context.SystemPrompt,
+                    userPrompt: BuildUserMessage(context))).Trim());
 
         bool isFinalAnswer =
             decided.DirectionType.Equals(

--- a/Standard.Agents/StandardAgent.Validations.cs
+++ b/Standard.Agents/StandardAgent.Validations.cs
@@ -11,12 +11,20 @@ public sealed partial class StandardAgent
 {
     private void ValidateComposition()
     {
-        if (this.generatorBroker is null && this.brainSettings is null)
+        // A native brain is a brain. Either seam satisfies this — the check exists to catch an
+        // agent with no way to think at all, not to prefer one contract over the other.
+        bool hasBrain =
+            this.generatorBroker is not null
+                || this.brainSettings is not null
+                || this.generatorBrokerV1 is not null;
+
+        if (hasBrain is false)
         {
             throw new InvalidAgentCompositionException(
                 message:
-                    "Agent has no brain. Call Brain(apiUrl, apiKey, model) "
-                        + "or UseGenerator(broker) before processing a prompt.");
+                    "Agent has no brain. Call Brain(apiUrl, apiKey, model), "
+                        + "UseGenerator(broker) or NativeBrain(apiUrl, apiKey, model) "
+                        + "before processing a prompt.");
         }
     }
 }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -24,6 +24,7 @@ using Standard.Agents.Brokers.Times;
 using Standard.Agents.Brokers.Tools;
 using Standard.Agents.Brokers.Verifiers;
 using Standard.Agents.Models.Brokers.Audits;
+using Standard.Agents.Models.Brokers.Generators.V1;
 using Standard.Agents.Models.Brokers.Sessions;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Coordinations.Agents;
@@ -94,6 +95,7 @@ public sealed partial class StandardAgent : IAgent
     private bool screenToolOutput;
     private AgentBudget? budget;
     private IResilienceBroker? resilienceBroker;
+    private IGeneratorBrokerV1? generatorBrokerV1;
     private ISessionBroker? sessionBroker;
     private int maxHistoryTurns = 20;
     private Func<string?>? principalResolver;
@@ -572,6 +574,48 @@ public sealed partial class StandardAgent : IAgent
         Set(() => this.generatorBroker = broker);
 
     /// <summary>
+    /// Uses <b>native tool calling</b>: tools are declared to the model as data and its choice
+    /// comes back as structured <c>tool_calls</c>, rather than as a <c>ACTION:</c> line the model
+    /// has to imitate. Frontier models are trained on this; the text protocol remains the default
+    /// because it works against any endpoint and small local models often do better with it.
+    /// </summary>
+    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint.</param>
+    /// <param name="apiKey">API key for the endpoint (empty string if none is needed).</param>
+    /// <param name="model">Model name to request.</param>
+    /// <param name="temperature">Sampling temperature. Defaults to 0.7.</param>
+    /// <param name="maxTokens">Maximum tokens per turn. Defaults to 1024.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent NativeBrain(
+        string apiUrl,
+        string apiKey,
+        string model,
+        double temperature = 0.7,
+        int maxTokens = 1024) =>
+        Set(() => this.generatorBrokerV1 =
+            new GeneratorBrokerV1(apiUrl, apiKey, model, temperature, maxTokens));
+
+    /// <summary>
+    /// Swaps in a custom native-brain broker — the <b>External</b> seam for a provider package
+    /// that speaks tool calls.
+    /// </summary>
+    /// <param name="broker">The V1 generator broker to use.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent UseNativeBrain(IGeneratorBrokerV1 broker) =>
+        Set(() => this.generatorBrokerV1 = broker);
+
+    /// <summary>
+    /// Supplies your own native brain as a delegate — the <b>Custom</b> mode of the V1 seam.
+    /// </summary>
+    /// <param name="generate">A <c>(messages, tools) =&gt; result</c> delegate.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent OnNativeBrain(
+        Func<
+            IReadOnlyList<ConversationMessage>,
+            IReadOnlyList<ToolDefinition>,
+            ValueTask<GenerationResult>> generate) =>
+        Set(() => this.generatorBrokerV1 = new FunctionGeneratorBrokerV1(generate));
+
+    /// <summary>
     /// Swaps in a custom memory broker, replacing the default file-backed one set up by
     /// <see cref="Memory"/>.
     /// </summary>
@@ -870,10 +914,18 @@ public sealed partial class StandardAgent : IAgent
                         : new FileAuditBroker(this.auditPath)),
                 this.principalResolver);
 
+        // With only a native brain configured there is no V0 generator to build, and none is
+        // needed: SpeaksNatively routes every call to the V1 seam. The placeholder exists so the
+        // Brain foundation keeps one shape rather than growing a nullable dependency.
         IGeneratorBroker generator =
-            this.generatorBroker ?? new GeneratorBroker(
-                brain!.ApiUrl, brain.ApiKey, brain.Model,
-                brain.Temperature, brain.MaxTokens, brain.TimeoutSeconds);
+            this.generatorBroker
+                ?? (brain is null
+                    ? new FunctionGeneratorBroker((systemPrompt, userPrompt) =>
+                        throw new InvalidOperationException(
+                            "This agent has a native brain; the text protocol is not in use."))
+                    : new GeneratorBroker(
+                        brain.ApiUrl, brain.ApiKey, brain.Model,
+                        brain.Temperature, brain.MaxTokens, brain.TimeoutSeconds));
 
         IMemoryService memoryService = this.memoryBroker is null
             ? new MemoryService(file, Path.GetFullPath(this.memoryPath), logging)
@@ -963,9 +1015,11 @@ public sealed partial class StandardAgent : IAgent
 
         DecisionOrchestrationService decision = new(
             gate,
-            new BrainService(generator, logging, redaction, this.resilienceBroker),
+            new BrainService(
+                generator, logging, redaction, this.resilienceBroker, this.generatorBrokerV1),
             new JudgeService(verifier, logging, redaction),
-            logging);
+            logging,
+            RenderToolDefinitions(allTools));
 
         DirectionOrchestrationService direction = new(
             new InternalToolService(toolBroker, logging),
@@ -991,6 +1045,14 @@ public sealed partial class StandardAgent : IAgent
     // carry a description are listed — a description is the opt-in (SPEC 6.1); a tool with
     // none is callable but not advertised. Derived from the registered tools, so it never
     // drifts from what is actually there.
+    // The same opt-in rule the text catalog uses (SPEC.md §6.1): a description is what offers a
+    // tool to the model. A tool without one stays callable but unadvertised, so declaring tools
+    // as data does not quietly widen what the Brain may reach for.
+    private static IReadOnlyList<ToolDefinition> RenderToolDefinitions(IEnumerable<ITool> tools) =>
+        [.. tools
+            .Where(tool => string.IsNullOrWhiteSpace(tool.Description) is false)
+            .Select(tool => new ToolDefinition(tool.Name, tool.Description, tool.Parameters))];
+
     private static string RenderToolCatalog(IEnumerable<ITool> tools)
     {
         IEnumerable<string> describedTools = tools


### PR DESCRIPTION
Second slice of the Enterprise Model. Closes the "brittle model contract" finding from the original review.

## Why

The text protocol asks a model to **imitate a format** — `ACTION: calculator: 2+2`. The same model emitting a `tool_call` is doing the thing it was **tuned for**. The text protocol stays the Core contract because it works against any endpoint and small local models often do better with it; V1 exists for the providers that do better than imitation.

## A sibling, not a replacement

`IGeneratorBroker` is untouched. The five provider packages compile against it exactly as before — **none of them has to move on our schedule** (plan §1.3).

## Where the seam sits

Adopting native calls changes how a choice is **read**, not what the agent **is**. Everything after interpretation — the Judge, the revision loop, Direction's perimeter, run-once — sees the same `AgentContext` it always did.

**One call performed per turn, deliberately.** Authorization, approval and run-once are judgments about *a single act*. The rest are re-proposed next turn if still wanted, and run-once makes a repeat of an already-performed act cost nothing.

## Carried over, not lost

- **Usage reported, not estimated** — a budget over a native brain measures real consumption.
- **Redaction covers V1 exactly as V0** — every message out redacted, the reply *including tool-call arguments* rehydrated.
- **A description is still the opt-in** — a tool without one stays callable but is never offered.

## Verified

Three acceptance tests: round-trip through the full loop, only described tools advertised, reported usage drives the budget.

One failed first **on my own wrong assertion** — `remember` is a described tool and *should* be advertised. I corrected the test, not the code.

344 tests · 25/25 vectors · 0 warnings · Enterprise still certified.