### PR TITLE
BUILD: Grant The Release Workflow Write Access To The Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     # Provenance attestation needs to write an attestation and read the workflow identity.
+    # `contents: write` is on top of that, because attaching the package and the bill of
+    # materials to the release updates the release itself — read is enough to build, and not
+    # enough to ship.
     permissions:
-      contents: read
+      contents: write
       id-token: write
       attestations: write
 


### PR DESCRIPTION
The `v1.0.0` run built, tested, certified, packed and attested — then failed attaching the artifacts, because `contents: read` cannot update a release. That step sits immediately before the NuGet push, so **nothing was published**; the tag and release exist and the package does not.

`contents: write` is the fix. Read is enough to build and not enough to ship.

Once this is on main the release will be re-cut at the fixed commit, since a re-run would replay the workflow file as it was at the tag.