### PR TITLE
MEDIUM ORCHESTRATIONS: Compensate A Failed Run

### DIFF
--- a/Standard.Agents.Conformance/Models/Expectation.cs
+++ b/Standard.Agents.Conformance/Models/Expectation.cs
@@ -56,4 +56,9 @@ public sealed record Expectation(
     //                              is certified: the passage that answers the question got there.
     //   GateScreenedPromptTimes  — exactly how many times the Gate was asked about the prompt.
     string? BrainSees = null,
-    int? GateScreenedPromptTimes = null);
+    int? GateScreenedPromptTimes = null,
+
+    //   CompensationOrder — the exact order the tools were reversed in, which is how the reverse
+    //                       unwind is certified: a later effect may depend on an earlier one, so
+    //                       undoing them in the order they ran would leave state inconsistent.
+    List<string>? CompensationOrder = null);

--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -59,4 +59,10 @@ public sealed record Vector(
     int KnowledgeMaxResults = 3,
 
     // Sessions (SPEC.md 4.11). When set, every prompt in the vector runs in this conversation.
-    string? SessionId = null);
+    string? SessionId = null,
+
+    // Compensation (SPEC.md §4.9). CompensateOnFailure turns the unwind on; CompensatingTools
+    // names the tools that know how to reverse themselves. A tool left out keeps the interface
+    // default and must be reported as an effect that stands.
+    bool CompensateOnFailure = false,
+    List<string>? CompensatingTools = null);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -165,10 +165,17 @@ return 1;
 
 async Task<VectorRun> RunVectorAsync(Vector vector)
 {
+    // The order the run was unwound in, written by the stubs as they reverse themselves.
+    List<string> compensationOrder = [];
+
     Dictionary<string, StubTool> stubTools =
         (vector.Tools ?? []).ToDictionary(
             pair => pair.Key,
-            pair => new StubTool(name: pair.Key, output: pair.Value));
+            pair => new StubTool(
+                name: pair.Key,
+                output: pair.Value,
+                reversible: vector.CompensatingTools?.Contains(pair.Key) is true,
+                compensationOrder: compensationOrder));
 
     // The guardians run through the real composition (OnGate / OnJudge), so each is handed
     // the rubric the framework composed — constitution, then policy (or the consumption skill),
@@ -264,6 +271,11 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     if (vector.ScreenToolOutput)
     {
         agent.ScreenToolOutput();
+    }
+
+    if (vector.CompensateOnFailure)
+    {
+        agent.CompensateOnFailure();
     }
 
     if (vector.Retries > 0)
@@ -371,7 +383,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         }
     }
 
-    return new VectorRun(result, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, promptScreenings, auditRecords);
+    return new VectorRun(result, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, promptScreenings, auditRecords, compensationOrder);
 }
 
 // The decision log's guarantees, certified from the records themselves: one run per prompt,
@@ -521,6 +533,17 @@ static bool GuardianInputConformant(
         && actualResult.Contains(vector.GateVerdict, StringComparison.Ordinal))
     {
         failure = "the guardian's own text became the agent's answer";
+
+        return false;
+    }
+
+    // The unwind runs in reverse, and only over what the run actually performed (SPEC.md §4.9).
+    if (vector.Expect.CompensationOrder is List<string> expectedOrder
+        && run.CompensationOrder.SequenceEqual(expectedOrder) is false)
+    {
+        failure =
+            $"compensation ran [{string.Join(", ", run.CompensationOrder)}], "
+                + $"expected [{string.Join(", ", expectedOrder)}]";
 
         return false;
     }
@@ -693,4 +716,5 @@ internal sealed record VectorRun(
     List<string> ModelInputs,
     List<string> BrainInputs,
     int PromptScreenings,
-    List<AuditRecord> AuditRecords);
+    List<AuditRecord> AuditRecords,
+    List<string> CompensationOrder);

