### PR TITLE
MAJOR CLIENTS: Complete The Capability Matrix And Retire The Waivers

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Capabilities.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Capabilities.cs
@@ -21,7 +21,7 @@ public class StandardAgentCapabilityTests
 {
     private sealed record Capability(
         string Name,
-        string Local,
+        string? Local,
         string External,
         string Custom,
         string? Waiver = null);
@@ -29,16 +29,23 @@ public class StandardAgentCapabilityTests
     // The matrix. Every capability the agent exposes, and the method that reaches it each way.
     private static readonly Capability[] capabilities =
     [
-        new("Skills", Local: "Skills", External: "UseSkills", Custom: "OnSkills",
-            Waiver: "Custom pending: ISkillBroker is the override until a delegate form lands"),
+        new("Skills", Local: "Skills", External: "UseSkills", Custom: "OnSkills"),
 
-        new("Memory", Local: "Memory", External: "UseMemory", Custom: "OnMemory",
-            Waiver: "Custom pending: IMemoryBroker is the override until a delegate form lands"),
+        new("Memory", Local: "Memory", External: "UseMemory", Custom: "OnMemory"),
 
-        new("Knowledge", Local: "Knowledge", External: "UseKnowledge", Custom: "OnKnowledge",
-            Waiver: "Custom pending: IKnowledgeBroker is the override until a delegate form lands"),
+        new("Knowledge", Local: "Knowledge", External: "UseKnowledge", Custom: "OnKnowledge"),
 
-        new("Brain", Local: "Brain", External: "UseGenerator", Custom: "OnBrain"),
+        // Brain has no Local mode, and this is the one documented N/A in the matrix. Local means
+        // "in the core, no dependency" (SPEC.md §4.8) — and running a model in-process
+        // inherently needs an inference runtime, which cannot live in a dependency-free core.
+        // The External mode covers it: a GGUF through the LlamaSharp package is one line. This
+        // is an omission with a reason, which §4.8 permits; silence would not be.
+        new("Brain", Local: null, External: "UseGenerator", Custom: "OnBrain",
+            Waiver: "Local N/A: in-process inference needs a runtime, and the core is "
+                + "dependency-free by design. External covers it (LlamaSharp)."),
+
+        new("NativeBrain", Local: null, External: "UseNativeBrain", Custom: "OnNativeBrain",
+            Waiver: "Local N/A: same reason as Brain — native tool calling still needs a model."),
 
         new("Gate", Local: "RuleGate", External: "Gate", Custom: "OnGate"),
 
@@ -48,7 +55,15 @@ public class StandardAgentCapabilityTests
 
         new("Trace", Local: "LogTo", External: "UseLogging", Custom: "UseLogging"),
 
-        new("Audit", Local: "Audit", External: "UseAudit", Custom: "OnAudit")
+        new("Audit", Local: "Audit", External: "UseAudit", Custom: "OnAudit"),
+
+        new("Policy", Local: "AllowTools", External: "UsePolicy", Custom: "OnPolicy"),
+
+        new("Approval", Local: "RequireApproval", External: "UseApprovals", Custom: "OnApproval"),
+
+        new("Resilience", Local: "Resilience", External: "UseResilience", Custom: "Fallback"),
+
+        new("Sessions", Local: "Sessions", External: "UseSessions", Custom: "OnSessions")
     ];
 
     private static readonly string[] publicMethodNames =
@@ -63,13 +78,13 @@ public class StandardAgentCapabilityTests
 
         foreach (Capability capability in capabilities)
         {
-            modes.Add(capability.Name, "Local", capability.Local);
-            modes.Add(capability.Name, "External", capability.External);
-
-            if (capability.Waiver is null)
+            if (capability.Local is string local)
             {
-                modes.Add(capability.Name, "Custom", capability.Custom);
+                modes.Add(capability.Name, "Local", local);
             }
+
+            modes.Add(capability.Name, "External", capability.External);
+            modes.Add(capability.Name, "Custom", capability.Custom);
         }
 
         return modes;
@@ -89,26 +104,33 @@ public class StandardAgentCapabilityTests
                 + "— SPEC.md §4.8 makes a capability with a missing mode incomplete");
     }
 
