### PR TITLE
MEDIUM ORCHESTRATIONS: Carry The Whole Identity Into Authorization

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/IdentityTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/IdentityTests.cs
@@ -138,6 +138,96 @@ public class IdentityTests
         actualResult.Should().Be("I could not do that");
     }
 
+    // An identifier alone answers "who" and nothing else. A policy engine is routinely written as
+    // "this principal, in this tenant, under this jurisdiction" — and a delegated act, where a
+    // service acts on a person's behalf, is a different question from that service acting for
+    // itself (SPEC.md §4.9).
+    [Fact]
+    public async Task ShouldCarryTheWholeIdentityIntoTheAuthorizationDecisionAsync()
+    {
+        // given
+        var tool = new CountingTool();
+        AgentPrincipal? seenByPolicy = null;
+
+        StandardAgent agent =
+            AgentThatCallsTheTool(tool, "ACTION: wire_transfer: 10000", "FINAL: paid")
+                .Principal(() => new AgentPrincipal
+                {
+                    Id = "svc-payments",
+                    TenantId = "acme-eu",
+                    Jurisdiction = "EU",
+                    DelegatedBy = "teller-42"
+                })
+                .OnPolicy(effect =>
+                {
+                    seenByPolicy = effect.Identity;
+
+                    return ValueTask.FromResult(AuthorizationDecision.Allow());
+                });
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "pay the invoice");
+
+        // then
+        seenByPolicy.Should().NotBeNull();
+        seenByPolicy!.Id.Should().Be("svc-payments");
+        seenByPolicy.TenantId.Should().Be("acme-eu");
+        seenByPolicy.Jurisdiction.Should().Be("EU");
+        seenByPolicy.DelegatedBy.Should().Be("teller-42");
+    }
+
+    [Fact]
+    public async Task ShouldRefuseAnActOnJurisdictionAloneAsync()
+    {
+        // given — the same act, by the same principal, permitted in one regime and not another
+        var tool = new CountingTool();
+
+        StandardAgent agent =
+            AgentThatCallsTheTool(
+                tool, "ACTION: wire_transfer: 10000", "FINAL: I could not do that")
+                .Principal(() => new AgentPrincipal { Id = "teller-42", Jurisdiction = "EU" })
+                .OnPolicy(effect => ValueTask.FromResult(
+                    effect.Identity?.Jurisdiction is "US"
+                        ? AuthorizationDecision.Allow()
+                        : AuthorizationDecision.Deny("cross-border transfers need US booking")));
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "pay the invoice");
+
+        // then
+        tool.ExecutionCount.Should().Be(0);
+    }
+
+    // The id-only overload still works and still reads the same way, so nothing written against
+    // 1.0 has to change to keep authorizing.
+    [Fact]
+    public async Task ShouldKeepTheIdentifierOnlyPrincipalWorkingAsync()
+    {
+        // given
+        var tool = new CountingTool();
+        string? seenId = null;
+        AgentPrincipal? seenIdentity = null;
+
+        StandardAgent agent =
+            AgentThatCallsTheTool(tool, "ACTION: wire_transfer: 10000", "FINAL: paid")
+                .Principal(() => "teller-42")
+                .OnPolicy(effect =>
+                {
+                    seenId = effect.Principal;
+                    seenIdentity = effect.Identity;
+
+                    return ValueTask.FromResult(AuthorizationDecision.Allow());
+                });
+
+        // when
+        await agent.ProcessPromptAsync(prompt: "pay the invoice");
+
+        // then — the id reads as before, and the richer view carries the same identity
+        seenId.Should().Be("teller-42");
+        seenIdentity!.Id.Should().Be("teller-42");
+        seenIdentity.TenantId.Should().BeNull();
+    }
+
     [Fact]
     public async Task ShouldCarryNoPrincipalWhenNoneIsConfiguredAsync()
     {

--- a/Standard.Agents/Models/Orchestrations/Effects/AgentEffect.cs
+++ b/Standard.Agents/Models/Orchestrations/Effects/AgentEffect.cs
@@ -19,7 +19,15 @@ public sealed record AgentEffect
     private const string KeySeparator = "|";
 
     public string RunId { get; init; } = "";
+
+    /// <summary>Who is acting, as an identifier. The same value as <c>Identity?.Id</c>.</summary>
     public string? Principal { get; init; }
+
+    /// <summary>
+    /// Who is acting, in full — tenant, jurisdiction and delegation where the host knows them
+    /// (SPEC.md §4.9). Null when no identity is configured.
+    /// </summary>
+    public AgentPrincipal? Identity { get; init; }
 
     public string ToolName { get; init; } = "";
     public string Arguments { get; init; } = "";
@@ -49,11 +57,15 @@ public sealed record AgentEffect
         string arguments,
         RiskLevel riskLevel = RiskLevel.Safe,
         bool approvalRequired = false,
-        string? principal = null) =>
+        AgentPrincipal? principal = null) =>
         new()
         {
             RunId = runId,
-            Principal = principal,
+
+            // Both views of one identity, kept in step here so they cannot disagree. The
+            // identifier stays for the callers that only ever needed "who".
+            Principal = principal?.Id,
+            Identity = null,
             ToolName = toolName,
             Arguments = arguments,
             RiskLevel = riskLevel,

--- a/Standard.Agents/Models/Orchestrations/Effects/AgentEffect.cs
+++ b/Standard.Agents/Models/Orchestrations/Effects/AgentEffect.cs
@@ -65,7 +65,7 @@ public sealed record AgentEffect
             // Both views of one identity, kept in step here so they cannot disagree. The
             // identifier stays for the callers that only ever needed "who".
             Principal = principal?.Id,
-            Identity = null,
+            Identity = principal,
             ToolName = toolName,
             Arguments = arguments,
             RiskLevel = riskLevel,

--- a/Standard.Agents/Models/Orchestrations/Effects/AgentPrincipal.cs
+++ b/Standard.Agents/Models/Orchestrations/Effects/AgentPrincipal.cs
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Orchestrations.Effects;
+
+/// <summary>
+/// Who is acting, in the terms a policy actually decides on (SPEC.md §4.9).
+/// </summary>
+/// <remarks>
+/// An identifier alone answers "who" and nothing else. Real authorization asks more: a policy
+/// engine is routinely written as <i>this principal, in this tenant, under this jurisdiction, on
+/// this resource</i> — and a delegated act, where a service is doing something on a person's
+/// behalf, is a different question again from that service acting for itself.
+/// <para>Every field beyond <see cref="Id"/> is optional. A host that has only a user id supplies
+/// only that, and nothing about the perimeter changes; the fields exist so a host that <i>does</i>
+/// know more is not forced to smuggle it through a string.</para>
+/// <para>The framework <b>consumes</b> a principal, it does not mint one. Establishing identity —
+/// tokens, sessions, sign-in — is the host's, and short-lived credentials stay a host concern.</para>
+/// </remarks>
+public sealed record AgentPrincipal
+{
+    /// <summary>Who is acting. The one field an identity cannot be without.</summary>
+    public string Id { get; init; } = "";
+
+    /// <summary>Which tenant they belong to, where one agent serves several.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// Which legal or regulatory regime this act falls under — the thing a policy consults when
+    /// the same act is permitted in one place and not another.
+    /// </summary>
+    public string? Jurisdiction { get; init; }
+
+    /// <summary>
+    /// Who this principal is acting <i>for</i>, when the act is delegated. A service acting on a
+    /// person's behalf is a different act, to a policy, from that service acting for itself.
+    /// </summary>
+    public string? DelegatedBy { get; init; }
+
+    /// <summary>Reads as the identifier, so a trace or a message says who without ceremony.</summary>
+    public override string ToString() =>
+        Id;
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
@@ -33,7 +33,7 @@ public partial class DirectionOrchestrationService
             // deciding whether it may happen is told, not merely the record written afterwards
             // (SPEC.md §4.9). Null when the host configured no identity, which claims nothing
             // rather than inventing someone.
-            principal: this.principalResolver?.Invoke());
+            principal: this.identityResolver?.Invoke());
 
         // 1 — authorize
         AuthorizationDecision decision = await this.policyBroker.AuthorizeAsync(effect);

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -8,6 +8,7 @@ using Standard.Agents.Brokers.Effects;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Policies;
 using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Effects;
 using Standard.Agents.Services.Foundations.ExternalTools;
 using Standard.Agents.Services.Foundations.Gates;
 using Standard.Agents.Services.Foundations.InternalTools;