--- a/Standard.Agents.Conformance/Tools/StubTool.cs
+++ b/Standard.Agents.Conformance/Tools/StubTool.cs
@@ -11,6 +11,8 @@ public sealed class StubTool : ITool
 {
     private readonly string output;
     private readonly List<string> receivedInputs = [];
+    private readonly bool reversible;
+    private readonly List<string>? compensationOrder;
 
     public string Name { get; }
 
@@ -20,10 +22,16 @@ public sealed class StubTool : ITool
     // still passes (conformance issue #78).
     public IReadOnlyList<string> ReceivedInputs => this.receivedInputs;
 
-    public StubTool(string name, string output)
+    public StubTool(
+        string name,
+        string output,
+        bool reversible = false,
+        List<string>? compensationOrder = null)
     {
         this.Name = name;
         this.output = output;
+        this.reversible = reversible;
+        this.compensationOrder = compensationOrder;
     }
 
     public async ValueTask<string> ExecuteAsync(string input)
@@ -31,5 +39,21 @@ public sealed class StubTool : ITool
         this.receivedInputs.Add(input);
 
         return this.output;
+    }
+
+    // A stub that was declared reversible reverses itself and writes its name to the shared
+    // order, so a vector can certify that the unwind ran in reverse. A stub that was not keeps
+    // the interface default, returning null — the case a vector needs to prove is reported as
+    // an effect that stands rather than silently counted as undone (SPEC.md §4.9).
+    public ValueTask<string?> CompensateAsync(string input, string outcome)
+    {
+        if (this.reversible is false)
+        {
+            return ValueTask.FromResult<string?>(null);
+        }
+
+        this.compensationOrder?.Add(Name);
+
+        return ValueTask.FromResult<string?>($"reversed {outcome}");
     }
 }

