### PR TITLE
MAJOR ORCHESTRATIONS: Release The Claim On A Held Act

### DIFF
--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -72,4 +72,9 @@ public sealed record Vector(
     // DurableEffectLedger puts run-once in a folder rather than in the instance's memory.
     // Together they are the only way to certify that an effect outcome survives a crash.
     bool NewInstancePerPrompt = false,
-    bool DurableEffectLedger = false);
+    bool DurableEffectLedger = false,
+
+    // A scripted authority — "pending", "approved", "denied" — answered in order, so a vector can
+    // hold an act on one run and permit it on the next. That is the shape of every real approval:
+    // the answer arrives after the agent already stopped.
+    List<string>? ApprovalDecisions = null);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -5,6 +5,7 @@
 
 using System.Text.Json;
 using Standard.Agents;
+using Standard.Agents.Brokers.Approvals;
 using Standard.Agents.Conformance;
 using Standard.Agents.Models.Brokers.Audits;
 
@@ -168,6 +169,10 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     // The order the run was unwound in, written by the stubs as they reverse themselves.
     List<string> compensationOrder = [];
 
+    Queue<ApprovalDecision> approvalDecisions = new(
+        (vector.ApprovalDecisions ?? []).Select(decision =>
+            Enum.Parse<ApprovalDecision>(decision, ignoreCase: true)));
+
     Dictionary<string, StubTool> stubTools =
         (vector.Tools ?? []).ToDictionary(
             pair => pair.Key,
@@ -285,6 +290,23 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         if (vector.RequireApproval is { Count: > 0 })
         {
             agent.RequireApproval([.. vector.RequireApproval]);
+        }
+
+        // A scripted authority, so a vector can hold an act on one run and permit it on the next
+        // — the shape of every real approval, where the answer arrives after the agent stopped.
+        // The queue is shared across instances, so the second process sees the second decision.
+        if (vector.ApprovalDecisions is { Count: > 0 })
+        {
+            agent.OnApproval(effect =>
+            {
+                lock (auditLock)
+                {
+                    return ValueTask.FromResult(
+                        approvalDecisions.Count > 0
+                            ? approvalDecisions.Dequeue()
+                            : ApprovalDecision.Pending);
+                }
+            });
         }
 
         if (vector.ScreenToolOutput)

--- a/Standard.Agents.Tests.Unit/Acceptance/ResumptionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/ResumptionTests.cs
@@ -5,6 +5,7 @@
 
 using FluentAssertions;
 using Moq;
+using Standard.Agents.Brokers.Approvals;
 using Standard.Agents.Brokers.Effects;
 using Standard.Agents.Brokers.Knowledges;
 using Standard.Agents.Brokers.Memorys;
@@ -127,6 +128,38 @@ public class ResumptionTests : IDisposable
         // then — an identity recorded only on success is one the failure case can never use
         actualSession.Should().NotBeNull();
         actualSession!.RunId.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ShouldPerformAHeldActOnceTheAuthorityApprovesItAsync()
+    {
+        // given — the first process proposes the transfer and the authority has not answered yet
+        var tool = new CountingTool();
+
+        string held = await NewProcess(tool, "ACTION: wire_transfer: 10000")
+            .RequireApproval("wire_transfer")
+            .OnApproval(effect => ValueTask.FromResult(ApprovalDecision.Pending))
+            .ProcessPromptAsync(prompt: "pay the invoice", "invoice-95", CancellationToken.None);
+
+        held.Should().Contain("waiting for approval");
+        tool.ExecutionCount.Should().Be(0);
+
+        // when — the authority says yes, and a second process resumes the run
+        var resumedTool = new CountingTool();
+
+        string actualResult = await NewProcess(
+            resumedTool,
+            "ACTION: wire_transfer: 10000",
+            "FINAL: paid")
+                .RequireApproval("wire_transfer")
+                .OnApproval(effect => ValueTask.FromResult(ApprovalDecision.Approved))
+                .ProcessPromptAsync(
+                    prompt: "yes, approve it", "invoice-95", CancellationToken.None);
+
+        // then — a held act is one that still has to be able to happen; an approval that arrives
+        // after the claim was left standing is an approval that can never be used
+        resumedTool.ExecutionCount.Should().Be(1);
+        actualResult.Should().Be("paid");
     }
 
     [Fact]

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
@@ -140,12 +140,18 @@ public partial class DirectionOrchestrationService
         AgentEffect effect,
         ApprovalDecision approval)
     {
+        // The act was held, not performed, so the claim taken when its intent was recorded is
+        // given back (SPEC.md §4.9). Leaving it standing would make the approval unusable when it
+        // finally arrives: the authority says yes, the resumed run proposes the act, and the
+        // ledger reports it as already done.
+        await this.effectLedgerBroker.DeleteClaimAsync(effect);
+
         if (approval is ApprovalDecision.Denied)
         {
             string denial = $"approval denied for '{effect.ToolName}'";
 
             await this.loggingBroker.LogProcessAsync(
-                "Direction", $"Approval → DENIED '{effect.ToolName}'");
+                "Direction", $"Approval → DENIED '{effect.ToolName}'; the claim was released");
 
             return Denied(context, denial);
         }
