### PR TITLE
RELEASES: Standard.Agents 1.1.0.0 — The Audit Of 1.0

### DIFF
--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -20,6 +20,24 @@
     <!-- The Standard's release format is v1.2.3.4 — model . service/routine . fix/config
          . automated build. Deliberately NOT semver; the segments say what KIND of change
          happened, so a model change can never hide in the service segment.
+         1.1.0.0: two defects found by auditing 1.0 against its own claims, and the documentation
+         brought up to what shipped. Identity now reaches the AUTHORIZATION decision and not only
+         the record of it: AgentEffect.For was called with principal: null, hardcoded, while the
+         principal resolver was wired to the logging broker alone - so the Enterprise profile
+         claimed identity-aware authorization and delivered identity-aware reporting. It is
+         resolved per act, since a singleton serves many callers. The streamed loop now enforces
+         every control the batched one does - cancellation, budgets, sessions, compensation -
+         because a control a caller can step around by changing method is not a control; it
+         gained a sessionId overload, and cancellation and exhaustion arrive as Status rather
+         than as an answer. Identity grew a shape: AgentPrincipal carries tenant, jurisdiction
+         and delegation, added ALONGSIDE the principal identifier rather than replacing it, so
+         nothing written against 1.0.0 breaks. A session now carries the effect it is waiting on,
+         so a resuming process can show an authority the act rather than only the news that
+         something waits. New public routines and new optional model fields, no existing field
+         repurposed and no contract removed: a service/routine change, so segment 2 advances,
+         3/4 reset. SPEC.md settles at 1.0 in the same pass, naming three mechanisms it had
+         required results from without describing - run continuity across processes, native
+         tool-call attribution, and the principal reaching the decision.
          1.0.0.0: the shape of an agent changed, which is why segment 1 moves — once, here, with
          every model change in the program batched into it rather than dribbled across eight
          releases. A run is no longer confined to one process. AgentSession carries the run that
@@ -97,7 +115,7 @@
          3/4 reset. Still tracks SPEC.md v0.1 (draft): segment 1 goes to 1 when the spec settles.
          (0.8.0.0: memory and knowledge came alive — knowledge retrieval in Recall + a built-in
          'remember' tool.) -->
-    <Version>1.0.0.0</Version>
+    <Version>1.1.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>

--- a/docs/enterprise-plan.md
+++ b/docs/enterprise-plan.md
@@ -169,7 +169,19 @@ MOVEMENT I — TRUST                MOVEMENT II — CONTROL           MOVEMENT I
 | 0.24 Data at scale | **landed** | ranked lexical retrieval over passages; vector 22 |
 | 0.25 Supply chain | **landed** | pinned SDK, warnings as errors, vulnerability and licence audit, secret scanning, SBOM, provenance; `docs/support.md` |
 | 1.0 Enterprise model | **landed** | sessions, cross-process run identity, durable run-once, compensation, native tool-call round-trip; vectors 25–29 |
-| 1.1 Evals & hosting | next | — |
+| 1.1 Audit of 1.0 | **landed** | identity reaches authorization, streamed path at parity, full principal, held effect on the session; vector 30; SPEC.md settles at 1.0 |
+| 1.2 Evals & hosting | next | — |
+
+**1.1 was not the release that was planned.** Auditing 1.0 against its own claims turned up two
+defects — `.Principal(...)` never reached the policy broker, and the streamed loop enforced neither
+budgets nor cancellation nor sessions — so 1.1 became the release that fixed them and brought the
+documentation up to what had actually shipped. Evals and hosting move to 1.2, unchanged in scope.
+
+Worth recording *why* neither defect was caught: both were invisible from the outside. An agent that
+authorizes without a principal returns exactly the same answer as one that does it properly, and a
+streamed run that ignores a budget looks identical until the bill arrives. Every vector before 30
+asserted on the returned result. Vector 30 reads what the policy broker was *handed*, which is the
+shape the remaining perimeter vectors should follow.
 
 The readiness levels (§2.1) are machine-verified, and the runner is the authority on where this
 stands — not this table:

--- a/docs/support.md
+++ b/docs/support.md
@@ -79,6 +79,12 @@ The live example: `.LocalBrain` / `.LocalGate` / `.LocalJudge` became `.OnBrain`
 names still work and are held to the new ones by
 `ShouldKeepObsoleteLocalAliasesBehavingLikeTheCustomVerbsAsync`.
 
+A second live example, from 1.1.0.0: `AgentEffect.Principal` is the principal's identifier and
+`AgentEffect.Identity` is the whole principal — tenant, jurisdiction, delegation. Both are set
+together and cannot disagree. `Principal` is **not** deprecated: it is what a policy that only cares
+who is acting should read. If it ever retires it will be at a major version, through the window
+above.
+
 **The V0 generator contract is not deprecated**, despite V1 arriving beside it. V0 is the text
 protocol, and it is the one that works against any endpoint — including the small local models
 that follow a format more reliably than they emit well-formed tool JSON. Nothing above is running


### PR DESCRIPTION
Not the release that was planned. Auditing 1.0 against its own claims turned up two defects, so 1.1 became the release that fixed them and brought the documentation up to what had actually shipped. Evals and hosting move to 1.2, unchanged in scope.

**Identity reaches the authorization decision**, not only the record of it. `AgentEffect.For(...)` was called with `principal: null`, hardcoded, while the resolver was wired to the logging broker alone — so Enterprise claimed identity-aware authorization and delivered identity-aware *reporting*. Resolved per act, since a singleton serves many callers.

**The streamed loop enforces every control the batched one does** — cancellation, budgets, sessions, compensation. A control a caller can step around by changing method is not a control.

**The principal grew a shape** — tenant, jurisdiction, delegation — added *alongside* the identifier rather than replacing it, so nothing written against 1.0.0 breaks. **A session carries the act it is waiting on**, so a resuming process can show an authority the act rather than only the news that something waits.

Both defects were invisible from outside: an agent that authorizes without a principal returns exactly the same answer as one that does it properly. Vector 30 reads what the policy broker was *handed* — the shape the remaining perimeter vectors should follow.

**SPEC.md settles at 1.0** in the same pass, naming three mechanisms it had required results from without describing: run continuity across processes, native tool-call attribution, and the principal reaching the decision. Three of those clauses exist because the implementation had the defect first.

New routines and new optional model fields; nothing repurposed, nothing removed. Segment 2 advances. 387 tests, 30 vectors, all four profiles certified.

Merging this cuts `v1.1.0`, which publishes to NuGet.