--- a/Standard.Agents.Tests.Unit/Acceptance/CompensationTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/CompensationTests.cs
@@ -1,0 +1,267 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Models.Orchestrations.Effects;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// Compensation end to end (SPEC.md §4.9). Run-once makes an effect safe to PROPOSE twice; these
+// pin what happens to the effects that cannot be made idempotent at all — the ones a bank asks
+// about when the run dies halfway through a two-step payment.
+public class CompensationTests
+{
+    // A tool that knows how to undo itself, and records the order it was called in.
+    private sealed class ReversibleTool : ITool
+    {
+        private readonly List<string> ledger;
+
+        public ReversibleTool(string name, List<string> ledger)
+        {
+            Name = name;
+            this.ledger = ledger;
+        }
+
+        public string Name { get; }
+
+        public string Description => $"Performs {Name}.";
+
+        public string Parameters => "{}";
+
+        public ValueTask<string> ExecuteAsync(string input)
+        {
+            this.ledger.Add($"do:{Name}");
+
+            return ValueTask.FromResult($"{Name}-receipt");
+        }
+
+        public ValueTask<string?> CompensateAsync(string input, string outcome)
+        {
+            this.ledger.Add($"undo:{Name}");
+
+            return ValueTask.FromResult<string?>($"reversed {outcome}");
+        }
+    }
+
+    // A tool that cannot be undone — it leaves the default, which says so.
+    private sealed class IrreversibleTool : ITool
+    {
+        private readonly List<string> ledger;
+
+        public IrreversibleTool(string name, List<string> ledger)
+        {
+            Name = name;
+            this.ledger = ledger;
+        }
+
+        public string Name { get; }
+
+        public string Description => $"Performs {Name}.";
+
+        public string Parameters => "{}";
+
+        public ValueTask<string> ExecuteAsync(string input)
+        {
+            this.ledger.Add($"do:{Name}");
+
+            return ValueTask.FromResult($"{Name}-sent");
+        }
+    }
+
+    private static StandardAgent AgentThatRuns(IEnumerable<ITool> tools, params string[] replies)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        var scriptedReplies = new Queue<string>(replies);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .Tools(tools)
+            .OnBrain(async (systemPrompt, userPrompt) =>
+                scriptedReplies.Count > 0
+                    ? scriptedReplies.Dequeue()
+                    : "ACTION: book_flight: LHR-JFK");
+    }
+
+    [Fact]
+    public async Task ShouldUnwindPerformedEffectsInReverseOrderWhenTheRunFailsAsync()
+    {
+        // given — the run books, then charges, then runs out of turns without ever answering
+        List<string> ledger = [];
+
+        StandardAgent agent = AgentThatRuns(
+            [new ReversibleTool("book_flight", ledger),
+                new ReversibleTool("charge_card", ledger)],
+            "ACTION: book_flight: LHR-JFK",
+            "ACTION: charge_card: 480.00")
+            .MaxTurns(2)
+            .CompensateOnFailure();
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "book me a flight");
+
+        // then — the charge is reversed before the booking it paid for
+        ledger.Should().Equal("do:book_flight", "do:charge_card", "undo:charge_card",
+            "undo:book_flight");
+
+        actualResult.Should().Contain("Unwound 2 of 2 effects.");
+    }
+
+    [Fact]
+    public async Task ShouldReportEffectsThatCouldNotBeUndoneAsync()
+    {
+        // given — one tool knows how to reverse itself and one does not
+        List<string> ledger = [];
+
+        StandardAgent agent = AgentThatRuns(
+            [new ReversibleTool("book_flight", ledger),
+                new IrreversibleTool("send_email", ledger)],
+            "ACTION: book_flight: LHR-JFK",
+            "ACTION: send_email: your ticket is confirmed")
+            .MaxTurns(2)
+            .CompensateOnFailure();
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "book me a flight");
+
+        // then — silence is not reversal; the caller is told what stands
+        actualResult.Should().Contain("Unwound 1 of 2 effects.");
+        actualResult.Should().Contain("'send_email' could not be undone; the effect stands.");
+        ledger.Should().NotContain("undo:send_email");
+    }
+
+    [Fact]
+    public async Task ShouldNotCompensateEffectsThatWereNeverPerformedAsync()
+    {
+        // given — policy denies the charge, so only the booking was ever performed
+        List<string> ledger = [];
+
+        StandardAgent agent = AgentThatRuns(
+            [new ReversibleTool("book_flight", ledger),
+                new ReversibleTool("charge_card", ledger)],
+            "ACTION: book_flight: LHR-JFK",
+            "ACTION: charge_card: 480.00")
+            .MaxTurns(2)
+            .CompensateOnFailure()
+            .OnPolicy(effect => ValueTask.FromResult(
+                effect.ToolName is "charge_card"
+                    ? AuthorizationDecision.Deny("card charges are not permitted")
+                    : AuthorizationDecision.Allow()));
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "book me a flight");
+
+        // then — a denied effect was never performed, so there is nothing of it to undo
+        ledger.Should().Equal("do:book_flight", "undo:book_flight");
+        actualResult.Should().Contain("Unwound 1 of 1 effects.");
+    }
+
+    [Fact]
+    public async Task ShouldNotUnwindARunThatDeliveredAnAnswerAsync()
+    {
+        // given — the run performs an effect and then answers, which is a completed run
+        List<string> ledger = [];
+
+        StandardAgent agent = AgentThatRuns(
+            [new ReversibleTool("book_flight", ledger)],
+            "ACTION: book_flight: LHR-JFK",
+            "FINAL: booked")
+            .CompensateOnFailure();
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "book me a flight");
+
+        // then
+        actualResult.Should().Be("booked");
+        ledger.Should().Equal("do:book_flight");
+    }
+
+    [Fact]
+    public async Task ShouldLeaveEffectsStandingWhenCompensationIsNotConfiguredAsync()
+    {
+        // given — compensation is off, which is the default
+        List<string> ledger = [];
+
+        StandardAgent agent = AgentThatRuns(
+            [new ReversibleTool("book_flight", ledger)],
+            "ACTION: book_flight: LHR-JFK")
+            .MaxTurns(1);
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "book me a flight");
+
+        // then — behavior is exactly as if the section did not exist
+        ledger.Should().Equal("do:book_flight");
+    }
+
+    [Fact]
+    public async Task ShouldUnwindTheRemainingEffectsWhenOneCompensationFailsAsync()
+    {
+        // given — undoing the charge throws; the booking behind it must still be unwound
+        List<string> ledger = [];
+
+        StandardAgent agent = AgentThatRuns(
+            [new ReversibleTool("book_flight", ledger), new ThrowingTool("charge_card", ledger)],
+            "ACTION: book_flight: LHR-JFK",
+            "ACTION: charge_card: 480.00")
+            .MaxTurns(2)
+            .CompensateOnFailure();
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "book me a flight");
+
+        // then — abandoning the rest would leave more standing, not less
+        ledger.Should().Contain("undo:book_flight");
+        actualResult.Should().Contain("Unwound 1 of 2 effects.");
+        actualResult.Should().Contain("'charge_card' could not be undone; the effect stands.");
+    }
+
+    // A tool whose undo fails — the reversal itself is an act against the world, and acts fail.
+    private sealed class ThrowingTool : ITool
+    {
+        private readonly List<string> ledger;
+
+        public ThrowingTool(string name, List<string> ledger)
+        {
+            Name = name;
+            this.ledger = ledger;
+        }
+
+        public string Name { get; }
+
+        public string Description => $"Performs {Name}.";
+
+        public string Parameters => "{}";
+
+        public ValueTask<string> ExecuteAsync(string input)
+        {
+            this.ledger.Add($"do:{Name}");
+
+            return ValueTask.FromResult($"{Name}-receipt");
+        }
+
+        public ValueTask<string?> CompensateAsync(string input, string outcome) =>
+            throw new InvalidOperationException("the reversal window has closed");
+    }
+}