@@ -153,7 +159,8 @@ public partial class DirectionOrchestrationService
         // Pending. The act is held, not performed — waiting is not consent (SPEC.md §4.9).
         await this.loggingBroker.LogProcessAsync(
             "Direction",
-            $"Approval → PENDING '{effect.ToolName}'; the effect was not performed");
+            $"Approval → PENDING '{effect.ToolName}'; the effect was not performed "
+                + "and the claim was released");
 
         return context with
         {

--- a/conformance/profiles/critical.json
+++ b/conformance/profiles/critical.json
@@ -6,7 +6,7 @@
     "conversation-carries-history",
     "failed-run-unwinds-in-reverse",
     "native-tool-call-round-trips",
-    "awaiting-input-resumes-in-a-new-process",
+    "awaiting-approval-resumes-in-a-new-process",
     "effect-outcome-survives-a-crash"
   ]
 }

--- a/conformance/vectors/28-awaiting-approval-resumes-in-a-new-process.json
+++ b/conformance/vectors/28-awaiting-approval-resumes-in-a-new-process.json
@@ -1,0 +1,21 @@
+{
+  "name": "awaiting-approval-resumes-in-a-new-process",
+  "description": "SPEC.md 4.9 and 4.11, Invariant 7: an approval that arrives after the agent stopped is the only kind that happens in practice - a human is asked, the process ends, and someone answers minutes later. The first run proposes the transfer, the authority says pending, and the act is held with its claim released, because a held act is one that still has to be able to happen. A brand-new agent instance then resumes the session with the authority's yes, proposes the same act, and performs it exactly once. Leaving the claim standing would make the approval unusable: the resumed run would be told the act was already done and the transfer would never happen.",
+  "generatorReplies": [
+    "ACTION: wire_transfer: 10000",
+    "ACTION: wire_transfer: 10000",
+    "FINAL: paid"
+  ],
+  "tools": { "wire_transfer": "transfer complete" },
+  "prompt": "pay the invoice",
+  "prompts": ["pay the invoice", "yes, approve it"],
+  "sessionId": "invoice-7712",
+  "requireApproval": ["wire_transfer"],
+  "approvalDecisions": ["pending", "approved"],
+  "newInstancePerPrompt": true,
+  "durableEffectLedger": true,
+  "expect": {
+    "result": "paid",
+    "toolRunCount": { "wire_transfer": 1 }
+  }
+}


### PR DESCRIPTION
The defect, in one sentence: an approval could only ever be granted too late.

The perimeter records intent at step 2 and approves at step 3. When approval came back `Pending`, the act was held — but the claim made at step 2 stayed. The authority then said yes, the resumed run proposed the act, and the ledger reported it as already done. The transfer never happened, and nothing looked wrong.

Direction now releases the claim on both unapproved paths, denied and pending, and logs the release so the record shows the claim was given back rather than leaving a reader to infer it from an absence.

The FAIL commit is the scenario itself: a first process told to wait, a second told yes, and no transfer. 373 tests, 27 vectors.

Spec: [The-Standard-Agent-Specs#19](https://github.com/hassanhabib/The-Standard-Agent-Specs/pull/19). Brokers: [#249](https://github.com/hassanhabib/The-Standard-Agent/pull/249).

One note on coverage: `DeleteClaimAsync` also declines to release a claim that already carries an outcome. That guard is the broker holding its own contract — it is not reachable through Direction, because step 2 returns early on a prior outcome — so it is documented rather than certified.