### PR TITLE
MAJOR FOUNDATIONS: Tie A Native Tool Result To Its Call

### DIFF
--- a/Standard.Agents.Conformance/Brokers/ScriptedNativeGeneratorBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/ScriptedNativeGeneratorBroker.cs
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Generators;
+using Standard.Agents.Models.Brokers.Generators.V1;
+
+namespace Standard.Agents.Conformance;
+
+// A scripted V1 model: each reply is either a tool call or an answer, taken in order.
+//
+// It records the conversation it was handed on every call, because that is what the round-trip
+// vector actually asserts. A generator that only returned scripted replies could not tell a
+// framework that hands back a tool message naming the call from one that narrates the result as
+// prose — and the difference between those two is the whole point of native tool calling.
+public sealed class ScriptedNativeGeneratorBroker : IGeneratorBrokerV1
+{
+    private readonly IReadOnlyList<NativeReply> replies;
+    private readonly List<IReadOnlyList<ConversationMessage>> conversations = [];
+    private int index;
+
+    public ScriptedNativeGeneratorBroker(IReadOnlyList<NativeReply> replies) =>
+        this.replies = replies;
+
+    public IReadOnlyList<IReadOnlyList<ConversationMessage>> Conversations => this.conversations;
+
+    public IReadOnlyList<ToolDefinition> LastTools { get; private set; } = [];
+
+    public async ValueTask<GenerationResult> GenerateAsync(
+        IReadOnlyList<ConversationMessage> messages,
+        IReadOnlyList<ToolDefinition> tools)
+    {
+        this.conversations.Add(messages);
+        LastTools = tools;
+
+        NativeReply reply = this.index < this.replies.Count
+            ? this.replies[this.index++]
+            : new NativeReply(Content: "done");
+
+        return new GenerationResult
+        {
+            Content = reply.Content ?? string.Empty,
+
+            ToolCalls =
+            [
+                .. (reply.ToolCalls ?? []).Select(call =>
+                    new ModelToolCall(call.Id, call.Name, call.ArgumentsJson))
+            ],
+
+            PromptTokens = reply.PromptTokens,
+            CompletionTokens = reply.CompletionTokens
+        };
+    }
+}
+
+/// <summary>One scripted V1 reply, as a vector writes it.</summary>
+public sealed record NativeReply(
+    string? Content = null,
+    List<NativeToolCall>? ToolCalls = null,
+    int PromptTokens = 0,
+    int CompletionTokens = 0);
+
+public sealed record NativeToolCall(string Id, string Name, string ArgumentsJson);

--- a/Standard.Agents.Conformance/Models/Expectation.cs
+++ b/Standard.Agents.Conformance/Models/Expectation.cs
@@ -61,4 +61,11 @@ public sealed record Expectation(
     //   CompensationOrder — the exact order the tools were reversed in, which is how the reverse
     //                       unwind is certified: a later effect may depend on an earlier one, so
     //                       undoing them in the order they ran would leave state inconsistent.
-    List<string>? CompensationOrder = null);
+    List<string>? CompensationOrder = null,
+
+    //   ToolResultAnswersCall — the tool's result must come back to the model as a tool message
+    //                           naming the call that asked for it, and the assistant's request
+    //                           must be replayed alongside it. This is the one thing the text
+    //                           protocol cannot express, so it is the one thing worth certifying
+    //                           about native tool calling (SPEC.md §6).
+    string? ToolResultAnswersCall = null);

--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -77,4 +77,8 @@ public sealed record Vector(
     // A scripted authority — "pending", "approved", "denied" — answered in order, so a vector can
     // hold an act on one run and permit it on the next. That is the shape of every real approval:
     // the answer arrives after the agent already stopped.
-    List<string>? ApprovalDecisions = null);
+    List<string>? ApprovalDecisions = null,
+
+    // Native tool calling (SPEC.md §6). When set, the Brain is a V1 generator and its replies are
+    // structured choices rather than lines of text.
+    List<NativeReply>? NativeReplies = null);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -8,6 +8,7 @@ using Standard.Agents;
 using Standard.Agents.Brokers.Approvals;
 using Standard.Agents.Conformance;
 using Standard.Agents.Models.Brokers.Audits;
+using Standard.Agents.Models.Brokers.Generators.V1;
 
 string? profileName = ReadProfileArgument(args);
 
@@ -169,6 +170,12 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     // The order the run was unwound in, written by the stubs as they reverse themselves.
     List<string> compensationOrder = [];
 