--- a/Standard.Agents/Brokers/Tools/IToolBroker.cs
+++ b/Standard.Agents/Brokers/Tools/IToolBroker.cs
@@ -10,4 +10,6 @@ public interface IToolBroker
     ValueTask<bool> HasAsync(string name);
 
     ValueTask<string> RunAsync(string name, string input);
+
+    ValueTask<string> CompensateAsync(string name, string input, string outcome);
 }

--- a/Standard.Agents/Brokers/Tools/ToolBroker.cs
+++ b/Standard.Agents/Brokers/Tools/ToolBroker.cs
@@ -21,4 +21,9 @@ public sealed class ToolBroker : IToolBroker
 
     public async ValueTask<string> RunAsync(string name, string input) =>
         await this.tools[name].ExecuteAsync(input);
+
+    // A tool that declares no way back returns null; the broker hands the natures an empty string,
+    // so nothing above it has to reason about null (SPEC.md §4.9).
+    public async ValueTask<string> CompensateAsync(string name, string input, string outcome) =>
+        await this.tools[name].CompensateAsync(input, outcome) ?? string.Empty;
 }

--- a/Standard.Agents/Models/Loggings/AgentRun.cs
+++ b/Standard.Agents/Models/Loggings/AgentRun.cs
@@ -33,6 +33,7 @@ public sealed class AgentRun
     private static readonly AsyncLocal<AgentRun?> current = new();
 
     private readonly Dictionary<string, string> verdicts = [];
+    private readonly List<PerformedEffect> performedEffects = [];
 
     private int sequence;
     private int processIndex;
@@ -94,6 +95,29 @@ public sealed class AgentRun
         lock (this.verdicts)
         {
             this.verdicts[prompt] = verdict;
+        }
+    }
+
+    /// <summary>
+    /// What this run actually performed, in order. Kept so the run can be unwound: compensation
+    /// needs to know what happened, and only the run knows (SPEC.md §4.9).
+    /// </summary>
+    public IReadOnlyList<PerformedEffect> PerformedEffects
+    {
+        get
+        {
+            lock (this.performedEffects)
+            {
+                return [.. this.performedEffects];
+            }
+        }
+    }
+
+    public void RecordPerformed(PerformedEffect effect)
+    {
+        lock (this.performedEffects)
+        {
+            this.performedEffects.Add(effect);
         }
     }
 

--- a/Standard.Agents/Models/Loggings/PerformedEffect.cs
+++ b/Standard.Agents/Models/Loggings/PerformedEffect.cs
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Loggings;
+
+/// <summary>
+/// An act this run actually performed, and what it produced. Recorded so the run can be unwound
+/// (SPEC.md §4.9): compensation needs the arguments the tool was called with <i>and</i> the outcome
+/// it returned, because the outcome carries the identity the undo has to name.
+/// </summary>
+/// <remarks>
+/// Only performed acts are kept. An effect denied by policy, held for approval, or replayed from
+/// the ledger was never performed by this run, and compensating it would undo something this run
+/// did not do.
+/// </remarks>
+public sealed record PerformedEffect(string ToolName, string Arguments, string Outcome);

--- a/Standard.Agents/Models/Orchestrations/Effects/CompensationOutcome.cs
+++ b/Standard.Agents/Models/Orchestrations/Effects/CompensationOutcome.cs
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Orchestrations.Effects;
+
+/// <summary>
+/// What became of one effect when the run was unwound (SPEC.md §4.9).
+/// </summary>
+/// <param name="ToolName">The tool whose act was being undone.</param>
+/// <param name="Undone">
+/// Whether it was actually reversed. <c>false</c> means the effect stands — either the tool
+/// declared no way back, or the attempt to undo it failed.
+/// </param>
+/// <param name="Detail">What was done, or why it could not be.</param>
+public sealed record CompensationOutcome(string ToolName, bool Undone, string Detail);

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Budgets.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Budgets.cs
@@ -5,6 +5,7 @@
 
 using Standard.Agents.Models.Coordinations.Agents;
 using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Effects;
 
 namespace Standard.Agents.Services.Coordinations;
 
