### PR TITLE
MEDIUM COORDINATIONS: Remember The Act A Session Is Waiting On

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/ResumptionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/ResumptionTests.cs
@@ -221,20 +221,32 @@ public class ResumptionTests : IDisposable
     }
 
     [Fact]
-    public async Task ShouldRememberNoActWhenNothingIsHeldAsync()
+    public async Task ShouldForgetTheHeldActOnceItIsNoLongerWaitingAsync()
     {
-        // given — a run that simply answered
+        // given — an act held for approval, so the session genuinely carries one
         var tool = new CountingTool();
-
-        await NewProcess(tool, "FINAL: nothing to do")
-            .ProcessPromptAsync(prompt: "anything pending?", "invoice-101", CancellationToken.None);
-
-        // when
         var sessionBroker = new FileSessionBroker(SessionsPath);
-        AgentSession? actualSession = await sessionBroker.SelectSessionAsync("invoice-101");
 
-        // then — a session that is waiting on nothing says so
-        actualSession!.PendingEffect.Should().BeNull();
+        await NewProcess(tool, "ACTION: wire_transfer: 10000")
+            .RequireApproval("wire_transfer")
+            .OnApproval(effect => ValueTask.FromResult(ApprovalDecision.Pending))
+            .ProcessPromptAsync(prompt: "pay the invoice", "invoice-101", CancellationToken.None);
+
+        AgentSession? whileHeld = await sessionBroker.SelectSessionAsync("invoice-101");
+        whileHeld!.PendingEffect.Should().NotBeNull();
+
+        // when — the authority permits it and the run finishes
+        await NewProcess(new CountingTool(), "ACTION: wire_transfer: 10000", "FINAL: paid")
+            .RequireApproval("wire_transfer")
+            .OnApproval(effect => ValueTask.FromResult(ApprovalDecision.Approved))
+            .ProcessPromptAsync(prompt: "yes, approve it", "invoice-101", CancellationToken.None);
+
+        AgentSession? afterApproval = await sessionBroker.SelectSessionAsync("invoice-101");
+
+        // then — a session that is waiting on nothing says so. Carrying the act past the pause
+        // would offer an authority an act the agent has already performed.
+        afterApproval!.Status.Should().Be(AgentStatus.Responded);
+        afterApproval.PendingEffect.Should().BeNull();
     }
 
     [Fact]

--- a/Standard.Agents.Tests.Unit/Acceptance/ResumptionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/ResumptionTests.cs
@@ -13,6 +13,7 @@ using Standard.Agents.Brokers.Sessions;
 using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Models.Brokers.Sessions;
 using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Tools;
 using Xunit;
 
@@ -187,6 +188,53 @@ public class ResumptionTests : IDisposable
         // then — resuming asks nothing of the caller but the answer; the session holds the rest
         resumedTool.ExecutionCount.Should().Be(1);
         actualResult.Should().Be("paid");