+    // One scripted native model for the whole vector, so its recorded conversations survive
+    // across instances exactly as a real endpoint's would.
+    ScriptedNativeGeneratorBroker? nativeGenerator = vector.NativeReplies is { Count: > 0 }
+        ? new ScriptedNativeGeneratorBroker(vector.NativeReplies)
+        : null;
+
     Queue<ApprovalDecision> approvalDecisions = new(
         (vector.ApprovalDecisions ?? []).Select(decision =>
             Enum.Parse<ApprovalDecision>(decision, ignoreCase: true)));
@@ -319,6 +326,11 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
             agent.CompensateOnFailure();
         }
 
+        if (nativeGenerator is not null)
+        {
+            agent.UseNativeBrain(nativeGenerator);
+        }
+
         if (vector.Retries > 0)
         {
             agent.Resilience(vector.Retries);
@@ -437,7 +449,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         }
     }
 
-    return new VectorRun(result, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, promptScreenings, auditRecords, compensationOrder);
+    return new VectorRun(result, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, promptScreenings, auditRecords, compensationOrder, nativeGenerator);
 }
 
 // The decision log's guarantees, certified from the records themselves: one run per prompt,
@@ -589,6 +601,31 @@ static bool GuardianInputConformant(
         failure = "the guardian's own text became the agent's answer";
 
         return false;
+    }
+
+    // A tool result must come back as an answer to the call that asked for it (SPEC.md §6). Both
+    // halves are checked: the assistant's request replayed with its id, and the tool's answer
+    // naming that id. A framework that narrates the result as prose fails on the second.
+    if (vector.Expect.ToolResultAnswersCall is string expectedCallId)
+    {
+        IReadOnlyList<ConversationMessage> lastConversation =
+            run.NativeGenerator?.Conversations.LastOrDefault() ?? [];
+
+        bool requestReplayed = lastConversation.Any(message =>
+            message.Role is MessageRole.Assistant
+                && message.ToolCalls.Any(call => call.Id == expectedCallId));
+
+        bool answerNamesCall = lastConversation.Any(message =>
+            message.Role is MessageRole.Tool && message.ToolCallId == expectedCallId);
+
+        if (requestReplayed is false || answerNamesCall is false)
+        {
+            failure =
+                $"the model was not handed call '{expectedCallId}' and its answer "
+                    + $"(request replayed: {requestReplayed}, answer names call: {answerNamesCall})";
+
+            return false;
+        }
     }
 
     // The unwind runs in reverse, and only over what the run actually performed (SPEC.md §4.9).
@@ -771,4 +808,5 @@ internal sealed record VectorRun(
     List<string> BrainInputs,
     int PromptScreenings,
     List<AuditRecord> AuditRecords,
-    List<string> CompensationOrder);
+    List<string> CompensationOrder,
+    ScriptedNativeGeneratorBroker? NativeGenerator);

--- a/Standard.Agents.Tests.Unit/Acceptance/NativeToolCallTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/NativeToolCallTests.cs
@@ -94,6 +94,65 @@ public class NativeToolCallTests
         actualResult.Should().Be("4183");
     }
 