@@ -71,6 +72,41 @@ public partial class AgentCoordinationService
     {
         await this.loggingBroker.LogOutcomeAsync($"stopped: {message}");
 
-        return message;
+        string unwound = await UnwindAsync();
+
+        return string.IsNullOrEmpty(unwound)
+            ? message
+            : $"{message} {unwound}";
+    }
+
+    // A run that stopped without delivering an answer may have left effects behind. Compensation
+    // (SPEC.md §4.9) asks Direction to unwind them, and the caller is told what stood — reporting
+    // a run cleanly unwound when it was not is worse than never offering compensation at all.
+    private async ValueTask<string> UnwindAsync()
+    {
+        if (this.compensateOnFailure is false)
+        {
+            return string.Empty;
+        }
+
+        IReadOnlyList<CompensationOutcome> outcomes =
+            await this.directionOrchestrationService.CompensateRunAsync();
+
+        if (outcomes.Count is 0)
+        {
+            return string.Empty;
+        }
+
+        int undoneCount = outcomes.Count(outcome => outcome.Undone);
+        string report = $"Unwound {undoneCount} of {outcomes.Count} effects.";
+
+        string[] standing =
+            [.. outcomes.Where(outcome => outcome.Undone is false).Select(outcome => outcome.Detail)];
+
+        await this.loggingBroker.LogOutcomeAsync($"compensated: {report}");
+
+        return standing.Length is 0
+            ? report
+            : $"{report} {string.Join(" ", standing)}";
     }
 }

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -33,6 +33,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
     private readonly ISessionBroker sessionBroker;
     private readonly int maxHistoryTurns;
     private readonly int maxTurns;
+    private readonly bool compensateOnFailure;
 
     public AgentCoordinationService(
         IDataOrchestrationService dataOrchestrationService,
@@ -43,8 +44,10 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         ITimeBroker? timeBroker = null,
         AgentBudget? budget = null,
         ISessionBroker? sessionBroker = null,
-        int maxHistoryTurns = 20)
+        int maxHistoryTurns = 20,
+        bool compensateOnFailure = false)
     {
+        this.compensateOnFailure = compensateOnFailure;
         this.dataOrchestrationService = dataOrchestrationService;
         this.decisionOrchestrationService = decisionOrchestrationService;
         this.directionOrchestrationService = directionOrchestrationService;
@@ -90,43 +93,68 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         var spend = new AgentSpend();
         DateTimeOffset startedOn = this.timeBroker.GetCurrentDateTimeOffset();
 
-        for (int turn = 0; turn < this.maxTurns; turn++)
+        try
         {
-            if (cancellationToken.IsCancellationRequested)
+            for (int turn = 0; turn < this.maxTurns; turn++)
             {
-                return await StopAsync(context, CancelledMessage, AgentStatus.Failed);
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return await StopAsync(context, CancelledMessage, AgentStatus.Failed);
+                }
+
+                if (IsBudgetExhausted(spend, startedOn, out string exhaustion))
+                {
+                    return await StopAsync(context, exhaustion, AgentStatus.Failed);
+                }
+
+                await this.loggingBroker.LogTurnAsync(turn);
+
+                await this.loggingBroker.LogStepAsync(AgentStep.Data);
+                context = await this.dataOrchestrationService.RecallAsync(context);
+
+                await this.loggingBroker.LogStepAsync(AgentStep.Decision);
+                context = await this.decisionOrchestrationService.ThinkAsync(context);
+
+                spend.AddTokens(context.PromptTokens, context.CompletionTokens);
+
+                if (context.Status is AgentStatus.Revising)
+                {
+                    await this.loggingBroker.LogOutcomeAsync($"turn {turn}: revising");
+
+                    continue;
+                }
+
+                await this.loggingBroker.LogStepAsync(AgentStep.Direction);
+                context = await this.directionOrchestrationService.ActAsync(context);
+
+                await this.loggingBroker.LogOutcomeAsync($"turn {turn}: {context.Status}");
+
+                if (context.Status != AgentStatus.Working)
+                {
+                    break;
+                }
             }
+        }
+        catch (Exception)
+        {
+            // A run that faulted mid-flight is the case compensation exists for: the effects it
+            // already performed are real, and nothing else will unwind them (SPEC.md §4.9).
+            await UnwindAsync();
 
-            if (IsBudgetExhausted(spend, startedOn, out string exhaustion))
+            throw;
+        }
+
+        // Turns ran out with the loop still Working: effects may have been performed and no answer
+        // was ever delivered, which is a failed run however calmly it ended.
+        if (context.Status is AgentStatus.Working)
+        {
+            string unwound = await UnwindAsync();
+
+            if (string.IsNullOrEmpty(unwound) is false)
             {
-                return await StopAsync(context, exhaustion, AgentStatus.Failed);
-            }
+                await this.loggingBroker.LogOutcomeAsync($"done: {context.Status}");
 
-            await this.loggingBroker.LogTurnAsync(turn);
-
-            await this.loggingBroker.LogStepAsync(AgentStep.Data);
-            context = await this.dataOrchestrationService.RecallAsync(context);
-
-            await this.loggingBroker.LogStepAsync(AgentStep.Decision);
-            context = await this.decisionOrchestrationService.ThinkAsync(context);
-
-            spend.AddTokens(context.PromptTokens, context.CompletionTokens);
-
-            if (context.Status is AgentStatus.Revising)
-            {
-                await this.loggingBroker.LogOutcomeAsync($"turn {turn}: revising");
-
-                continue;
-            }
-
-            await this.loggingBroker.LogStepAsync(AgentStep.Direction);
-            context = await this.directionOrchestrationService.ActAsync(context);
-
-            await this.loggingBroker.LogOutcomeAsync($"turn {turn}: {context.Status}");
-
-            if (context.Status != AgentStatus.Working)
-            {
-                break;
+                return $"{context.Result} {unwound}".Trim();
             }
         }
 
