### PR TITLE
MEDIUM CLIENTS: Resume A Session

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/ResumptionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/ResumptionTests.cs
@@ -163,6 +163,33 @@ public class ResumptionTests : IDisposable
     }
 
     [Fact]
+    public async Task ShouldFinishAHeldRunThroughResumeAsync()
+    {
+        // given — the authority has not answered, so the act is held
+        var tool = new CountingTool();
+
+        await NewProcess(tool, "ACTION: wire_transfer: 10000")
+            .RequireApproval("wire_transfer")
+            .OnApproval(effect => ValueTask.FromResult(ApprovalDecision.Pending))
+            .ProcessPromptAsync(prompt: "pay the invoice", "invoice-97", CancellationToken.None);
+
+        // when — a different process resumes the conversation with the authority's yes
+        var resumedTool = new CountingTool();
+
+        string actualResult = await NewProcess(
+            resumedTool,
+            "ACTION: wire_transfer: 10000",
+            "FINAL: paid")
+                .RequireApproval("wire_transfer")
+                .OnApproval(effect => ValueTask.FromResult(ApprovalDecision.Approved))
+                .ResumeAsync(sessionId: "invoice-97", answer: "yes, approve it");
+
+        // then — resuming asks nothing of the caller but the answer; the session holds the rest
+        resumedTool.ExecutionCount.Should().Be(1);
+        actualResult.Should().Be("paid");
+    }
+
+    [Fact]
     public async Task ShouldStartAFreshRunAfterTheSessionDeliveredAnAnswerAsync()
     {
         // given — the first prompt answers, which completes the run

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -816,6 +816,39 @@ public sealed partial class StandardAgent : IAgent
     }
 
     /// <summary>
+    /// Continues a session that stopped in the middle of something — waiting on a person, waiting
+    /// on an authority, or killed outright (SPEC.md §4.9, §4.11).
+    /// </summary>
+    /// <remarks>
+    /// This is the same call as <see cref="ProcessPromptAsync(string, string, CancellationToken)"/>
+    /// and reads the answer the same way; it exists because <i>resuming</i> is what the caller is
+    /// doing, and a verb that says so is worth more than one saved line of documentation.
+    /// <para>A session that never delivered an answer keeps the interrupted run's identity, so an
+    /// act it already performed is recognised as its own and replayed rather than performed twice.
+    /// That only holds across processes if the ledger is durable — see
+    /// <see cref="EffectLedger(string)"/>; the built-in one lives in memory and dies with the
+    /// instance.</para>
+    /// <para>Nothing is required of the caller beyond the answer. There is no separate resume
+    /// mode and no state to hand back: the session already holds everything, which is what makes
+    /// a different process able to pick it up.</para>
+    /// </remarks>
+    /// <param name="sessionId">The conversation to continue.</param>
+    /// <param name="answer">
+    /// What the agent was waiting for — a reply to its question, or an authority's decision.
+    /// </param>
+    /// <param name="cancellationToken">Token to stop the run.</param>
+    /// <returns>The agent's answer, now that it can finish.</returns>
+    public async ValueTask<string> ResumeAsync(
+        string sessionId,
+        string answer,
+        CancellationToken cancellationToken = default)
+    {
+        await ValueTask.CompletedTask;
+
+        return string.Empty;
+    }
+
+    /// <summary>
     /// Keeps conversations in a folder, one file per session — the <b>Local</b> mode of sessions.
     /// </summary>
     /// <param name="path">Folder to keep sessions in.</param>

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -843,9 +843,7 @@ public sealed partial class StandardAgent : IAgent
         string answer,
         CancellationToken cancellationToken = default)
     {
-        await ValueTask.CompletedTask;
-
-        return string.Empty;
+        return await ResolveAgent().ProcessPromptAsync(answer, sessionId, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
`ResumeAsync(sessionId, answer)` — the verb the plan promised, and the one a caller continuing a held run is actually reaching for.

It is the same call underneath, deliberately: there is no separate resume mode to keep correct alongside the normal one. It asks nothing of the caller but the answer, because the session already holds the rest — which is exactly what makes a different process able to pick it up.

```csharp
await agent.ResumeAsync(sessionId: "invoice-97", answer: "yes, approve it");
```

Proven end to end: a first process is told `Pending` and stops; a second, separately constructed, resumes with the authority''s yes and the transfer goes out exactly once. 375 tests.