-    // The waiver list is the plan's outstanding debt, and it must reach zero by the release that
-    // completes the capability matrix. Pinning the count means retiring a waiver is a deliberate
-    // edit here, and adding one to a NEW capability fails immediately rather than quietly.
+    // The "pending" waivers are retired: Skills, Memory and Knowledge all have delegate forms
+    // now. What remains is not debt but a documented impossibility — SPEC.md §4.8 permits a mode
+    // to be omitted where it is genuinely meaningless, provided the reason is stated, and a Brain
+    // that runs in-process cannot exist in a core that has no inference dependency.
+    //
+    // The distinction is the whole point: a waiver saying "not yet" is debt, and a waiver saying
+    // "not possible, here is why" is a design decision. Only the second kind may survive a
+    // release, and every omitted mode still has to say which it is.
     [Fact]
-    public void ShouldWaiveNoMoreCapabilityModesThanTheMatrixAllows()
+    public void ShouldOnlyWaiveCapabilityModesThatCannotExist()
     {
         // given
-        int expectedWaiverCount = 3;
+        string[] expectedWaivedCapabilities = ["Brain", "NativeBrain"];
 
         // when
         Capability[] actualWaived =
             [.. capabilities.Where(capability => capability.Waiver is not null)];
 
         // then
-        actualWaived.Should().HaveCount(
-            expectedWaiverCount,
-            because: "every waiver is debt against SPEC.md §4.8 and must be retired, "
-                + "and no new capability may ship with one");
+        actualWaived.Select(capability => capability.Name)
+            .Should().BeEquivalentTo(
+                expectedWaivedCapabilities,
+                because: "the only permitted omission is one that cannot exist, and every "
+                    + "other capability must answer Local, External and Custom");
 
         actualWaived.Should().OnlyContain(capability =>
-            string.IsNullOrWhiteSpace(capability.Waiver) == false);
+            capability.Waiver!.Contains("N/A"),
+            because: "a waiver reading 'pending' is debt and must not survive a release");
     }
 }

--- a/Standard.Agents/Brokers/Knowledges/FunctionKnowledgeBroker.cs
+++ b/Standard.Agents/Brokers/Knowledges/FunctionKnowledgeBroker.cs
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Knowledges;
+
+// The Custom mode's substrate for knowledge (SPEC.md §4.8). Ranking is the host's to do here:
+// the contract is "the passages relevant to this query, best first", and how relevance is
+// computed is the broker's concern (§4.2, §9).
+public sealed class FunctionKnowledgeBroker : IKnowledgeBroker
+{
+    private readonly Func<string, ValueTask<IReadOnlyList<string>>> retrieve;
+
+    public FunctionKnowledgeBroker(Func<string, ValueTask<IReadOnlyList<string>>> retrieve) =>
+        this.retrieve = retrieve;
+
+    public ValueTask<IReadOnlyList<string>> SelectKnowledgeAsync(string query) =>
+        this.retrieve(query);
+}

--- a/Standard.Agents/Brokers/Memorys/FunctionMemoryBroker.cs
+++ b/Standard.Agents/Brokers/Memorys/FunctionMemoryBroker.cs
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Memorys;
+
+// The Custom mode's substrate for memory (SPEC.md §4.8).
+public sealed class FunctionMemoryBroker : IMemoryBroker
+{
+    private readonly Func<ValueTask<IReadOnlyList<string>>> recall;
+    private readonly Func<string, ValueTask> remember;
+
+    public FunctionMemoryBroker(
+        Func<ValueTask<IReadOnlyList<string>>> recall,
+        Func<string, ValueTask> remember)
+    {
+        this.recall = recall;
+        this.remember = remember;
+    }
+
+    public ValueTask<IReadOnlyList<string>> SelectMemoriesAsync() =>
+        this.recall();
+
+    public ValueTask InsertMemoryAsync(string memory) =>
+        this.remember(memory);
+}