@@ -230,6 +258,18 @@ public partial class AgentCoordinationService : IAgentCoordinationService
             yield return new AgentStreamEvent(
                 AgentStreamEventType.Response,
                 RetriesExhaustedMessage);
+        }
+
+        // The streamed loop unwinds on the same terms as the batched one. A control enforced on
+        // one path and not the other is a control a caller can step around by changing method.
+        if (context.Status is AgentStatus.Working)
+        {
+            string unwound = await UnwindAsync();
+
+            if (string.IsNullOrEmpty(unwound) is false)
+            {
+                yield return new AgentStreamEvent(AgentStreamEventType.Status, unwound);
+            }
         }
 
         await this.loggingBroker.LogOutcomeAsync($"done: {context.Status}");

--- a/Standard.Agents/Services/Foundations/InternalTools/IInternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/InternalTools/IInternalToolService.cs
@@ -10,4 +10,10 @@ public interface IInternalToolService
     ValueTask<bool> HandlesAsync(string name);
 
     ValueTask<string> RunAsync(string name, string input);
+
+    /// <summary>
+    /// Undoes what a tool did, where the tool knows how (SPEC.md §4.9). Returns what was done, or
+    /// an empty string when the tool declared no way back.
+    /// </summary>
+    ValueTask<string> CompensateAsync(string name, string input, string outcome);
 }

--- a/Standard.Agents/Services/Foundations/InternalTools/InternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/InternalTools/InternalToolService.cs
@@ -36,4 +36,12 @@ TryCatch(async () =>
 
     return await this.toolBroker.RunAsync(name, input);
 });
+
+    public ValueTask<string> CompensateAsync(string name, string input, string outcome) =>
+    TryCatch(async () =>
+    {
+        ValidateName(name);
+
+        return await this.toolBroker.CompensateAsync(name, input, outcome);
+    });
 }

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
@@ -74,6 +74,12 @@ public partial class DirectionOrchestrationService
         // 5 — record the outcome, before the loop advances
         await this.effectLedgerBroker.InsertOutcomeAsync(effect, output);
 
+        // Remember that this run performed it, so it can be unwound. Only here: an effect denied,
+        // held for approval, or replayed from the ledger returned above and was never performed by
+        // this run, and compensating it would undo something this run did not do (SPEC.md §4.9).
+        AgentRun.Current?.RecordPerformed(
+            new PerformedEffect(effect.ToolName, effect.Arguments, output));
+
         await this.loggingBroker.LogProcessAsync(
             "Direction", $"Tool '{effect.ToolName}' ← {context.Payload}", detail: true);
 
@@ -164,9 +170,54 @@ public partial class DirectionOrchestrationService
     // the booking before the payment it paid for would leave the payment attached to nothing.
     public async ValueTask<IReadOnlyList<CompensationOutcome>> CompensateRunAsync()
     {
-        await ValueTask.CompletedTask;
+        AgentRun? run = AgentRun.Current;
 
-        return [];
+        if (run is null)
+        {
+            return [];
+        }
+
+        List<CompensationOutcome> outcomes = [];
+
+        foreach (PerformedEffect effect in run.PerformedEffects.Reverse())
+        {
+            CompensationOutcome outcome = await CompensateEffectAsync(effect);
+
+            await this.loggingBroker.LogProcessAsync(
+                "Direction",
+                $"Compensate '{effect.ToolName}' → "
+                    + $"{(outcome.Undone ? "UNDONE" : "STANDS")}: {outcome.Detail}");
+
+            outcomes.Add(outcome);
+        }
+
+        return outcomes;
+    }
+
+    // Best effort per effect. A reversal is itself an act against the world, and acts fail;
+    // abandoning the rest because this one refused would leave more standing, not less.
+    private async ValueTask<CompensationOutcome> CompensateEffectAsync(PerformedEffect effect)
+    {
+        string stands = $"'{effect.ToolName}' could not be undone; the effect stands.";
+
+        if (await this.internalToolService.HandlesAsync(effect.ToolName) is false)
+        {
+            return new CompensationOutcome(effect.ToolName, Undone: false, Detail: stands);
+        }
+
+        try
+        {
+            string reversal = await this.internalToolService.CompensateAsync(
+                effect.ToolName, effect.Arguments, effect.Outcome);
+
+            return string.IsNullOrEmpty(reversal)
+                ? new CompensationOutcome(effect.ToolName, Undone: false, Detail: stands)
+                : new CompensationOutcome(effect.ToolName, Undone: true, Detail: reversal);
+        }
+        catch (Exception)
+        {
+            return new CompensationOutcome(effect.ToolName, Undone: false, Detail: stands);
+        }
     }
 
     private async ValueTask<string> RunToolAsync(AgentContext context)

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
@@ -156,6 +156,19 @@ public partial class DirectionOrchestrationService
         };
     }
 
