### PR TITLE
MAJOR COORDINATIONS: Carry One Run Across Processes

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/ResumptionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/ResumptionTests.cs
@@ -1,0 +1,156 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Effects;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Sessions;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// Resumption across processes (SPEC.md §4.9, §4.11). Run-once inside one instance is the easy
+// half. The half an auditor asks about is the run that was killed immediately after the transfer
+// went out, and the process that picked the session up afterwards.
+public class ResumptionTests : IDisposable
+{
+    private readonly string workingPath =
+        Path.Combine(Path.GetTempPath(), $"standard-agent-resume-{Guid.NewGuid():n}");
+
+    private string SessionsPath => Path.Combine(this.workingPath, "sessions");
+
+    private string LedgerPath => Path.Combine(this.workingPath, "ledger");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this.workingPath))
+        {
+            Directory.Delete(this.workingPath, recursive: true);
+        }
+    }
+
+    private sealed class CountingTool : ITool
+    {
+        public string Name => "wire_transfer";
+        public string Description => "Moves money.";
+        public string Parameters => "{}";
+
+        public int ExecutionCount { get; private set; }
+
+        public ValueTask<string> ExecuteAsync(string input)
+        {
+            ExecutionCount++;
+
+            return ValueTask.FromResult("transfer complete");
+        }
+    }
+
+    // A separate instance each time, wired to the same folders — the closest a unit test comes to
+    // a different process, and the thing an in-memory ledger could never demonstrate.
+    private StandardAgent NewProcess(CountingTool tool, params string[] replies)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        var scriptedReplies = new Queue<string>(replies);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .Tool(tool)
+            .Sessions(SessionsPath)
+            .UseEffectLedger(new FileEffectLedgerBroker(LedgerPath))
+            .OnBrain(async (systemPrompt, userPrompt) =>
+                scriptedReplies.Count > 0 ? scriptedReplies.Dequeue() : "FINAL: done");
+    }
+
+    [Fact]
+    public async Task ShouldNotRepeatAnEffectAfterTheRunWasInterruptedAsync()
+    {
+        // given — the first process pays the invoice and dies before it can answer
+        var tool = new CountingTool();
+
+        await NewProcess(tool, "ACTION: wire_transfer: 10000")
+            .MaxTurns(1)
+            .ProcessPromptAsync(prompt: "pay the invoice", "invoice-88", CancellationToken.None);
+
+        tool.ExecutionCount.Should().Be(1);
+
+        // when — a second process picks the session up and the Brain proposes the same act
+        var resumedTool = new CountingTool();
+
+        string actualResult = await NewProcess(
+            resumedTool,
+            "ACTION: wire_transfer: 10000",
+            "FINAL: already paid")
+                .ProcessPromptAsync(
+                    prompt: "did that go through?", "invoice-88", CancellationToken.None);
+
+        // then — the resumed run kept the interrupted run's identity, so the effect is replayed
+        resumedTool.ExecutionCount.Should().Be(0);
+        actualResult.Should().Be("already paid");
+    }
+
+    [Fact]
+    public async Task ShouldRecordTheRunOnTheSessionBeforeAnyWorkAsync()
+    {
+        // given — a run cancelled before it starts, which never reaches the end of the loop and
+        // is deliberately never written back as an answer
+        var tool = new CountingTool();
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        await NewProcess(tool, "ACTION: wire_transfer: 10000")
+            .ProcessPromptAsync(prompt: "pay the invoice", "invoice-91", cancellation.Token);
+
+        // when
+        var sessionBroker = new FileSessionBroker(SessionsPath);
+        AgentSession? actualSession = await sessionBroker.SelectSessionAsync("invoice-91");
+
+        // then — an identity recorded only on success is one the failure case can never use
+        actualSession.Should().NotBeNull();
+        actualSession!.RunId.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ShouldStartAFreshRunAfterTheSessionDeliveredAnAnswerAsync()
+    {
+        // given — the first prompt answers, which completes the run
+        var tool = new CountingTool();
+
+        await NewProcess(tool, "FINAL: nothing to do")
+            .ProcessPromptAsync(prompt: "anything pending?", "invoice-93", CancellationToken.None);
+
+        var sessionBroker = new FileSessionBroker(SessionsPath);
+        AgentSession? answered = await sessionBroker.SelectSessionAsync("invoice-93");
+
+        // when — the next prompt in the same conversation performs an act
+        var payingTool = new CountingTool();
+
+        await NewProcess(payingTool, "ACTION: wire_transfer: 10000", "FINAL: paid")
+            .ProcessPromptAsync(prompt: "pay the invoice", "invoice-93", CancellationToken.None);
+
+        AgentSession? afterPayment = await sessionBroker.SelectSessionAsync("invoice-93");
+
+        // then — a completed conversation is not an interrupted run; the act is performed
+        payingTool.ExecutionCount.Should().Be(1);
+        afterPayment!.RunId.Should().NotBe(answered!.RunId);
+    }
+}