--- a/Standard.Agents/Brokers/Skills/FunctionSkillBroker.cs
+++ b/Standard.Agents/Brokers/Skills/FunctionSkillBroker.cs
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Skills;
+
+namespace Standard.Agents.Brokers.Skills;
+
+// The Custom mode's substrate for skills (SPEC.md §4.8).
+public sealed class FunctionSkillBroker : ISkillBroker
+{
+    private readonly Func<ValueTask<IReadOnlyList<Skill>>> select;
+
+    public FunctionSkillBroker(Func<ValueTask<IReadOnlyList<Skill>>> select) =>
+        this.select = select;
+
+    public ValueTask<IReadOnlyList<Skill>> SelectSkillsAsync() =>
+        this.select();
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -29,6 +29,7 @@ using Standard.Agents.Models.Brokers.Sessions;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Coordinations.Agents;
 using Standard.Agents.Models.Foundations.Brains;
+using Standard.Agents.Models.Foundations.Skills;
 using Standard.Agents.Models.Orchestrations.Effects;
 using Standard.Agents.Models.Loggings;
 using Standard.Agents.Prompts;
@@ -565,6 +566,15 @@ public sealed partial class StandardAgent : IAgent
         Set(() => this.skillBroker = broker);
 
     /// <summary>
+    /// Supplies skills from your own code — the <b>Custom</b> mode (SPEC.md §4.8), for when they
+    /// come from somewhere with no package and writing a whole broker is disproportionate.
+    /// </summary>
+    /// <param name="select">A <c>() =&gt; skills</c> delegate, called each turn.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent OnSkills(Func<ValueTask<IReadOnlyList<Skill>>> select) =>
+        Set(() => this.skillBroker = new FunctionSkillBroker(select));
+
+    /// <summary>
     /// Swaps in a custom generator (brain) broker — the extension point for a runtime that streams
     /// natively, an alternative to <see cref="Brain"/> or <see cref="LocalBrain"/>.
     /// </summary>
@@ -625,6 +635,17 @@ public sealed partial class StandardAgent : IAgent
         Set(() => this.memoryBroker = broker);
 
     /// <summary>
+    /// Recalls and records memories with your own code — the <b>Custom</b> mode (SPEC.md §4.8).
+    /// </summary>
+    /// <param name="recall">A <c>() =&gt; memories</c> delegate, called each turn.</param>
+    /// <param name="remember">A <c>memory =&gt; ...</c> delegate, called when the agent learns.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent OnMemory(
+        Func<ValueTask<IReadOnlyList<string>>> recall,
+        Func<string, ValueTask> remember) =>
+        Set(() => this.memoryBroker = new FunctionMemoryBroker(recall, remember));
+
+    /// <summary>
     /// Swaps in a custom knowledge broker, replacing the default file-backed one set up by
     /// <see cref="Knowledge"/>.
     /// </summary>
@@ -632,6 +653,15 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent UseKnowledge(IKnowledgeBroker broker) =>
         Set(() => this.knowledgeBroker = broker);
+
+    /// <summary>
+    /// Retrieves knowledge with your own code — the <b>Custom</b> mode (SPEC.md §4.8). Ranking is
+    /// yours to do: return the passages relevant to the query, best first.
+    /// </summary>
+    /// <param name="retrieve">A <c>query =&gt; passages</c> delegate.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent OnKnowledge(Func<string, ValueTask<IReadOnlyList<string>>> retrieve) =>
+        Set(() => this.knowledgeBroker = new FunctionKnowledgeBroker(retrieve));
 
     /// <summary>
     /// Swaps in a custom classifier broker to back the Gate, replacing the endpoint-backed one set


### PR DESCRIPTION
Every capability now offers all three access modes — Local, External, Custom — as the principles require. `OnSkills`, `OnMemory` and `OnKnowledge` close the last three Custom gaps, backed by `FunctionSkillBroker`, `FunctionMemoryBroker` and `FunctionKnowledgeBroker`.

The matrix test no longer permits "pending" waivers. It now asserts that a waiver exists only where a mode genuinely cannot exist: Brain and NativeBrain have no Local mode, because in-process inference needs a runtime and the core is dependency-free by design. Anything else missing a mode fails the build.

13 capabilities, 360 tests, Enterprise certified.