### PR TITLE
MAJOR COORDINATIONS: Enforce Every Control On The Streamed Path

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/StreamParityTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/StreamParityTests.cs
@@ -1,0 +1,200 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// One prompt, two doors. Invariant 6 already says a control must hold "on every path by which a
+// prompt can be processed", and names the batched and the streamed loop specifically. It says that
+// about guardian neutralization, but the reason generalizes: a control a caller can step around by
+// changing method is not a control.
+//
+// Budgets, cancellation and sessions were enforced on the batched path only.
+public class StreamParityTests : IDisposable
+{
+    private readonly string sessionsPath =
+        Path.Combine(Path.GetTempPath(), $"standard-agent-stream-{Guid.NewGuid():n}");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this.sessionsPath))
+        {
+            Directory.Delete(this.sessionsPath, recursive: true);
+        }
+    }
+
+    private sealed class CountingTool : ITool
+    {
+        public string Name => "calculator";
+        public string Description => "Evaluates arithmetic.";
+        public string Parameters => "{}";
+
+        public int ExecutionCount { get; private set; }
+
+        public ValueTask<string> ExecuteAsync(string input)
+        {
+            ExecutionCount++;
+
+            return ValueTask.FromResult("4183");
+        }
+    }
+
+    private static StandardAgent AgentThatLoops(
+        CountingTool tool,
+        Func<string, string, ValueTask<string>> brain)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .Tool(tool)
+            .OnBrain(brain);
+    }
+
+    private static async Task<List<AgentStreamEvent>> DrainAsync(
+        IAsyncEnumerable<AgentStreamEvent> events)
+    {
+        List<AgentStreamEvent> drained = [];
+
+        await foreach (AgentStreamEvent streamEvent in events)
+        {
+            drained.Add(streamEvent);
+        }
+
+        return drained;
+    }
+
+    [Fact]
+    public async Task ShouldStopAStreamedRunWhenCancelledAsync()
+    {
+        // given — a model that would loop forever, and a token already cancelled
+        var tool = new CountingTool();
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        StandardAgent agent = AgentThatLoops(
+            tool,
+            async (systemPrompt, userPrompt) => "ACTION: calculator: 47*89")
+            .MaxTurns(50);
+
+        // when
+        List<AgentStreamEvent> actualEvents =
+            await DrainAsync(agent.StreamPromptAsync("loop", cancellation.Token));
+
+        // then — a cancelled run stops at the turn boundary and says so, on this path too
+        tool.ExecutionCount.Should().Be(0);
+
+        actualEvents.Should().Contain(streamEvent =>
+            streamEvent.Content.Contains("cancelled"));
+    }
+
+    [Fact]
+    public async Task ShouldStopAStreamedRunWhenTheBudgetIsExhaustedAsync()
+    {
+        // given — a model that would loop forever, and no time to do it in
+        var tool = new CountingTool();
+
+        StandardAgent agent = AgentThatLoops(
+            tool,
+            async (systemPrompt, userPrompt) => "ACTION: calculator: 47*89")
+            .MaxTurns(50)
+            .Budget(maxWallClock: TimeSpan.Zero);
+
+        // when
+        List<AgentStreamEvent> actualEvents =
+            await DrainAsync(agent.StreamPromptAsync("loop"));
+
+        // then — a budget a caller can step around by streaming is not a budget
+        actualEvents.Should().Contain(streamEvent =>
+            streamEvent.Content.Contains("budget"));
+    }
+
+    [Fact]
+    public async Task ShouldCarryTheConversationOnAStreamedRunAsync()
+    {
+        // given — the first prompt is answered on the batched path
+        var tool = new CountingTool();
+        string secondPrompt = string.Empty;
+
+        StandardAgent first = AgentThatLoops(
+            tool,
+            async (systemPrompt, userPrompt) => "FINAL: Paris")
+            .Sessions(this.sessionsPath);
+
+        await first.ProcessPromptAsync(
+            "what is the capital of France?", "trip-3", CancellationToken.None);
+
+        // when — the follow-up is streamed
+        StandardAgent second = AgentThatLoops(
+            tool,
+            async (systemPrompt, userPrompt) =>
+            {
+                secondPrompt = userPrompt;
+
+                return "FINAL: about two million";
+            })
+            .Sessions(this.sessionsPath);
+
+        await DrainAsync(second.StreamPromptAsync(
+            "and how many people live there?", "trip-3", CancellationToken.None));
+
+        // then — the streamed path loads the conversation like the batched one does
+        secondPrompt.Should().Contain("Paris");
+    }
+
+    [Fact]
+    public async Task ShouldRecordAStreamedExchangeInTheConversationAsync()
+    {
+        // given
+        var tool = new CountingTool();
+
+        StandardAgent agent = AgentThatLoops(
+            tool,
+            async (systemPrompt, userPrompt) => "FINAL: Paris")
+            .Sessions(this.sessionsPath);
+
+        // when — the first exchange happens on the streamed path
+        await DrainAsync(agent.StreamPromptAsync(
+            "what is the capital of France?", "trip-9", CancellationToken.None));
+
+        string thirdPrompt = string.Empty;
+
+        StandardAgent follower = AgentThatLoops(
+            tool,
+            async (systemPrompt, userPrompt) =>
+            {
+                thirdPrompt = userPrompt;
+
+                return "FINAL: about two million";
+            })
+            .Sessions(this.sessionsPath);
+
+        await follower.ProcessPromptAsync(
+            "and how many people live there?", "trip-9", CancellationToken.None);
+
+        // then — a streamed answer is part of the conversation, not lost from it
+        thirdPrompt.Should().Contain("Paris");
+    }
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Budgets.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Budgets.cs
@@ -79,6 +79,37 @@ public partial class AgentCoordinationService
             : $"{message} {unwound}";
     }
 