@@ -34,7 +35,7 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
     // Asked once per act rather than captured once at composition, because who is acting can
     // change between prompts on the same agent — a singleton serving many callers is the shape
     // this framework asks hosts to adopt (SPEC.md §4.4).
-    private readonly Func<string?>? principalResolver;
+    private readonly Func<AgentPrincipal?>? identityResolver;
 
     public DirectionOrchestrationService(
         IInternalToolService internalToolService,
@@ -47,10 +48,10 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
         IEffectLedgerBroker? effectLedgerBroker = null,
         IEnumerable<string>? irreversibleTools = null,
         IGateService? screeningService = null,
-        Func<string?>? principalResolver = null)
+        Func<AgentPrincipal?>? identityResolver = null)
     {
         this.screeningService = screeningService;
-        this.principalResolver = principalResolver;
+        this.identityResolver = identityResolver;
 
         this.internalToolService = internalToolService;
         this.externalToolService = externalToolService;

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -100,7 +100,7 @@ public sealed partial class StandardAgent : IAgent
     private IGeneratorBrokerV1? generatorBrokerV1;
     private ISessionBroker? sessionBroker;
     private int maxHistoryTurns = 20;
-    private Func<string?>? principalResolver;
+    private Func<AgentPrincipal?>? identityResolver;
 
     private IAgentCoordinationService? agent;
 
@@ -453,7 +453,26 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="principal">A function returning the current principal's identifier.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent Principal(Func<string?> principal) =>
-        Set(() => this.principalResolver = principal);
+        Set(() => this.identityResolver = () =>
+            principal() is string id
+                ? new AgentPrincipal { Id = id }
+                : null);
+
+    /// <summary>
+    /// Declares who is acting, in the terms a policy decides on — tenant, jurisdiction and
+    /// delegation as well as the identifier (SPEC.md §4.9).
+    /// </summary>
+    /// <remarks>
+    /// The identity reaches the policy broker on <c>effect.Identity</c> at the moment it decides,
+    /// and is stamped on every record of the run. It is resolved <b>per act</b>, so a shared agent
+    /// serving many callers answers for the right one each time.
+    /// <para>Only <see cref="AgentPrincipal.Id"/> is required. The framework consumes a principal
+    /// and never mints one: establishing identity stays the host's.</para>
+    /// </remarks>
+    /// <param name="principal">A function returning who is acting right now.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Principal(Func<AgentPrincipal?> principal) =>
+        Set(() => this.identityResolver = principal);
 
     /// <summary>
     /// Turns on <b>PII redaction at the brain boundary</b>: before any prompt reaches the brain,
@@ -1063,7 +1082,7 @@ public sealed partial class StandardAgent : IAgent
                     ?? (string.IsNullOrEmpty(this.auditPath)
                         ? new NotConfiguredAuditBroker()
                         : new FileAuditBroker(this.auditPath)),
-                this.principalResolver);
+                () => this.identityResolver?.Invoke()?.Id);
 
         // With only a native brain configured there is no V0 generator to build, and none is
         // needed: SpeaksNatively routes every call to the V1 seam. The placeholder exists so the
