### PR TITLE
DOCUMENTATION: Bring The Conformance Suite Guide Up To Thirty Vectors

### DIFF
--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -1,16 +1,27 @@
 # Conformance Suite
 
 A **language-neutral** set of behavioral test vectors that any Standard-Agents
-implementation runs to self-certify against [`SPEC.md`](../SPEC.md).
+implementation runs to self-certify against
+[`SPEC.md`](https://github.com/hassanhabib/The-Standard-Agent-Specs/blob/main/SPEC.md).
+Thirty vectors, four readiness profiles, every vector proven able to fail.
+
+The vectors are the executable half of the specification. Prose can be read two ways; a vector
+cannot, which is why "conformant" here means *this suite passes* rather than *we believe we
+followed the document*.
 
 ## Why scripted
 
 Agent behavior involves an LLM, which is non-deterministic — so it cannot be asserted
 directly. Conformance instead tests the **deterministic** contracts: the loop, reply
-interpretation, tool routing, and the feed-back of results into Data. It does this by
-replacing the Brain with a **scripted generator** and tools with **stubs**, then
-asserting on the one thing that is a stable cross-language contract: **the returned
-result**.
+interpretation, tool routing, the perimeter, and the feed-back of results into Data. It
+does this by replacing the Brain with a **scripted generator** and tools with **stubs**,
+then asserting on things that are stable cross-language contracts — the returned result
+first among them, and, where a control is only observable from inside, what each broker
+was actually handed.
+
+That second kind matters more than it sounds. Several guarantees here are invisible from
+the outside: an implementation that authorizes without a principal returns exactly the
+same answer as one that does it properly. Certifying only the result would pass both.
 
 ## Vector schema (JSON)
 
@@ -31,6 +42,50 @@ result**.
 - **prompt** — the user task.
 - **expect** — `{ "result": "<exact>" }` or `{ "resultContains": "<substring>" }`.
 
+Those five are the whole schema for a Core vector, and the first seven vectors use nothing else.
+Everything below is **optional and additive**: a field a vector omits behaves exactly as if the
+capability it configures did not exist, which is why the early vectors still deserialize unchanged.
+
+### Setup — what the agent is configured with
+
+| Field | Effect |
+|---|---|
+| `prompts`, `concurrent` | drive several prompts through one agent, in order or all at once |
+| `maxTurns` | cap the loop |
+| `constitution`, `consumption` | inline markdown, written to a file the real builder is pointed at |
+| `gateVerdict`, `judgeScore`, `gateVerdictOnToolOutput` | scripted guardian answers (default `allow` / `1.0`) |
+| `redact` | boundary redaction |
+| `requireApproval`, `approvalDecisions` | acts needing an authority, and its answers in order |
+| `principal`, `deniedForPrincipal` | who is acting, and what a policy refuses them |
+| `screenToolOutput` | screen untrusted tool results through the Gate |
+| `cancelBeforeStart`, `transientFailures`, `retries`, `budgetMaxWallClockSeconds` | resilience and budget |
+| `fallbackReply`, `failuresBeforeOpen` | the circuit breaker's alternative |
+| `knowledge`, `knowledgeMaxResults` | real files in a real folder, so ranking is exercised |
+| `sessionId` | run every prompt in one conversation |
+| `compensateOnFailure`, `compensatingTools` | unwind a failed run; tools left out declare no way back |
+| `newInstancePerPrompt`, `durableEffectLedger` | a fresh agent per prompt over shared folders — the harness's stand-in for a different process |
+| `nativeReplies` | the Brain is a native (§6.2) generator returning structured choices |
+
+### Expectations — what must be true afterwards
+
+| Field | Asserts |
+|---|---|
+| `result`, `resultContains` | the answer |
+| `toolInput`, `toolRunCount`, `toolNeverRan` | what each tool was called with, and how often |
+| `brainSees`, `brainNeverSees`, `noModelSees` | what reached the Brain, and what reached no model at all |
+| `guardianRubricContains`, `guardianRubricExcludes` | the composed rubric, in **both** guardians |
+| `judgeSawTask`, `guardianNeverAnswers`, `gateScreenedPromptTimes` | guardian integrity |
+| `auditRunCount`, `auditRetainsEveryPrompt`, `auditSequencesUniquePerRun` | the decision log |
+| `compensationOrder` | the exact order the unwind ran in |
+| `toolResultAnswersCall` | the call id was replayed and answered |
+| `policySawPrincipal` | the identity the policy broker was **handed when it decided** |
+
+Two of those are worth singling out, because they are the difference between checking a control and
+checking the *report* of one. `policySawPrincipal` reads the decision's input rather than the audit
+log — an implementation that names the caller afterwards and authorizes without them fails it.
+`noModelSees` covers every model call, not just the Brain's, because redaction that covers one call
+and not the others is not redaction.
+
 ## Runner contract
 
 To certify an implementation, provide a harness that, for each vector:
@@ -44,6 +99,15 @@ To certify an implementation, provide a harness that, for each vector:
 4. Runs the agent on `prompt` and compares the returned result to `expect`.
 
 A conformant implementation **passes every vector**.
+
+Two rules the reference harness follows, both learned the hard way:
+
+- **Every double replaces a broker, never a service.** The whole 1·3·9 under test is the real
+  library. A harness that stubs a service is certifying its own stub.
+- **Observe through the real seams.** The decision log is watched through its own Custom sink, the
+  generator is *wrapped* rather than replaced so redaction and streaming still run, and guardians
+  answer through the real rubric composition. Anything observed off to the side is a claim about
+  the harness rather than about the implementation.
 
 ## Reference runner (C#)
 
@@ -72,3 +136,57 @@ the deterministic core of the Standard.
 | `unknown-tool-recovers` | An unknown tool routes to External and the agent recovers |
 | `max-turns-cap` | A never-terminating Brain is capped by the loop |
 | `structured-tool-call` | A structured `TOOL:` call (§6.1) routes to the tool with its arguments |
+| `gate-refusal-short-circuits` | A Gate refusal ends the run without reaching the Brain |
+| `constitution-binds-guardians` | A constitution reaches *both* guardian rubrics |
+| `consumption-replaces-policy` | A consumption skill replaces the policy in both, contract intact |
+| `audit-retains-every-run` | Beginning a run never discards a prior run's records (§4.7) |
+| `concurrent-runs-are-isolated` | Eight prompts at once on one instance; no record corrupts another |
+| `judge-receives-the-task` | The Judge scores against the task, not the candidate alone (§4.2) |
+| `redaction-covers-every-model-call` | Brain, Gate and Judge all see the token, never the value (§4.6) |
+| `guardian-overreach-is-neutralized` | A guardian that answers or acts is classified, not obeyed (§7.6) |
+| `approval-blocks-irreversible-tool` | `Pending` holds the act — waiting is not consent (§4.9) |
+| `duplicate-effect-executes-once` | One act however many times it is proposed; the key is canonical |
+| `injected-instruction-in-tool-output-is-refused` | Indirect injection is withheld from the Brain (§4.9) |
+| `cancellation-stops-the-loop` | A cancelled run stops at a turn boundary and is not an answer |
+| `transient-failure-recovers` | Retry by error category, not by matching a message (§4.10) |
+| `budget-stops-the-loop` | Exhaustion stops the loop and is distinguishable from a refusal |
+| `knowledge-retrieves-by-relevance` | Retrieval returns the passage that answers, not the first found |
+| `guardian-screens-once-per-prompt` | An unchanged prompt is screened once, not once per turn |
+| `open-circuit-falls-back-to-secondary` | An unhealthy provider degrades rather than fails (§4.10) |
+| `conversation-carries-history` | A follow-up resolves against what came before (§4.11) |
+| `failed-run-unwinds-in-reverse` | Compensation undoes what was performed, newest first (§4.9) |
+| `effect-outcome-survives-a-crash` | A new instance resumes and does not repeat the act (§4.9, §4.11) |
+| `awaiting-approval-resumes-in-a-new-process` | A held act runs once the authority says yes, elsewhere |
+| `native-tool-call-round-trips` | A result returns as a tool message naming its call (§6.2) |
+| `policy-authorizes-on-identity` | The principal reaches the decision, not only the log (§3.3, §4.9) |
+
+## Readiness profiles
+
+Full (§8.2) spans an agent with a Judge and an agent that can move money, so the vectors are also
+grouped into levels. Each is a list of required vector names in `conformance/profiles/`, which is
+what makes a claim answerable with an exit code rather than an opinion (SPEC.md §1.1):
+
+```bash
+dotnet run --project Standard.Agents.Conformance -- --profile Critical
+```
+
+| Profile | Adds |
+|---|---|
+| **Core** | conversation, skills, knowledge, memory, simple tools |
+| **Reliable** | guardians that see what they guard, a durable decision log, run isolation, cancellation, timeouts |
+| **Enterprise** | identity-aware authorization, approval before irreversible acts, run-once, budgets, ranked retrieval |
+| **Critical** | conversation and effects that survive a process, compensation, native tool calls that round-trip |
+
+A profile names the evidence it requires **before** that evidence exists — the level is the target,
+not a description of what already passes. `NOT CERTIFIED` lists exactly which vectors are missing.
+
+## Sabotage-verification
+
+A vector that cannot fail proves nothing, and vectors written from a passing implementation are
+prone to exactly that. Every vector here has been **proven able to fail**: the behaviour it checks
+was deliberately broken, the vector observed failing, and the break reverted.
+
+Two in this suite were vacuous when first written and were caught this way —
+`knowledge-retrieves-by-relevance` passed with the ranking inverted, and
+`redaction-covers-every-model-call` passed while only the Brain's input was being recorded. Both
+were rewritten. If you add a vector, break the thing it covers first.


### PR DESCRIPTION
`conformance/CONFORMANCE.md` documented a five-field vector schema and seven vectors. There are thirty vectors, roughly thirty fields, four readiness profiles — and a sabotage rule that existed only in commit messages.

Since this file is the entry point for anyone porting the Standard to another language, being three-quarters out of date is a principle-0 problem, not a tidiness one.

- **The full vector table** — all thirty, one line each, with the spec section they pin.
- **The schema, split** into *setup* (what the agent is configured with) and *expectations* (what must be true afterwards), with the Core five called out as the whole schema for a Core vector and everything else marked additive.
- **Readiness profiles** and what each level adds, plus the note that a profile names its evidence *before* that evidence exists.
- **Sabotage-verification** as a documented rule, naming the two vectors that were vacuous when first written — `knowledge-retrieves-by-relevance` passed with the ranking inverted, `redaction-covers-every-model-call` passed while only the Brain''s input was recorded.
- **Two harness rules**: every double replaces a broker and never a service, and observation goes through the real seams — the log through its own sink, the generator *wrapped* rather than replaced.

The "why scripted" section now says why asserting on the returned result alone is not enough: an implementation that authorizes without a principal returns exactly the same answer as one that does it properly.

Companion to the spec settling at 1.0 ([The-Standard-Agent-Specs#20](https://github.com/hassanhabib/The-Standard-Agent-Specs/pull/20)).