+    // Compensation (SPEC.md §4.9, Invariant 7). Run-once makes an effect safe to PROPOSE twice;
+    // compensation is for the effects that cannot be made idempotent at all — a payment sent, a
+    // message delivered — where the only way back is a second, opposite act.
+    //
+    // It unwinds in reverse order, because a later effect may depend on an earlier one: undoing
+    // the booking before the payment it paid for would leave the payment attached to nothing.
+    public async ValueTask<IReadOnlyList<CompensationOutcome>> CompensateRunAsync()
+    {
+        await ValueTask.CompletedTask;
+
+        return [];
+    }
+
     private async ValueTask<string> RunToolAsync(AgentContext context)
     {
         bool isLocalTool = await this.internalToolService.HandlesAsync(context.DirectionType);

--- a/Standard.Agents/Services/Orchestrations/Direction/IDirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/IDirectionOrchestrationService.cs
@@ -4,10 +4,17 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Effects;
 
 namespace Standard.Agents.Services.Orchestrations.Direction;
 
 public interface IDirectionOrchestrationService
 {
     ValueTask<AgentContext> ActAsync(AgentContext context);
+
+    /// <summary>
+    /// Unwinds what this run performed, in reverse order (SPEC.md §4.9). Reports every effect it
+    /// could not undo rather than reporting the run cleanly unwound.
+    /// </summary>
+    ValueTask<IReadOnlyList<CompensationOutcome>> CompensateRunAsync();
 }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -94,6 +94,7 @@ public sealed partial class StandardAgent : IAgent
     private IEffectLedgerBroker? effectLedgerBroker;
     private IEnumerable<string>? approvalRequiredTools;
     private bool screenToolOutput;
+    private bool compensateOnFailure;
     private AgentBudget? budget;
     private IResilienceBroker? resilienceBroker;
     private IGeneratorBrokerV1? generatorBrokerV1;
@@ -545,6 +546,24 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent ScreenToolOutput() =>
         Set(() => this.screenToolOutput = true);
+
+    /// <summary>
+    /// Unwinds what a run performed when the run fails before it delivers an answer — cancelled,
+    /// out of budget, out of turns, or faulted (SPEC.md §4.9).
+    /// </summary>
+    /// <remarks>
+    /// Run-once makes an effect safe to <i>propose</i> twice. Compensation is for the effects that
+    /// cannot be made idempotent at all — a payment sent, a message delivered — where the only way
+    /// back is a second, opposite act.
+    /// <para>Each tool says how it is undone by overriding
+    /// <see cref="Tools.ITool.CompensateAsync"/>; a tool that does not is reported as an effect
+    /// that stands. Unwinding runs in reverse order, because a later effect may depend on an
+    /// earlier one, and it touches only what this run actually performed — never an effect that
+    /// was denied, held for approval, or replayed from the ledger.</para>
+    /// </remarks>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent CompensateOnFailure() =>
+        Set(() => this.compensateOnFailure = true);
 
     /// <summary>
     /// Caps how many Recall→Think→Act turns a single prompt may take before the agent stops —
@@ -1068,7 +1087,7 @@ public sealed partial class StandardAgent : IAgent
 
         return new AgentCoordinationService(
             data, decision, direction, logging, this.maxTurns, new TimeBroker(), this.budget,
-            this.sessionBroker, this.maxHistoryTurns);
+            this.sessionBroker, this.maxHistoryTurns, this.compensateOnFailure);
     }
 
     // The catalog a "{{tools}}" marker in the agent's Data expands into. Only tools that

