### PR TITLE
MAJOR ORCHESTRATIONS: Carry The Principal Into Authorization

### DIFF
--- a/Standard.Agents.Conformance/Models/Expectation.cs
+++ b/Standard.Agents.Conformance/Models/Expectation.cs
@@ -68,4 +68,9 @@ public sealed record Expectation(
     //                           must be replayed alongside it. This is the one thing the text
     //                           protocol cannot express, so it is the one thing worth certifying
     //                           about native tool calling (SPEC.md §6).
-    string? ToolResultAnswersCall = null);
+    string? ToolResultAnswersCall = null,
+
+    //   PolicySawPrincipal — the identity the policy broker was actually handed when it decided.
+    //                        An audit record naming the caller afterwards is not authorization,
+    //                        so this reads the decision's input rather than the log (SPEC.md §4.9).
+    string? PolicySawPrincipal = null);

--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -81,4 +81,12 @@ public sealed record Vector(
 
     // Native tool calling (SPEC.md §6). When set, the Brain is a V1 generator and its replies are
     // structured choices rather than lines of text.
-    List<NativeReply>? NativeReplies = null);
+    List<NativeReply>? NativeReplies = null,
+
+    // Identity (SPEC.md §4.9). Who the host says is acting. Set it and the policy broker must be
+    // told; leave it and the effect must claim no identity rather than invent one.
+    string? Principal = null,
+
+    // Tools this principal may not act with, refused by policy on the identity alone. This is a
+    // scripted policy engine, not the allow-list: the allow-list cannot express "not for them".
+    List<string>? DeniedForPrincipal = null);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -9,6 +9,7 @@ using Standard.Agents.Brokers.Approvals;
 using Standard.Agents.Conformance;
 using Standard.Agents.Models.Brokers.Audits;
 using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Orchestrations.Effects;
 
 string? profileName = ReadProfileArgument(args);
 
@@ -169,6 +170,9 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
 {
     // The order the run was unwound in, written by the stubs as they reverse themselves.
     List<string> compensationOrder = [];
+
+    // Every identity the policy broker was handed, in order.
+    List<string?> policyPrincipals = [];
 
     // One scripted native model for the whole vector, so its recorded conversations survive
     // across instances exactly as a real endpoint's would.
@@ -331,6 +335,31 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
             agent.UseNativeBrain(nativeGenerator);
         }
 
+        if (vector.Principal is not null)
+        {
+            agent.Principal(() => vector.Principal);
+        }
+
+        // A scripted policy engine that decides on the identity, which the allow-list cannot do:
+        // it can say "not this tool", never "not for them". The principal it was handed is
+        // recorded, because the decision's input is the thing worth certifying.
+        if (vector.Principal is not null || vector.DeniedForPrincipal is { Count: > 0 })
+        {
+            agent.OnPolicy(effect =>
+            {
+                lock (auditLock)
+                {
+                    policyPrincipals.Add(effect.Principal);
+                }
+
+                return ValueTask.FromResult(
+                    (vector.DeniedForPrincipal ?? []).Contains(effect.ToolName)
+                        ? AuthorizationDecision.Deny(
+                            $"'{effect.Principal}' may not use '{effect.ToolName}'")
+                        : AuthorizationDecision.Allow());
+            });
+        }
+
         if (vector.Retries > 0)
         {
             agent.Resilience(vector.Retries);
@@ -449,7 +478,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         }
     }
 
-    return new VectorRun(result, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, promptScreenings, auditRecords, compensationOrder, nativeGenerator);
+    return new VectorRun(result, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, promptScreenings, auditRecords, compensationOrder, nativeGenerator, policyPrincipals);
 }
 
 // The decision log's guarantees, certified from the records themselves: one run per prompt,
@@ -601,6 +630,32 @@ static bool GuardianInputConformant(
         failure = "the guardian's own text became the agent's answer";
 
         return false;
+    }
+
+    // Identity must reach the decision, not only the record of it (SPEC.md §4.9). This reads what
+    // the policy broker was handed; an implementation that names the caller in the audit log and
+    // authorizes without them fails here, which is exactly the defect this vector exists for.
+    if (vector.Expect.PolicySawPrincipal is string expectedPrincipal)
+    {
+        if (run.PolicyPrincipals.Count is 0)
+        {
+            failure = "policy was never asked, so it cannot have been told who was acting";
+
+            return false;
+        }
+
+        string?[] wrong =
+            [.. run.PolicyPrincipals.Where(principal =>
+                string.Equals(principal, expectedPrincipal, StringComparison.Ordinal) is false)];
+
+        if (wrong.Length > 0)
+        {
+            failure =
+                $"policy decided for principal(s) [{string.Join(", ", wrong.Select(p => p ?? "null"))}], "
+                    + $"expected '{expectedPrincipal}' every time";
+
+            return false;
+        }
     }
 
     // A tool result must come back as an answer to the call that asked for it (SPEC.md §6). Both