+    }
+
+    // SPEC.md §4.11 says a session carries `pending : AgentEffect?` — the act it was left waiting
+    // on. Storing only the question text means a resuming process cannot show a human WHAT they
+    // are approving, and an approval broker cannot check that the act it is now approving is the
+    // act that was held.
+    [Fact]
+    public async Task ShouldRememberTheActTheSessionIsWaitingOnAsync()
+    {
+        // given
+        var tool = new CountingTool();
+
+        await NewProcess(tool, "ACTION: wire_transfer: 10000")
+            .RequireApproval("wire_transfer")
+            .OnApproval(effect => ValueTask.FromResult(ApprovalDecision.Pending))
+            .ProcessPromptAsync(prompt: "pay the invoice", "invoice-99", CancellationToken.None);
+
+        // when
+        var sessionBroker = new FileSessionBroker(SessionsPath);
+        AgentSession? actualSession = await sessionBroker.SelectSessionAsync("invoice-99");
+
+        // then — the held act travels with the session, so the authority is shown the act and
+        // not merely told that something is waiting
+        actualSession.Should().NotBeNull();
+        actualSession!.Status.Should().Be(AgentStatus.AwaitingApproval);
+        actualSession.PendingEffect.Should().NotBeNull();
+        actualSession.PendingEffect!.ToolName.Should().Be("wire_transfer");
+        actualSession.PendingEffect.Arguments.Should().Contain("10000");
+        actualSession.PendingEffect.IdempotencyKey.Should().NotBeEmpty();
+        actualSession.PendingEffect.ApprovalRequired.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ShouldRememberNoActWhenNothingIsHeldAsync()
+    {
+        // given — a run that simply answered
+        var tool = new CountingTool();
+
+        await NewProcess(tool, "FINAL: nothing to do")
+            .ProcessPromptAsync(prompt: "anything pending?", "invoice-101", CancellationToken.None);
+
+        // when
+        var sessionBroker = new FileSessionBroker(SessionsPath);
+        AgentSession? actualSession = await sessionBroker.SelectSessionAsync("invoice-101");
+
+        // then — a session that is waiting on nothing says so
+        actualSession!.PendingEffect.Should().BeNull();
     }
 
     [Fact]

--- a/Standard.Agents/Models/Brokers/Sessions/AgentSession.cs
+++ b/Standard.Agents/Models/Brokers/Sessions/AgentSession.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Effects;
 
 namespace Standard.Agents.Models.Brokers.Sessions;
 
@@ -28,6 +29,18 @@ public sealed record AgentSession
 
     /// <summary>The question the agent asked and is waiting on, when awaiting input.</summary>
     public string PendingQuestion { get; init; } = "";
+
+    /// <summary>
+    /// The act this session is waiting on an authority to permit, when awaiting approval
+    /// (SPEC.md §4.11, §4.9).
+    /// </summary>
+    /// <remarks>
+    /// The act travels with the session, not just the fact that something is waiting. A process
+    /// that picks the session up has to be able to show a human <i>what</i> they are approving,
+    /// and an approval broker has to be able to check that the act it is now being asked about is
+    /// the act that was held — its <c>IdempotencyKey</c> is what makes that checkable.
+    /// </remarks>
+    public AgentEffect? PendingEffect { get; init; }
 
     /// <summary>
     /// The run that last worked this session, written when the run <i>starts</i>.

--- a/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
+++ b/Standard.Agents/Models/Orchestrations/Agents/AgentContext.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Orchestrations.Effects;
 
 namespace Standard.Agents.Models.Orchestrations.Agents;
 
@@ -29,6 +30,11 @@ public sealed record AgentContext
     // The call Direction is performing this turn, so its result can be tied back to it. Empty
     // outside the native path.
     public string ToolCallId { get; init; } = "";
+
+    // The act an authority has been asked to permit and has not yet answered on (SPEC.md §4.9,
+    // §4.11). It rides out to the session so a different process can show a human the act itself
+    // rather than only the news that something is waiting.
+    public AgentEffect? PendingEffect { get; init; }
 
     public string Intent { get; init; } = "";
     public string Route { get; init; } = "";

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Sessions.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Sessions.cs
@@ -111,7 +111,12 @@ public partial class AgentCoordinationService
             PendingQuestion = context.Status is AgentStatus.AwaitingInput
                 or AgentStatus.AwaitingApproval
                     ? context.Result
-                    : string.Empty
+                    : string.Empty,
+
+            // Set only by the branch that holds an act, and the context belongs to this run
+            // alone — so a run that did not hold anything carries nothing, and the session
+            // stops advertising a held act as soon as one is permitted and performed.
+            PendingEffect = context.PendingEffect
         };
 
         await this.sessionBroker.UpsertSessionAsync(session);

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
@@ -171,6 +171,10 @@ public partial class DirectionOrchestrationService
         return context with
         {
             Result = $"'{effect.ToolName}' is waiting for approval before it can run.",
+
+            // The act travels with the pause, so whoever resumes can be shown what they are
+            // permitting rather than only that something is waiting (SPEC.md §4.11).
+            PendingEffect = effect,
             Status = AgentStatus.AwaitingApproval
         };
     }


### PR DESCRIPTION
The implementation disagreed with its own spec. SPEC.md §4.11 says a session carries `pending : AgentEffect?` — the act it was left waiting on. We stored `PendingQuestion`, a string.

The consequence is real: a process that picks up a held conversation could not show a human **what** they were approving, and an approval broker could not check that the act it is now being asked about is the act that was held. The idempotency key is what makes that checkable, and it was being thrown away at the pause.

`AgentSession.PendingEffect` now carries it, set by the one branch that holds an act.

Two notes on how this was arrived at, both from the sabotage pass:

- I first wrote a status guard on the write (`Status is AwaitingApproval ? effect : null`). Sabotaging it changed nothing, because the context belongs to one run and only the holding branch ever sets the field. It was dead code and is gone.
- The "forgets it afterwards" test originally used a run that simply answered — which could not catch that sabotage either, since nothing was ever held. It now holds an act, approves it, and asserts the session stops advertising it.

384 tests, 30 vectors.