+    // An async iterator cannot put a catch clause around a yield, so the streamed loop unwinds
+    // through these instead of through one try around the whole body. They cover the two steps
+    // that do not yield — and Direction, the one that performs effects, is among them.
+    private async ValueTask<AgentContext> RecallOrUnwindAsync(AgentContext context)
+    {
+        try
+        {
+            return await this.dataOrchestrationService.RecallAsync(context);
+        }
+        catch (Exception)
+        {
+            await UnwindAsync();
+
+            throw;
+        }
+    }
+
+    private async ValueTask<AgentContext> ActOrUnwindAsync(AgentContext context)
+    {
+        try
+        {
+            return await this.directionOrchestrationService.ActAsync(context);
+        }
+        catch (Exception)
+        {
+            await UnwindAsync();
+
+            throw;
+        }
+    }
+
     // A run that stopped without delivering an answer may have left effects behind. Compensation
     // (SPEC.md §4.9) asks Direction to unwind them, and the caller is told what stood — reporting
     // a run cleanly unwound when it was not is worse than never offering compensation at all.

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -200,20 +200,43 @@ public partial class AgentCoordinationService : IAgentCoordinationService
     {
         ValidatePrompt(prompt);
 
+        AgentSession? session = await PeekSessionAsync(sessionId);
+
         // This prompt's run — see ProcessPromptAsync. A streamed prompt is a run like any other,
         // which is the whole point: every control below is the one the batched loop enforces.
-        using IDisposable run = AgentRun.Begin();
+        using IDisposable run = AgentRun.Begin(ResumedRunId(session));
 
         await this.loggingBroker.LogResetAsync();
 
-        AgentContext context = new() { Prompt = prompt };
+        AgentContext context = new() { Prompt = prompt, SessionId = sessionId };
+
+        await BeginSessionAsync(context, session);
+        context = await LoadSessionAsync(context, session);
+
+        var spend = new AgentSpend();
+        DateTimeOffset startedOn = this.timeBroker.GetCurrentDateTimeOffset();
+        string? stoppedBecause = null;
 
         for (int turn = 0; turn < this.maxTurns; turn++)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                stoppedBecause = CancelledMessage;
+
+                break;
+            }
+
+            if (IsBudgetExhausted(spend, startedOn, out string exhaustion))
+            {
+                stoppedBecause = exhaustion;
+
+                break;
+            }
+
             await this.loggingBroker.LogTurnAsync(turn);
 
             await this.loggingBroker.LogStepAsync(AgentStep.Data);
-            context = await this.dataOrchestrationService.RecallAsync(context);
+            context = await RecallOrUnwindAsync(context);
 
             await this.loggingBroker.LogStepAsync(AgentStep.Decision);
 
@@ -228,6 +251,8 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
             context = decisionStream.Result;
 
+            spend.AddTokens(context.PromptTokens, context.CompletionTokens);
+
             if (context.Status is AgentStatus.Revising)
             {
                 await this.loggingBroker.LogOutcomeAsync($"turn {turn}: revising");
@@ -236,7 +261,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
             }
 
             await this.loggingBroker.LogStepAsync(AgentStep.Direction);
-            context = await this.directionOrchestrationService.ActAsync(context);
+            context = await ActOrUnwindAsync(context);
 
             await this.loggingBroker.LogOutcomeAsync($"turn {turn}: {context.Status}");
 
@@ -264,6 +289,18 @@ public partial class AgentCoordinationService : IAgentCoordinationService
             }
         }
 