+    // The id is the whole point of native tool calling. A model that asked for call_1 expects the
+    // answer back as a tool message naming call_1 — that is what it was trained on, and it is the
+    // one thing the text protocol cannot express (SPEC.md §6). Replaying the result as narrated
+    // prose leaves the model matching answers to questions by reading, which is exactly the
+    // guessing native calls exist to remove.
+    [Fact]
+    public async Task ShouldReturnAToolResultTiedToTheCallThatAskedForItAsync()
+    {
+        // given
+        var tool = new CalculatorTool();
+        IReadOnlyList<ConversationMessage> secondTurn = [];
+
+        StandardAgent agent = AgentWith(tool, (tools, call) => call == 0
+            ? new GenerationResult
+            {
+                ToolCalls =
+                [
+                    new ModelToolCall("call_7", "calculator", """{"expression":"47*89"}""")
+                ]
+            }
+            : new GenerationResult { Content = "4183" });
+
+        agent = agent.OnNativeBrain((messages, tools) =>
+        {
+            if (messages.Any(message => message.Role is MessageRole.Tool))
+            {
+                secondTurn = messages;
+
+                return ValueTask.FromResult(new GenerationResult { Content = "4183" });
+            }
+
+            return ValueTask.FromResult(new GenerationResult
+            {
+                ToolCalls =
+                [
+                    new ModelToolCall("call_7", "calculator", """{"expression":"47*89"}""")
+                ]
+            });
+        });
+
+        // when
+        await agent.ProcessPromptAsync("what is 47 times 89?");
+
+        // then — the assistant's request and the tool's answer are both present, and the answer
+        // names the call it answers
+        ConversationMessage? request = secondTurn.FirstOrDefault(message =>
+            message.Role is MessageRole.Assistant && message.ToolCalls.Count > 0);
+
+        ConversationMessage? answer =
+            secondTurn.FirstOrDefault(message => message.Role is MessageRole.Tool);
+
+        request.Should().NotBeNull();
+        request!.ToolCalls[0].Id.Should().Be("call_7");
+
+        answer.Should().NotBeNull();
+        answer!.ToolCallId.Should().Be("call_7");
+        answer.Content.Should().Be("4183");
+    }
+
     private sealed class UndescribedTool : ITool
     {
         public string Name => "secret";

--- a/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
@@ -20,6 +20,16 @@ public sealed record AgentContext
     public string SystemPrompt { get; init; } = "";
     public IReadOnlyList<string> Observations { get; init; } = [];
 
+    // What a native call asked for and what came back, kept as a pair (SPEC.md §6). Observations
+    // alone cannot express this: they are prose, and prose cannot say WHICH call a result answers.
+    // On the V0 text path this stays empty and observations remain the whole record, which is the
+    // limitation that path has always had.
+    public IReadOnlyList<ToolExchange> ToolExchanges { get; init; } = [];
+
+    // The call Direction is performing this turn, so its result can be tied back to it. Empty
+    // outside the native path.
+    public string ToolCallId { get; init; } = "";
+
     public string Intent { get; init; } = "";
     public string Route { get; init; } = "";
     public string DirectionType { get; init; } = "";

--- a/Standard.Agents/Models/Orchestrations/Agents/ToolExchange.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/ToolExchange.cs
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Orchestrations.Agents;
+
+/// <summary>
+/// One native tool call and its result, kept together.
+/// </summary>
+/// <remarks>
+/// The id is the whole point. A hosted model that asked for a call expects the answer back as a
+/// tool message naming that call — that is what it was trained on, and it is the one thing the
+/// text protocol cannot express (SPEC.md §6). Replaying the result as narrated prose instead
+/// leaves the model to match answers to questions by reading, which is exactly the guessing
+/// native tool calling exists to remove.
+/// </remarks>
+public sealed record ToolExchange(
+    string CallId,
+    string ToolName,
+    string ArgumentsJson,
+    string Result);

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.V1.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.V1.cs
@@ -88,13 +88,49 @@ public partial class BrainService
             Content = context.Prompt
         };
 
-        if (context.Observations.Count > 0)
+        // Native calls go back as what they were: the assistant's request, then the tool's answer
+        // naming the call it answers (SPEC.md §6). This is the shape hosted models are trained on,
+        // and it is the reason the id exists — narrating "calculator: 4183" would leave the model
+        // matching answers to questions by reading.
+        foreach (ToolExchange exchange in context.ToolExchanges)
+        {
+            yield return new ConversationMessage
+            {
+                Role = MessageRole.Assistant,
+
+                ToolCalls =
+                [
+                    new ModelToolCall(
+                        exchange.CallId, exchange.ToolName, exchange.ArgumentsJson)
+                ]
+            };
+
+            yield return new ConversationMessage
+            {
+                Role = MessageRole.Tool,
+                ToolCallId = exchange.CallId,
+                Content = exchange.Result
+            };
+        }
+
+        // What is left is everything the exchanges do not already carry — a denial, a screening
+        // refusal, a V0-shaped observation. Dropping these would lose the very results the
+        // perimeter withheld, which are the ones the model most needs to see.
+        string[] alreadySent =
+            [.. context.ToolExchanges.Select(exchange =>
+                $"{exchange.ToolName}: {exchange.Result}")];
+
+        string[] narrated =
+            [.. context.Observations.Where(observation =>
+                alreadySent.Contains(observation, StringComparer.Ordinal) is false)];
+
+        if (narrated.Length > 0)
         {
             yield return new ConversationMessage
             {
                 Role = MessageRole.Assistant,
                 Content = "Observations so far:\n"
-                    + string.Join('\n', context.Observations.Select(o => $"- {o}"))
+                    + string.Join('\n', narrated.Select(o => $"- {o}"))
             };
         }
     }

--- a/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Native.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/DecisionOrchestrationService.Native.cs
@@ -43,6 +43,7 @@ public partial class DecisionOrchestrationService
                 Intent = RespondIntent,
                 DirectionType = ReturnResponseDirection,
                 Payload = result.Content,
+                ToolCallId = string.Empty,
                 RawReply = result.Content
             };
         }