--- a/Standard.Agents/Models/Brokers/Sessions/AgentSession.cs
+++ b/Standard.Agents/Models/Brokers/Sessions/AgentSession.cs
@@ -28,6 +28,17 @@ public sealed record AgentSession
 
     /// <summary>The question the agent asked and is waiting on, when awaiting input.</summary>
     public string PendingQuestion { get; init; } = "";
+
+    /// <summary>
+    /// The run that last worked this session, written when the run <i>starts</i>.
+    /// </summary>
+    /// <remarks>
+    /// Written at the start rather than at the end because a crash means nothing at the end runs
+    /// at all. It is what lets a resumed run keep the identity the interrupted one had — and
+    /// therefore derive the same idempotency keys (SPEC.md §4.9), so an effect that already went
+    /// out is replayed rather than performed a second time.
+    /// </remarks>
+    public string RunId { get; init; } = "";
 }
 
 /// <summary>One exchange: what was asked, and what came back.</summary>

--- a/Standard.Agents/Models/Loggings/AgentRun.cs
+++ b/Standard.Agents/Models/Loggings/AgentRun.cs
@@ -54,10 +54,19 @@ public sealed class AgentRun
     /// Starts a run on the calling flow and returns the scope that ends it. Call it from the
     /// coordination loop, before anything the run should be credited with.
     /// </summary>
-    public static IDisposable Begin()
+    /// <param name="resumedId">
+    /// The identity of a run this one continues, or <c>null</c> to start a new one. A resumed run
+    /// keeps the interrupted run's identity so the effects it already performed are recognised as
+    /// its own rather than proposed again (SPEC.md §4.9, §4.11).
+    /// </param>
+    public static IDisposable Begin(string? resumedId = null)
     {
         AgentRun? enclosingRun = current.Value;
-        current.Value = new AgentRun(Guid.NewGuid().ToString("n"));
+
+        current.Value = new AgentRun(
+            string.IsNullOrEmpty(resumedId)
+                ? Guid.NewGuid().ToString("n")
+                : resumedId);
 
         return new Scope(enclosingRun);
     }

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Sessions.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Sessions.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
 
 namespace Standard.Agents.Services.Coordinations;