+        // Cancelled or out of budget. Reported as a Status rather than a Response, because it is
+        // not an answer — the same distinction the batched path draws by returning the message
+        // instead of the result (SPEC.md §4.10).
+        if (stoppedBecause is not null)
+        {
+            await this.loggingBroker.LogOutcomeAsync($"stopped: {stoppedBecause}");
+
+            yield return new AgentStreamEvent(AgentStreamEventType.Status, stoppedBecause);
+
+            context = context with { Status = AgentStatus.Failed };
+        }
+
         if (context.Status is AgentStatus.Revising)
         {
             yield return new AgentStreamEvent(
@@ -273,11 +310,17 @@ public partial class AgentCoordinationService : IAgentCoordinationService
             yield return new AgentStreamEvent(
                 AgentStreamEventType.Response,
                 RetriesExhaustedMessage);
+
+            context = context with
+            {
+                Result = RetriesExhaustedMessage,
+                Status = AgentStatus.Refused
+            };
         }
 
         // The streamed loop unwinds on the same terms as the batched one. A control enforced on
         // one path and not the other is a control a caller can step around by changing method.
-        if (context.Status is AgentStatus.Working)
+        if (context.Status is AgentStatus.Working or AgentStatus.Failed)
         {
             string unwound = await UnwindAsync();
 
@@ -293,5 +336,10 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         {
             await this.dataOrchestrationService.RememberAsync(context.Remember);
         }
+
+        // Recorded on the same terms as the batched path: only a run that delivered an answer.
+        // A streamed answer that never joined the conversation would leave the next prompt
+        // blind to it, and a cancelled one recorded would tell it something that never happened.
+        await SaveSessionAsync(context, completed: stoppedBecause is null);
     }
 }

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -188,13 +188,20 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         return context.Result;
     });
 
+    public IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
+        string prompt,
+        CancellationToken cancellationToken = default) =>
+        ProcessPromptStreamAsync(prompt, string.Empty, cancellationToken);
+
     public async IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
         string prompt,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        string sessionId,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         ValidatePrompt(prompt);
 
-        // This prompt's run — see ProcessPromptAsync. A streamed prompt is a run like any other.
+        // This prompt's run — see ProcessPromptAsync. A streamed prompt is a run like any other,
+        // which is the whole point: every control below is the one the batched loop enforces.
         using IDisposable run = AgentRun.Begin();
 
         await this.loggingBroker.LogResetAsync();

--- a/Standard.Agents/Services/Coordinations/IAgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/IAgentCoordinationService.cs
@@ -21,4 +21,14 @@ public interface IAgentCoordinationService
     IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
         string prompt,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The streamed loop, in a conversation. Every control the batched loop enforces — budgets,
+    /// cancellation, sessions — holds here too: a control a caller can step around by changing
+    /// method is not a control (SPEC.md §7.6, §4.10, §4.11).
+    /// </summary>
+    IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
+        string prompt,
+        string sessionId,
+        CancellationToken cancellationToken);
 }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -969,6 +969,33 @@ public sealed partial class StandardAgent : IAgent
         }
     }
 
+    /// <summary>
+    /// Streams the agent's work as part of a <b>conversation</b> — the streamed equivalent of
+    /// <see cref="ProcessPromptAsync(string, string, CancellationToken)"/>.
+    /// </summary>
+    /// <remarks>
+    /// Every control the batched call enforces holds here too: budgets, cancellation, session
+    /// loading and the record of the exchange. A control a caller can step around by changing
+    /// method is not a control (SPEC.md §7.6).
+    /// </remarks>
+    /// <param name="prompt">The user's prompt.</param>
+    /// <param name="sessionId">Which conversation this belongs to.</param>
+    /// <param name="cancellationToken">Token to stop streaming early.</param>
+    /// <returns>An async stream of events describing the agent's run.</returns>
+    public async IAsyncEnumerable<AgentStreamEvent> StreamPromptAsync(
+        string prompt,
+        string sessionId,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        IAsyncEnumerable<AgentStreamEvent> events =
+            ResolveAgent().ProcessPromptStreamAsync(prompt, sessionId, cancellationToken);
+
+        await foreach (AgentStreamEvent streamEvent in events.WithCancellation(cancellationToken))
+        {
+            yield return streamEvent;
+        }
+    }
+
     // Composes once and reuses. Guarded because one agent serves prompts concurrently
     // (SPEC.md §4.4) and an unguarded `??=` lets two arriving prompts each build a graph —
     // two brokers over one audit sink, two of everything, one silently discarded.


### PR DESCRIPTION
**The second defect.** Invariant 6 says a control must hold "on every path by which a prompt can be processed", and names the batched and streamed loops specifically. It says that about guardian neutralization, but the reason generalizes: *a control a caller can step around by changing method is not a control.*

`ProcessPromptStreamAsync` had no cancellation check, no budget check, and no session at all — not even a `sessionId` to pass. A caller could exceed a token, cost or wall-clock budget by streaming, and a streamed answer never joined the conversation.

- Cancellation and budget are checked at the turn boundary, as on the batched path.
- Cancellation and exhaustion arrive as a **`Status`** event, not a `Response` — they are not answers, the same distinction the batched path draws by returning the message instead of the result.
- Sessions load and record. Only a run that delivered is written: a cancelled one recorded would tell the next prompt something that never happened.
- `.StreamPromptAsync(prompt, sessionId, ct)` on the client; the old signature routes through the new one.

**One honest gap.** An async iterator cannot put a catch clause around a `yield`, so exception-path unwinding goes through the two steps that do not yield. Direction — the step that performs effects — is one of them. The decision-stream enumeration is not covered, and that is stated rather than papered over.

Four parity tests, each sabotage-verified: removing the budget check, the session save, or the session load each fails a distinct one. 379 tests, 29 vectors.