@@ -1186,7 +1205,7 @@ public sealed partial class StandardAgent : IAgent
             this.effectLedgerBroker,
             this.approvalRequiredTools,
             this.screenToolOutput ? gate : null,
-            this.principalResolver);
+            this.identityResolver);
 
         return new AgentCoordinationService(
             data, decision, direction, logging, this.maxTurns, new TimeBroker(), this.budget,


### PR DESCRIPTION
The last loose end from the 1.0 plan: *full identity*.

The principal reached the policy broker as an identifier. That answers "who" and nothing else — so a policy could not be written the way policies actually are (*this principal, in this tenant, under this jurisdiction*), and could not tell a service acting for itself from one acting on a person''s behalf.

`AgentPrincipal { Id, TenantId, Jurisdiction, DelegatedBy }` reaches the decision on `effect.Identity`. Every field beyond the id is optional; the framework consumes a principal and never mints one, so establishing identity stays the host''s.

```csharp
.Principal(() => new AgentPrincipal
{
    Id = "svc-payments", TenantId = "acme-eu", Jurisdiction = "EU", DelegatedBy = "teller-42"
})
```

**Additive, deliberately.** Repurposing `Principal` from `string?` to the record would break every policy broker written against 1.0.0 the day after it shipped, and `docs/support.md` promises models are stable within a major version with existing fields not repurposed. Both views are set together so they cannot disagree, and the identifier can retire at 2.0 through the normal deprecation window. A test pins the id-only overload to the same behavior.

387 tests, 30 vectors, Critical certified.