--- a/Standard.Agents/Tools/ITool.cs
+++ b/Standard.Agents/Tools/ITool.cs
@@ -14,4 +14,22 @@ public interface ITool
     string Parameters => "{}";
 
     ValueTask<string> ExecuteAsync(string input);
+
+    /// <summary>
+    /// Undoes what <see cref="ExecuteAsync"/> did, given the same input and what it returned.
+    /// Return what was done to undo it, or <c>null</c> if this tool cannot be undone.
+    /// </summary>
+    /// <remarks>
+    /// Run-once (SPEC.md §4.9) makes an effect safe to <i>propose</i> twice. Compensation is for
+    /// the effects that cannot be made idempotent at all — a payment sent, a message delivered —
+    /// where the only way back is a second, opposite act: a refund, a retraction.
+    /// <para>Both arguments are needed. The input alone cannot cancel the specific booking that
+    /// was made; the outcome carries the identity the undo has to name.</para>
+    /// <para>Not every tool can do this, and a tool that cannot says so by leaving the default,
+    /// which returns <c>null</c> and is reported as an effect that stands. Silently doing nothing
+    /// and reporting success would be the worst of both: the caller believes the run was unwound
+    /// when it was not.</para>
+    /// </remarks>
+    ValueTask<string?> CompensateAsync(string input, string outcome) =>
+        ValueTask.FromResult<string?>(null);
 }

--- a/conformance/profiles/critical.json
+++ b/conformance/profiles/critical.json
@@ -4,6 +4,7 @@
   "inherits": "Enterprise",
   "requires": [
     "conversation-carries-history",
+    "failed-run-unwinds-in-reverse",
     "native-tool-call-round-trips",
     "awaiting-input-resumes-in-a-new-process",
     "effect-outcome-survives-a-crash"

--- a/conformance/vectors/26-failed-run-unwinds-in-reverse.json
+++ b/conformance/vectors/26-failed-run-unwinds-in-reverse.json
@@ -1,0 +1,22 @@
+{
+  "name": "failed-run-unwinds-in-reverse",
+  "description": "SPEC.md 4.9 and Invariant 7: run-once makes an effect safe to propose twice, but it does nothing for an effect that cannot be made idempotent at all. The run books a flight, charges a card, then emails a confirmation, and never delivers an answer. Compensation unwinds what it actually performed, in reverse order - the charge is reversed before the booking it paid for, because undoing the booking first would leave the payment attached to nothing. The email tool declares no way back, so it is reported as an effect that stands rather than silently counted as undone: a run that reports itself cleanly unwound when it was not is worse than one that never offered compensation.",
+  "generatorReplies": [
+    "ACTION: book_flight: LHR-JFK",
+    "ACTION: charge_card: 480.00",
+    "ACTION: send_email: your ticket is confirmed"
+  ],
+  "tools": {
+    "book_flight": "booking QX7A21",
+    "charge_card": "charge CH99120",
+    "send_email": "message sent"
+  },
+  "prompt": "book me a flight to New York",
+  "maxTurns": 3,
+  "compensateOnFailure": true,
+  "compensatingTools": ["book_flight", "charge_card"],
+  "expect": {
+    "compensationOrder": ["charge_card", "book_flight"],
+    "resultContains": "'send_email' could not be undone; the effect stands."
+  }
+}


### PR DESCRIPTION
Run-once makes an effect safe to *propose* twice. It does nothing for the effects that cannot be made idempotent at all — a payment sent, a message delivered — where the only way back is a second, opposite act. This closes the last v1.0 exit criterion.

A tool declares how it is undone by overriding `ITool.CompensateAsync(input, outcome)`; both arguments are needed, because the input alone cannot cancel the specific booking that was made. A tool that declares nothing keeps the default and is reported as an effect that stands.

`.CompensateOnFailure()` turns the unwind on. It runs when a run stops without delivering an answer — cancelled, out of budget, out of turns, or faulted — on both the batched and the streamed path, and only over what the run actually *performed*: an effect denied by policy, held for approval, or replayed from the ledger was never performed by this run. The unwind is in reverse order, and best-effort per effect, so a reversal that throws does not strand the ones behind it.

Sabotage-verified three ways at the unit level (forward order, treating an empty reversal as undone, recording the effect before it was authorized) and twice at the conformance level. 366 tests, 26 vectors, Enterprise certified.

Spec: [The-Standard-Agent-Specs#18](https://github.com/hassanhabib/The-Standard-Agent-Specs/pull/18)