@@ -809,4 +864,5 @@ internal sealed record VectorRun(
     int PromptScreenings,
     List<AuditRecord> AuditRecords,
     List<string> CompensationOrder,
-    ScriptedNativeGeneratorBroker? NativeGenerator);
+    ScriptedNativeGeneratorBroker? NativeGenerator,
+    List<string?> PolicyPrincipals);

--- a/Standard.Agents.Tests.Unit/Acceptance/IdentityTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/IdentityTests.cs
@@ -1,0 +1,166 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Models.Orchestrations.Effects;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// Identity-aware authorization (SPEC.md §4.9). The Enterprise profile claims it, and the claim is
+// only true if the principal reaches the decision — not merely the record of it. A policy engine
+// asked "may this act happen?" without being told whose act it is can answer nothing about
+// identity, however faithfully the audit log names the caller afterwards.
+public class IdentityTests
+{
+    private sealed class CountingTool : ITool
+    {
+        public string Name => "wire_transfer";
+        public string Description => "Moves money.";
+        public string Parameters => "{}";
+
+        public int ExecutionCount { get; private set; }
+
+        public ValueTask<string> ExecuteAsync(string input)
+        {
+            ExecutionCount++;
+
+            return ValueTask.FromResult("transfer complete");
+        }
+    }
+
+    private static StandardAgent AgentThatCallsTheTool(CountingTool tool, params string[] replies)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        var scriptedReplies = new Queue<string>(replies);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .Tool(tool)
+            .OnBrain(async (systemPrompt, userPrompt) =>
+                scriptedReplies.Count > 0 ? scriptedReplies.Dequeue() : "FINAL: done");
+    }
+
+    [Fact]
+    public async Task ShouldCarryThePrincipalIntoTheAuthorizationDecisionAsync()
+    {
+        // given
+        var tool = new CountingTool();
+        string? seenByPolicy = null;
+
+        StandardAgent agent =
+            AgentThatCallsTheTool(tool, "ACTION: wire_transfer: 10000", "FINAL: paid")
+                .Principal(() => "teller-42")
+                .OnPolicy(effect =>
+                {
+                    seenByPolicy = effect.Principal;
+
+                    return ValueTask.FromResult(AuthorizationDecision.Allow());
+                });
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "pay the invoice");
+
+        // then — an audit trail that names the caller after the fact is not authorization
+        seenByPolicy.Should().Be("teller-42");
+    }
+
+    [Fact]
+    public async Task ShouldLetPolicyRefuseAnActOnTheIdentityAloneAsync()
+    {
+        // given — the same act, permitted for one principal and not the other
+        var tool = new CountingTool();
+        string secondPrompt = string.Empty;
+        int brainCalls = 0;
+
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        StandardAgent agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .Tool(tool)
+            .Principal(() => "intern-9")
+            .OnBrain(async (systemPrompt, userPrompt) =>
+            {
+                brainCalls++;
+
+                if (brainCalls > 1)
+                {
+                    secondPrompt = userPrompt;
+                }
+
+                return brainCalls == 1
+                    ? "ACTION: wire_transfer: 10000"
+                    : "FINAL: I could not do that";
+            })
+            .OnPolicy(effect => ValueTask.FromResult(
+                effect.Principal is "teller-42"
+                    ? AuthorizationDecision.Allow()
+                    : AuthorizationDecision.Deny(
+                        $"'{effect.Principal}' may not move money")));
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync(prompt: "pay the invoice");
+
+        // then — the denial names who was refused, which is what makes it reviewable
+        tool.ExecutionCount.Should().Be(0);
+        secondPrompt.Should().Contain("'intern-9' may not move money");
+        actualResult.Should().Be("I could not do that");
+    }
+
+    [Fact]
+    public async Task ShouldCarryNoPrincipalWhenNoneIsConfiguredAsync()
+    {
+        // given — the neutral case: nothing configured, nothing asserted about identity
+        var tool = new CountingTool();
+        bool policyRan = false;
+        string? seenByPolicy = "not asked";
+
+        StandardAgent agent =
+            AgentThatCallsTheTool(tool, "ACTION: wire_transfer: 10000", "FINAL: paid")
+                .OnPolicy(effect =>
+                {
+                    policyRan = true;
+                    seenByPolicy = effect.Principal;
+
+                    return ValueTask.FromResult(AuthorizationDecision.Allow());
+                });
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "pay the invoice");
+
+        // then — absent an identity the effect claims none, rather than inventing one
+        policyRan.Should().BeTrue();
+        seenByPolicy.Should().BeNull();
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
@@ -28,7 +28,12 @@ public partial class DirectionOrchestrationService
             arguments: context.Payload,
             riskLevel: RiskLevelFor(context.DirectionType),
             approvalRequired: RequiresApproval(context.DirectionType),