@@ -15,16 +16,32 @@ namespace Standard.Agents.Services.Coordinations;
 // a different process, long after the instance that created it is gone.
 public partial class AgentCoordinationService
 {
-    private async ValueTask<AgentContext> LoadSessionAsync(AgentContext context)
+    // Read before the run begins, because a resumed run must keep the identity the interrupted
+    // one had. Nothing is logged here: there is no run yet to credit the record to.
+    private async ValueTask<AgentSession?> PeekSessionAsync(string sessionId) =>
+        string.IsNullOrEmpty(sessionId)
+            ? null
+            : await this.sessionBroker.SelectSessionAsync(sessionId);
+
+    // A session that never delivered an answer was interrupted — killed, cancelled, out of turns,
+    // or waiting on an authority. The next prompt in that session continues that run rather than
+    // starting a fresh one, so the effects it already performed keep their idempotency keys and
+    // are replayed rather than performed twice (SPEC.md §4.9, §4.11).
+    private static string? ResumedRunId(AgentSession? session) =>
+        null;
+
+    // The start-of-run checkpoint. Written before any work, because a crash means nothing at the
+    // end runs at all — and an identity recorded only on success is an identity the failure case
+    // can never use.
+    private async ValueTask BeginSessionAsync(AgentContext context, AgentSession? session)
     {
-        if (string.IsNullOrEmpty(context.SessionId))
-        {
-            return context;
-        }
+        await ValueTask.CompletedTask;
+    }
 
-        AgentSession? session =
-            await this.sessionBroker.SelectSessionAsync(context.SessionId);
-
+    private async ValueTask<AgentContext> LoadSessionAsync(
+        AgentContext context,
+        AgentSession? session)
+    {
         if (session is null)
         {
             return context;
@@ -62,6 +79,7 @@ public partial class AgentCoordinationService
             Id = context.SessionId,
             History = [.. history, new AgentTurn(context.Prompt, context.Result)],
             Status = context.Status,
+            RunId = AgentRun.Current?.Id ?? string.Empty,
 
             // What the agent is waiting on, so a later prompt can see it was mid-question
             // rather than mid-nothing.

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Sessions.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Sessions.cs
@@ -28,14 +28,39 @@ public partial class AgentCoordinationService
     // starting a fresh one, so the effects it already performed keep their idempotency keys and
     // are replayed rather than performed twice (SPEC.md §4.9, §4.11).
     private static string? ResumedRunId(AgentSession? session) =>
-        null;
+        session is not null
+            && string.IsNullOrEmpty(session.RunId) is false
+            && Delivered(session.Status) is false
+                ? session.RunId
+                : null;
+
+    // Delivered means the caller got a conclusion — an answer, or a refusal that is itself an
+    // answer. Everything else left the run in the middle of something.
+    private static bool Delivered(AgentStatus status) =>
+        status is AgentStatus.Responded or AgentStatus.Refused;
 
     // The start-of-run checkpoint. Written before any work, because a crash means nothing at the
     // end runs at all — and an identity recorded only on success is an identity the failure case
     // can never use.
     private async ValueTask BeginSessionAsync(AgentContext context, AgentSession? session)
     {
-        await ValueTask.CompletedTask;
+        if (string.IsNullOrEmpty(context.SessionId))
+        {
+            return;
+        }
+
+        // History is carried through untouched. The checkpoint records who is working the
+        // session, not what was said — this prompt has no answer yet, and writing one here
+        // would tell the next prompt the agent said something it never said.
+        await this.sessionBroker.UpsertSessionAsync(
+            new AgentSession
+            {
+                Id = context.SessionId,
+                History = session?.History ?? [],
+                Status = AgentStatus.Working,
+                PendingQuestion = session?.PendingQuestion ?? string.Empty,
+                RunId = AgentRun.Current?.Id ?? string.Empty
+            });
     }
 
     private async ValueTask<AgentContext> LoadSessionAsync(

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Sessions;
 using Standard.Agents.Brokers.Times;
+using Standard.Agents.Models.Brokers.Sessions;
 using Standard.Agents.Models.Coordinations.Agents;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Loggings;
@@ -75,17 +76,24 @@ public partial class AgentCoordinationService : IAgentCoordinationService
     {
         ValidatePrompt(prompt);
 
+        // Read before the run begins: a session that never delivered an answer was interrupted,
+        // and the next prompt in it continues that run rather than starting a fresh one.
+        AgentSession? session = await PeekSessionAsync(sessionId);
+
         // This prompt's run. SPEC.md §4.4: one instance serves prompts concurrently, and each
         // invocation establishes its own identity, so everything recorded below is credited to
         // this run and to no other.
-        using IDisposable run = AgentRun.Begin();
+        using IDisposable run = AgentRun.Begin(ResumedRunId(session));
 
         await this.loggingBroker.LogResetAsync();
 
         AgentContext context = new() { Prompt = prompt, SessionId = sessionId };
 
+        // The start-of-run checkpoint, written before any work is done (SPEC.md §4.11).
+        await BeginSessionAsync(context, session);
+
         // What was said before, loaded before Decision runs so the Brain sees it (SPEC.md §4.11).
-        context = await LoadSessionAsync(context);
+        context = await LoadSessionAsync(context, session);
 
         // Budgets and cancellation are both checked at the turn boundary (SPEC.md §4.10): a turn
         // is the smallest unit the loop can stop between without abandoning work mid-flight —


### PR DESCRIPTION
Run-once inside one instance is the easy half. The half an auditor asks about is the run killed immediately after the wire transfer went out, and the process that picked the session up afterwards.

That only works if the resumed run keeps the interrupted run''s identity. Idempotency keys are derived from the run, the tool and the canonical arguments (SPEC.md §4.9) — a fresh run id produces fresh keys, and the act goes out a second time.

- `AgentSession` carries `RunId`, written at the **start** of the run. A crash means nothing at the end runs at all, so an identity recorded only on success is one the failure case can never use.
- The start-of-run checkpoint carries history through untouched. This prompt has no answer yet, and writing one there would tell the next prompt the agent said something it never said.
- A session resumes only when it never *delivered* — `Responded` and `Refused` are conclusions; `Working`, `Failed`, `AwaitingInput` and `AwaitingApproval` left the run in the middle of something.

Proven against `FileEffectLedgerBroker` with two separate agent instances over the same folders — the closest a unit test comes to a different process, and the thing an in-memory ledger could never demonstrate. Sabotage-verified three ways. 369 tests.