@@ -61,6 +62,9 @@ public partial class DecisionOrchestrationService
             Intent = call.Name,
             DirectionType = call.Name,
             Payload = call.ArgumentsJson,
+
+            // Carried so Direction can tie the result back to the call that asked for it.
+            ToolCallId = call.Id,
             RawReply = result.Content
         };
     }

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
@@ -128,6 +128,7 @@ public partial class DirectionOrchestrationService
         {
             Result = refusal,
             Observations = [.. context.Observations, $"{context.DirectionType}: {refusal}"],
+            ToolExchanges = WithExchange(context, refusal),
             Status = AgentStatus.Working
         };
     }
@@ -243,14 +244,32 @@ public partial class DirectionOrchestrationService
         {
             Result = reason,
             Observations = [.. context.Observations, $"{context.DirectionType}: {reason}"],
+            ToolExchanges = WithExchange(context, reason),
             Status = AgentStatus.Working
         };
+
+    // A call the model made gets an answer, whatever the answer is. A denial and a withheld
+    // result are answers; leaving the call unanswered would strand it, and some providers reject
+    // a conversation whose tool call has no matching tool message (SPEC.md §6).
+    private static IReadOnlyList<ToolExchange> WithExchange(AgentContext context, string result) =>
+        string.IsNullOrEmpty(context.ToolCallId)
+            ? context.ToolExchanges
+            : [.. context.ToolExchanges,
+                new ToolExchange(
+                    context.ToolCallId, context.DirectionType, context.Payload, result)];
 
     private static AgentContext Observed(AgentContext context, string output) =>
         context with
         {
             Result = output,
             Observations = [.. context.Observations, $"{context.DirectionType}: {output}"],
+
+            // On the native path the result is also kept beside the call that asked for it, so
+            // the next turn can hand it back as a tool message rather than as narration
+            // (SPEC.md §6). Observations still carry it too: they are what the V0 path reads,
+            // and what the trace and the Judge read on both.
+            ToolExchanges = WithExchange(context, output),
+
             Status = AgentStatus.Working
         };
 

--- a/conformance/vectors/29-native-tool-call-round-trips.json
+++ b/conformance/vectors/29-native-tool-call-round-trips.json
@@ -1,0 +1,25 @@
+{
+  "name": "native-tool-call-round-trips",
+  "description": "SPEC.md 6: a hosted model that asked for call_7 expects the answer back as a tool message naming call_7 - that is what it was trained on, and it is the one thing the text protocol cannot express. The model asks for the calculator natively, the framework performs it, and the next turn hands back the assistant's request with its id and the tool's answer against that id. Narrating the result as prose instead would leave the model matching answers to questions by reading, which is exactly the guessing native tool calling exists to remove. Adopting native calls changes how a choice is READ, not what the agent is: the same tool ran, with the arguments the model sent.",
+  "generatorReplies": [],
+  "nativeReplies": [
+    {
+      "toolCalls": [
+        {
+          "id": "call_7",
+          "name": "calculator",
+          "argumentsJson": "{\"expression\":\"47*89\"}"
+        }
+      ]
+    },
+    { "content": "4183" }
+  ],
+  "tools": { "calculator": "4183" },
+  "prompt": "what is 47 times 89?",
+  "expect": {
+    "result": "4183",
+    "toolRunCount": { "calculator": 1 },
+    "toolInput": { "calculator": "{\"expression\":\"47*89\"}" },
+    "toolResultAnswersCall": "call_7"
+  }
+}


### PR DESCRIPTION
The V1 generator landed, but the loop still narrated tool results back as prose. A model that asked for `call_7` got `- calculator: 4183` in an assistant message — which means it has to match answers to questions by reading. That is exactly the guessing native tool calling exists to remove, and the id is the one thing the text protocol cannot express (SPEC.md §6).

- `ToolExchange` keeps a call and its result together; `AgentContext` carries the exchanges and the call currently being performed.
- The V1 conversation now replays the assistant''s request with its id, then a tool message answering that id.
- **Every** outcome answers the call, not just a success. A denial and a screening refusal are answers too; leaving a call unanswered strands it, and some providers reject a conversation whose tool call has no matching tool message.
- Observations still carry everything — they are what the V0 path reads, and what the trace and the Judge read on both. Only the ones already sent as tool messages are left out of the narration, matched exactly rather than by resemblance.

V0 is untouched: no exchange is recorded when there is no call id, so the text path behaves exactly as before.

Vector 29 certifies both halves and was sabotage-verified twice — dropping the id from the tool message fails it, and dropping the replayed request fails it. 374 tests, 29 vectors, Enterprise certified. This closes the last uncertified 1.0 exit criterion.