### PR TITLE
BROKERS: Delete An Unperformed Effect Claim

### DIFF
--- a/Standard.Agents/Brokers/Effects/FileEffectLedgerBroker.cs
+++ b/Standard.Agents/Brokers/Effects/FileEffectLedgerBroker.cs
@@ -69,6 +69,33 @@ public sealed class FileEffectLedgerBroker : IEffectLedgerBroker
         File.Move(temporaryFile, claimFile, overwrite: true);
     }
 
+    // Only an unfinished claim is given back. A file that already carries an outcome names an act
+    // that happened, and deleting it would turn run-once back into run-again.
+    public async ValueTask DeleteClaimAsync(AgentEffect effect)
+    {
+        string claimFile = FileFor(effect);
+
+        if (File.Exists(claimFile) is false)
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(await ReadOutcomeAsync(claimFile)) is false)
+        {
+            return;
+        }
+
+        try
+        {
+            File.Delete(claimFile);
+        }
+        catch (IOException)
+        {
+            // Another process is holding it; it owns the claim, and forcing it open would be
+            // worse than leaving a claim that a later run will read as in flight.
+        }
+    }
+
     // A ledger written by a process that then died can be read by one that is still starting up,
     // so the read tolerates a claim that is empty or being replaced rather than faulting.
     private static async ValueTask<string> ReadOutcomeAsync(string claimFile)

--- a/Standard.Agents/Brokers/Effects/FunctionEffectLedgerBroker.cs
+++ b/Standard.Agents/Brokers/Effects/FunctionEffectLedgerBroker.cs
@@ -14,13 +14,16 @@ public sealed class FunctionEffectLedgerBroker : IEffectLedgerBroker
 {
     private readonly Func<AgentEffect, ValueTask<string?>> claim;
     private readonly Func<AgentEffect, string, ValueTask> record;
+    private readonly Func<AgentEffect, ValueTask> release;
 
     public FunctionEffectLedgerBroker(
         Func<AgentEffect, ValueTask<string?>> claim,
-        Func<AgentEffect, string, ValueTask> record)
+        Func<AgentEffect, string, ValueTask> record,
+        Func<AgentEffect, ValueTask> release)
     {
         this.claim = claim;
         this.record = record;
+        this.release = release;
     }
 
     public ValueTask<string?> SelectOutcomeAsync(AgentEffect effect) =>
@@ -28,4 +31,7 @@ public sealed class FunctionEffectLedgerBroker : IEffectLedgerBroker
 
     public ValueTask InsertOutcomeAsync(AgentEffect effect, string outcome) =>
         this.record(effect, outcome);
+
+    public ValueTask DeleteClaimAsync(AgentEffect effect) =>
+        this.release(effect);
 }

--- a/Standard.Agents/Brokers/Effects/IEffectLedgerBroker.cs
+++ b/Standard.Agents/Brokers/Effects/IEffectLedgerBroker.cs
@@ -22,4 +22,14 @@ public interface IEffectLedgerBroker
 
     /// <summary>Records what the effect produced, before the loop advances.</summary>
     ValueTask InsertOutcomeAsync(AgentEffect effect, string outcome);
+
+    /// <summary>
+    /// Gives back a claim on an act that was held rather than performed (SPEC.md §4.9).
+    /// </summary>
+    /// <remarks>
+    /// A held act is one that still has to be able to happen. Leaving its claim standing builds
+    /// an approval that can only ever be granted too late: the authority says yes, the resumed
+    /// run proposes the act, and the ledger reports it as already done.
+    /// </remarks>
+    ValueTask DeleteClaimAsync(AgentEffect effect);
 }

--- a/Standard.Agents/Brokers/Effects/InMemoryEffectLedgerBroker.cs
+++ b/Standard.Agents/Brokers/Effects/InMemoryEffectLedgerBroker.cs
@@ -41,4 +41,14 @@ public sealed class InMemoryEffectLedgerBroker : IEffectLedgerBroker
 
         return ValueTask.CompletedTask;
     }
+
+    // Only an unfinished claim is given back. A key that already carries an outcome names an act
+    // that happened, and forgetting that would turn run-once back into run-again.
+    public ValueTask DeleteClaimAsync(AgentEffect effect)
+    {
+        this.outcomesByKey.TryRemove(
+            new KeyValuePair<string, string?>(effect.IdempotencyKey, null));
+
+        return ValueTask.CompletedTask;
+    }
 }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -565,11 +565,20 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="record">
     /// An <c>(effect, outcome) =&gt; ...</c> delegate, called once the act has been performed.
     /// </param>
+    /// <param name="release">
+    /// An <c>effect =&gt; ...</c> delegate, called when the act was <i>held</i> rather than
+    /// performed — denied, or waiting on an authority. Give the claim back: a held act is one
+    /// that still has to be able to happen, and a claim left standing makes the approval
+    /// unusable when it finally arrives. Release only an unfinished claim; a key that already
+    /// carries an outcome names an act that happened.
+    /// </param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent OnEffectLedger(
         Func<AgentEffect, ValueTask<string?>> claim,
-        Func<AgentEffect, string, ValueTask> record) =>
-        Set(() => this.effectLedgerBroker = new FunctionEffectLedgerBroker(claim, record));
+        Func<AgentEffect, string, ValueTask> record,
+        Func<AgentEffect, ValueTask> release) =>
+        Set(() =>
+            this.effectLedgerBroker = new FunctionEffectLedgerBroker(claim, record, release));
 
     /// <summary>
     /// Screens what tools hand back before the Brain reads it (SPEC.md §4.9). A tool result is


### PR DESCRIPTION
Found by building the cross-process approval vector.

The perimeter records intent at step 2 and approves at step 3. When approval comes back `Pending`, the act is held — but the run-once claim made at step 2 stays. The authority then says yes, the resumed run proposes the act, and the ledger reports it as already done. The transfer never happens, and nothing looks wrong.

`DeleteClaimAsync` gives the claim back, on all three brokers. Only an *unfinished* claim is released: a key that already carries an outcome names an act that happened, and forgetting that would turn run-once back into run-again. The file ledger declines to force a claim another process is holding — a claim a later run reads as in flight is better than one taken from its owner.

`OnEffectLedger` gains a third delegate rather than defaulting it, because a custom ledger that cannot release is a custom ledger with this bug in it.

Spec: [The-Standard-Agent-Specs#19](https://github.com/hassanhabib/The-Standard-Agent-Specs/pull/19). The orchestration change that calls it, and the vector that proves it, follow.