-            principal: null);
+
+            // Who is acting, asked at the moment the act is described — so the policy broker
+            // deciding whether it may happen is told, not merely the record written afterwards
+            // (SPEC.md §4.9). Null when the host configured no identity, which claims nothing
+            // rather than inventing someone.
+            principal: this.principalResolver?.Invoke());
 
         // 1 — authorize
         AuthorizationDecision decision = await this.policyBroker.AuthorizeAsync(effect);

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -31,6 +31,11 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
     private readonly IGateService? screeningService;
     private readonly HashSet<string> irreversibleToolNames;
 
+    // Asked once per act rather than captured once at composition, because who is acting can
+    // change between prompts on the same agent — a singleton serving many callers is the shape
+    // this framework asks hosts to adopt (SPEC.md §4.4).
+    private readonly Func<string?>? principalResolver;
+
     public DirectionOrchestrationService(
         IInternalToolService internalToolService,
         IExternalToolService externalToolService,
@@ -41,9 +46,11 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
         IApprovalBroker? approvalBroker = null,
         IEffectLedgerBroker? effectLedgerBroker = null,
         IEnumerable<string>? irreversibleTools = null,
-        IGateService? screeningService = null)
+        IGateService? screeningService = null,
+        Func<string?>? principalResolver = null)
     {
         this.screeningService = screeningService;
+        this.principalResolver = principalResolver;
 
         this.internalToolService = internalToolService;
         this.externalToolService = externalToolService;

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -1158,7 +1158,8 @@ public sealed partial class StandardAgent : IAgent
                     : new RequireApprovalBroker(this.approvalRequiredTools)),
             this.effectLedgerBroker,
             this.approvalRequiredTools,
-            this.screenToolOutput ? gate : null);
+            this.screenToolOutput ? gate : null,
+            this.principalResolver);
 
         return new AgentCoordinationService(
             data, decision, direction, logging, this.maxTurns, new TimeBroker(), this.budget,

--- a/conformance/profiles/enterprise.json
+++ b/conformance/profiles/enterprise.json
@@ -4,6 +4,7 @@
   "inherits": "Reliable",
   "requires": [
     "approval-blocks-irreversible-tool",
+    "policy-authorizes-on-identity",
     "injected-instruction-in-tool-output-is-refused",
     "duplicate-effect-executes-once",
     "budget-stops-the-loop",

--- a/conformance/vectors/30-policy-authorizes-on-identity.json
+++ b/conformance/vectors/30-policy-authorizes-on-identity.json
@@ -1,0 +1,23 @@
+{
+  "name": "policy-authorizes-on-identity",
+  "description": "SPEC.md 4.9: authorization is a judgment about an act, and who is acting is part of what the act IS. The host declares a principal; the policy broker must be handed it at the moment it decides, not merely have it written to the audit log afterwards. Here the principal may use the calculator and may not move money - a refusal the allow-list cannot express, because an allow-list can say 'not this tool' and never 'not for them'. The denial names who was refused, which is what makes it reviewable. An implementation that records the caller and authorizes without them passes every audit check and fails this.",
+  "generatorReplies": [
+    "ACTION: wire_transfer: 10000",
+    "ACTION: calculator: 2+2",
+    "FINAL: I could not move the money, but 2+2 is 4"
+  ],
+  "tools": {
+    "wire_transfer": "transfer complete",
+    "calculator": "4"
+  },
+  "prompt": "pay the invoice and add two and two",
+  "principal": "intern-9",
+  "deniedForPrincipal": ["wire_transfer"],
+  "expect": {
+    "result": "I could not move the money, but 2+2 is 4",
+    "policySawPrincipal": "intern-9",
+    "toolNeverRan": ["wire_transfer"],
+    "toolRunCount": { "calculator": 1 },
+    "brainSees": "'intern-9' may not use 'wire_transfer'"
+  }
+}


### PR DESCRIPTION
**A defect in a certified profile.** Enterprise is described as *identity-aware authorization*. It was not.

`AgentEffect.For(...)` was called with `principal: null`, hardcoded, and `.Principal(...)` was wired only into the `LoggingBroker`. So the audit trail named the caller and the policy broker — the thing actually deciding whether the act may happen — always saw `null`. An audit record written after the fact is not authorization.

Nothing caught it: no test read the effect the policy broker was handed, and no vector exercised a policy that decides on identity. Both now exist.

- The resolver reaches Direction and is invoked **per act**, not captured at composition — who is acting changes between prompts on the same agent, which is the singleton shape this framework asks hosts to adopt.
- Absent an identity the effect carries `null`, claiming nothing rather than inventing someone. Certified by its own test.
- **Vector 30** refuses an act on the identity alone — something the allow-list structurally cannot express, since it can say "not this tool" and never "not for them" — and asserts the denial names who was refused. It reads the *decision''s input*, not the log, so an implementation with this exact defect fails it.

Vector 30 is now required by **Enterprise**, the profile that made the claim. 378 tests, 30 vectors, sabotage-verified.