### PR TITLE
MAJOR FOUNDATIONS: Add Session Service

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Sessions/SessionServiceTests.Exceptions.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Sessions/SessionServiceTests.Exceptions.cs
@@ -1,0 +1,152 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Foundations.Sessions.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Sessions;
+
+// The whole point of the foundation. A store failure has to arrive as a SESSION failure — an
+// IOException surfacing unmapped is what let a full disk get blamed on the loop.
+public partial class SessionServiceTests
+{
+    [Fact]
+    public async Task ShouldThrowDependencyExceptionOnRetrieveSessionIfIOErrorOccursAsync()
+    {
+        // given
+        string randomSessionId = CreateRandomString();
+        var ioException = new IOException();
+
+        var failedSessionDependencyException =
+            new FailedSessionDependencyException(
+                message: "Failed session dependency error occurred, contact support.",
+                innerException: ioException);
+
+        var expectedSessionDependencyException =
+            new SessionDependencyException(
+                message: "Session dependency error occurred, contact support.",
+                innerException: failedSessionDependencyException);
+
+        this.sessionBrokerMock.Setup(broker =>
+            broker.SelectSessionAsync(It.IsAny<string>()))
+                .ThrowsAsync(ioException);
+
+        // when
+        ValueTask<AgentSession?> retrieveTask =
+            this.sessionService.RetrieveSessionAsync(randomSessionId);
+
+        SessionDependencyException actualSessionDependencyException =
+            await Assert.ThrowsAsync<SessionDependencyException>(retrieveTask.AsTask);
+
+        // then
+        actualSessionDependencyException.Should()
+            .BeEquivalentTo(expectedSessionDependencyException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedSessionDependencyException))),
+                    Times.Once);
+
+        this.sessionBrokerMock.Verify(broker =>
+            broker.SelectSessionAsync(randomSessionId),
+                Times.Once);
+
+        this.sessionBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task
+        ShouldThrowCriticalDependencyExceptionOnRecordSessionIfAccessDeniedAsync()
+    {
+        // given
+        AgentSession randomSession = CreateRandomSession();
+        var unauthorizedAccessException = new UnauthorizedAccessException();
+
+        var failedSessionDependencyException =
+            new FailedSessionDependencyException(
+                message: "Failed session dependency error occurred, contact support.",
+                innerException: unauthorizedAccessException);
+
+        var expectedSessionDependencyException =
+            new SessionDependencyException(
+                message: "Session dependency error occurred, contact support.",
+                innerException: failedSessionDependencyException);
+
+        this.sessionBrokerMock.Setup(broker =>
+            broker.UpsertSessionAsync(It.IsAny<AgentSession>()))
+                .ThrowsAsync(unauthorizedAccessException);
+
+        // when
+        ValueTask recordTask = this.sessionService.RecordSessionAsync(randomSession);
+
+        SessionDependencyException actualSessionDependencyException =
+            await Assert.ThrowsAsync<SessionDependencyException>(recordTask.AsTask);
+
+        // then
+        actualSessionDependencyException.Should()
+            .BeEquivalentTo(expectedSessionDependencyException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogCriticalAsync(It.Is(SameExceptionAs(
+                expectedSessionDependencyException))),
+                    Times.Once);
+
+        this.sessionBrokerMock.Verify(broker =>
+            broker.UpsertSessionAsync(randomSession),
+                Times.Once);
+
+        this.sessionBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnRetrieveSessionIfServiceErrorOccursAsync()
+    {
+        // given
+        string randomSessionId = CreateRandomString();
+        var serviceException = new Exception();
+
+        var failedSessionServiceException =
+            new FailedSessionServiceException(
+                message: "Failed session service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedSessionServiceException =
+            new SessionServiceException(
+                message: "Session service error occurred, contact support.",
+                innerException: failedSessionServiceException);
+
+        this.sessionBrokerMock.Setup(broker =>
+            broker.SelectSessionAsync(It.IsAny<string>()))
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<AgentSession?> retrieveTask =
+            this.sessionService.RetrieveSessionAsync(randomSessionId);
+
+        SessionServiceException actualSessionServiceException =
+            await Assert.ThrowsAsync<SessionServiceException>(retrieveTask.AsTask);
+
+        // then
+        actualSessionServiceException.Should()
+            .BeEquivalentTo(expectedSessionServiceException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedSessionServiceException))),
+                    Times.Once);
+
+        this.sessionBrokerMock.Verify(broker =>
+            broker.SelectSessionAsync(randomSessionId),
+                Times.Once);
+
+        this.sessionBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Sessions/SessionServiceTests.Logic.RecordSession.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Sessions/SessionServiceTests.Logic.RecordSession.cs
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Moq;
+using Standard.Agents.Models.Brokers.Sessions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Sessions;
+
+public partial class SessionServiceTests
+{
+    [Fact]
+    public async Task ShouldRecordSessionAsync()
+    {
+        // given
+        AgentSession randomSession = CreateRandomSession();
+        AgentSession inputSession = randomSession;
+
+        // when
+        await this.sessionService.RecordSessionAsync(inputSession);
+
+        // then
+        this.sessionBrokerMock.Verify(broker =>
+            broker.UpsertSessionAsync(inputSession),
+                Times.Once);
+
+        this.sessionBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Sessions/SessionServiceTests.Logic.RetrieveSession.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Sessions/SessionServiceTests.Logic.RetrieveSession.cs
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Brokers.Sessions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Sessions;
+
+public partial class SessionServiceTests
+{
+    [Fact]
+    public async Task ShouldRetrieveSessionAsync()
+    {
+        // given
+        string randomSessionId = CreateRandomString();
+        AgentSession randomSession = CreateRandomSession();
+        AgentSession retrievedSession = randomSession;
+        AgentSession expectedSession = retrievedSession;
+
+        this.sessionBrokerMock.Setup(broker =>
+            broker.SelectSessionAsync(randomSessionId))
+                .ReturnsAsync(retrievedSession);
+
+        // when
+        AgentSession? actualSession =
+            await this.sessionService.RetrieveSessionAsync(randomSessionId);
+
+        // then
+        actualSession.Should().BeEquivalentTo(expectedSession);
+
+        this.sessionBrokerMock.Verify(broker =>
+            broker.SelectSessionAsync(randomSessionId),
+                Times.Once);
+
+        this.sessionBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // A conversation that has not started yet is not an error. It is the ordinary first prompt,
+    // and the caller has to be able to tell it apart from a failure to read.
+    [Fact]
+    public async Task ShouldRetrieveNoSessionOnRetrieveSessionIfNoneExistsAsync()
+    {
+        // given
+        string randomSessionId = CreateRandomString();
+
+        this.sessionBrokerMock.Setup(broker =>
+            broker.SelectSessionAsync(randomSessionId))
+                .ReturnsAsync((AgentSession?)null);
+
+        // when
+        AgentSession? actualSession =
+            await this.sessionService.RetrieveSessionAsync(randomSessionId);
+
+        // then
+        actualSession.Should().BeNull();
+
+        this.sessionBrokerMock.Verify(broker =>
+            broker.SelectSessionAsync(randomSessionId),
+                Times.Once);
+
+        this.sessionBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Sessions/SessionServiceTests.Validations.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Sessions/SessionServiceTests.Validations.cs
@@ -1,0 +1,102 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Foundations.Sessions.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Sessions;
+
+public partial class SessionServiceTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task
+        ShouldThrowValidationExceptionOnRetrieveSessionIfIdIsInvalidAndLogItAsync(
+            string? invalidSessionId)
+    {
+        // given
+        var invalidSessionException =
+            new InvalidSessionException(
+                message: "Invalid session. Please correct the error and try again.");
+
+        var expectedSessionValidationException =
+            new SessionValidationException(
+                message: "Session validation error occurred, fix the error and try again.",
+                innerException: invalidSessionException);
+
+        // when
+        ValueTask<AgentSession?> retrieveTask =
+            this.sessionService.RetrieveSessionAsync(invalidSessionId!);
+
+        SessionValidationException actualSessionValidationException =
+            await Assert.ThrowsAsync<SessionValidationException>(retrieveTask.AsTask);
+
+        // then
+        actualSessionValidationException.Should()
+            .BeEquivalentTo(expectedSessionValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedSessionValidationException))),
+                    Times.Once);
+
+        this.sessionBrokerMock.Verify(broker =>
+            broker.SelectSessionAsync(It.IsAny<string>()),
+                Times.Never);
+
+        this.sessionBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // A session written without an id cannot be read back. Nothing throws, the next prompt finds
+    // nothing, and the agent forgets — with no error anywhere to explain it.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task
+        ShouldThrowValidationExceptionOnRecordSessionIfIdIsInvalidAndLogItAsync(
+            string? invalidSessionId)
+    {
+        // given
+        var invalidSession = new AgentSession { Id = invalidSessionId! };
+
+        var invalidSessionException =
+            new InvalidSessionException(
+                message: "Invalid session. Please correct the error and try again.");
+
+        var expectedSessionValidationException =
+            new SessionValidationException(
+                message: "Session validation error occurred, fix the error and try again.",
+                innerException: invalidSessionException);
+
+        // when
+        ValueTask recordTask = this.sessionService.RecordSessionAsync(invalidSession);
+
+        SessionValidationException actualSessionValidationException =
+            await Assert.ThrowsAsync<SessionValidationException>(recordTask.AsTask);
+
+        // then
+        actualSessionValidationException.Should()
+            .BeEquivalentTo(expectedSessionValidationException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedSessionValidationException))),
+                    Times.Once);
+
+        this.sessionBrokerMock.Verify(broker =>
+            broker.UpsertSessionAsync(It.IsAny<AgentSession>()),
+                Times.Never);
+
+        this.sessionBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Sessions/SessionServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Sessions/SessionServiceTests.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Sessions;
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Services.Foundations.Sessions;
+using Tynamix.ObjectFiller;
+using Xeptions;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Sessions;
+
+public partial class SessionServiceTests
+{
+    private readonly Mock<ISessionBroker> sessionBrokerMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+    private readonly ISessionService sessionService;
+
+    public SessionServiceTests()
+    {
+        this.sessionBrokerMock = new Mock<ISessionBroker>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.sessionService = new SessionService(
+            sessionBroker: this.sessionBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static AgentSession CreateRandomSession() =>
+        new()
+        {
+            Id = CreateRandomString(),
+            History = [new AgentTurn(CreateRandomString(), CreateRandomString())],
+            RunId = CreateRandomString()
+        };
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents/Models/Foundations/Sessions/Exceptions/FailedSessionDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Sessions/Exceptions/FailedSessionDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Sessions.Exceptions;
+
+public class FailedSessionDependencyException : Xeption
+{
+    public FailedSessionDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Sessions/Exceptions/FailedSessionServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Sessions/Exceptions/FailedSessionServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Sessions.Exceptions;
+
+public class FailedSessionServiceException : Xeption
+{
+    public FailedSessionServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Sessions/Exceptions/InvalidSessionException.cs
+++ b/Standard.Agents/Models/Foundations/Sessions/Exceptions/InvalidSessionException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Sessions.Exceptions;
+
+public class InvalidSessionException : Xeption
+{
+    public InvalidSessionException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Sessions/Exceptions/SessionDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Sessions/Exceptions/SessionDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Sessions.Exceptions;
+
+public class SessionDependencyException : Xeption
+{
+    public SessionDependencyException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Sessions/Exceptions/SessionServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Sessions/Exceptions/SessionServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Sessions.Exceptions;
+
+public class SessionServiceException : Xeption
+{
+    public SessionServiceException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Sessions/Exceptions/SessionValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Sessions/Exceptions/SessionValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Sessions.Exceptions;
+
+public class SessionValidationException : Xeption
+{
+    public SessionValidationException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Sessions.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Sessions.cs
@@ -21,7 +21,7 @@ public partial class AgentCoordinationService
     private async ValueTask<AgentSession?> PeekSessionAsync(string sessionId) =>
         string.IsNullOrEmpty(sessionId)
             ? null
-            : await this.sessionBroker.SelectSessionAsync(sessionId);
+            : await this.sessionService!.RetrieveSessionAsync(sessionId);
 
     // A session that never delivered an answer was interrupted — killed, cancelled, out of turns,
     // or waiting on an authority. The next prompt in that session continues that run rather than
@@ -52,7 +52,7 @@ public partial class AgentCoordinationService
         // History is carried through untouched. The checkpoint records who is working the
         // session, not what was said — this prompt has no answer yet, and writing one here
         // would tell the next prompt the agent said something it never said.
-        await this.sessionBroker.UpsertSessionAsync(
+        await this.sessionService!.RecordSessionAsync(
             new AgentSession
             {
                 Id = context.SessionId,
@@ -95,7 +95,7 @@ public partial class AgentCoordinationService
         }
 
         AgentSession? existing =
-            await this.sessionBroker.SelectSessionAsync(context.SessionId);
+            await this.sessionService!.RetrieveSessionAsync(context.SessionId);
 
         IReadOnlyList<AgentTurn> history = existing?.History ?? [];
 
@@ -119,6 +119,6 @@ public partial class AgentCoordinationService
             PendingEffect = context.PendingEffect
         };
 
-        await this.sessionBroker.UpsertSessionAsync(session);
+        await this.sessionService!.RecordSessionAsync(session);
     }
 }

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -5,7 +5,7 @@
 
 using System.Runtime.CompilerServices;
 using Standard.Agents.Brokers.Loggings;
-using Standard.Agents.Brokers.Sessions;
+using Standard.Agents.Services.Foundations.Sessions;
 using Standard.Agents.Brokers.Times;
 using Standard.Agents.Models.Brokers.Sessions;
 using Standard.Agents.Models.Coordinations.Agents;
@@ -31,7 +31,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
     private readonly ILoggingBroker loggingBroker;
     private readonly ITimeBroker timeBroker;
     private readonly AgentBudget? budget;
-    private readonly ISessionBroker sessionBroker;
+    private readonly ISessionService? sessionService;
     private readonly int maxHistoryTurns;
     private readonly int maxTurns;
     private readonly bool compensateOnFailure;
@@ -44,7 +44,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         int maxTurns = DefaultMaxTurns,
         ITimeBroker? timeBroker = null,
         AgentBudget? budget = null,
-        ISessionBroker? sessionBroker = null,
+        ISessionService? sessionService = null,
         int maxHistoryTurns = 20,
         bool compensateOnFailure = false)
     {
@@ -56,7 +56,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         this.maxTurns = maxTurns;
         this.timeBroker = timeBroker ?? new TimeBroker();
         this.budget = budget;
-        this.sessionBroker = sessionBroker ?? new NotConfiguredSessionBroker();
+        this.sessionService = sessionService;
         this.maxHistoryTurns = maxHistoryTurns;
     }
 

--- a/Standard.Agents/Services/Foundations/Sessions/ISessionService.cs
+++ b/Standard.Agents/Services/Foundations/Sessions/ISessionService.cs
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Sessions;
+
+namespace Standard.Agents.Services.Foundations.Sessions;
+
+public interface ISessionService
+{
+    /// <summary>
+    /// The conversation so far, or <c>null</c> when this is the first prompt in it.
+    /// </summary>
+    ValueTask<AgentSession?> RetrieveSessionAsync(string sessionId);
+
+    /// <summary>Writes the conversation back, replacing what was there.</summary>
+    ValueTask RecordSessionAsync(AgentSession session);
+}

--- a/Standard.Agents/Services/Foundations/Sessions/SessionService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Sessions/SessionService.Exceptions.cs
@@ -1,0 +1,153 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Foundations.Sessions.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Sessions;
+
+public partial class SessionService
+{
+    private delegate ValueTask<AgentSession?> ReturningSessionFunction();
+    private delegate ValueTask ReturningNothingFunction();
+
+    private async ValueTask<AgentSession?> TryCatch(
+        ReturningSessionFunction returningSessionFunction)
+    {
+        try
+        {
+            return await returningSessionFunction();
+        }
+        catch (InvalidSessionException invalidSessionException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidSessionException);
+        }
+        catch (FileNotFoundException fileNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(fileNotFoundException);
+        }
+        catch (DirectoryNotFoundException directoryNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(directoryNotFoundException);
+        }
+        catch (UnauthorizedAccessException unauthorizedAccessException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(unauthorizedAccessException);
+        }
+        catch (IOException ioException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(ioException);
+        }
+        catch (Exception exception)
+        {
+            var failedSessionServiceException =
+                new FailedSessionServiceException(
+                    message: "Failed session service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedSessionServiceException);
+        }
+    }
+
+    private async ValueTask TryCatch(ReturningNothingFunction returningNothingFunction)
+    {
+        try
+        {
+            await returningNothingFunction();
+        }
+        catch (InvalidSessionException invalidSessionException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidSessionException);
+        }
+        catch (FileNotFoundException fileNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(fileNotFoundException);
+        }
+        catch (DirectoryNotFoundException directoryNotFoundException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(directoryNotFoundException);
+        }
+        catch (UnauthorizedAccessException unauthorizedAccessException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(unauthorizedAccessException);
+        }
+        catch (IOException ioException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(ioException);
+        }
+        catch (Exception exception)
+        {
+            var failedSessionServiceException =
+                new FailedSessionServiceException(
+                    message: "Failed session service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedSessionServiceException);
+        }
+    }
+
+    private async ValueTask<SessionValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption? exception)
+    {
+        var sessionValidationException =
+            new SessionValidationException(
+                message: "Session validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(sessionValidationException);
+
+        return sessionValidationException;
+    }
+
+    private async ValueTask<SessionDependencyException>
+        CreateAndLogCriticalDependencyExceptionAsync(Exception exception)
+    {
+        var failedSessionDependencyException =
+            new FailedSessionDependencyException(
+                message: "Failed session dependency error occurred, contact support.",
+                innerException: exception);
+
+        var sessionDependencyException =
+            new SessionDependencyException(
+                message: "Session dependency error occurred, contact support.",
+                innerException: failedSessionDependencyException);
+
+        await this.loggingBroker.LogCriticalAsync(sessionDependencyException);
+
+        return sessionDependencyException;
+    }
+
+    private async ValueTask<SessionDependencyException> CreateAndLogDependencyExceptionAsync(
+        Exception exception)
+    {
+        var failedSessionDependencyException =
+            new FailedSessionDependencyException(
+                message: "Failed session dependency error occurred, contact support.",
+                innerException: exception);
+
+        var sessionDependencyException =
+            new SessionDependencyException(
+                message: "Session dependency error occurred, contact support.",
+                innerException: failedSessionDependencyException);
+
+        await this.loggingBroker.LogErrorAsync(sessionDependencyException);
+
+        return sessionDependencyException;
+    }
+
+    private async ValueTask<SessionServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption? exception)
+    {
+        var sessionServiceException =
+            new SessionServiceException(
+                message: "Session service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(sessionServiceException);
+
+        return sessionServiceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Sessions/SessionService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Sessions/SessionService.Validations.cs
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Foundations.Sessions.Exceptions;
+
+namespace Standard.Agents.Services.Foundations.Sessions;
+
+public partial class SessionService
+{
+    private static void ValidateSessionId(string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            throw new InvalidSessionException(
+                message: "Invalid session. Please correct the error and try again.");
+        }
+    }
+
+    // A session with no id cannot be read back, so writing one loses the conversation silently —
+    // the next prompt finds nothing and the agent forgets, with no error anywhere to explain it.
+    private static void ValidateSession(AgentSession session)
+    {
+        if (session is null || string.IsNullOrWhiteSpace(session.Id))
+        {
+            throw new InvalidSessionException(
+                message: "Invalid session. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Sessions/SessionService.cs
+++ b/Standard.Agents/Services/Foundations/Sessions/SessionService.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Sessions;
+using Standard.Agents.Models.Brokers.Sessions;
+
+namespace Standard.Agents.Services.Foundations.Sessions;
+
+// The conversation, as a foundation rather than as a broker reached from above.
+//
+// Coordination held ISessionBroker directly, which meant a disk full or a permission denied
+// surfaced unmapped and was attributed to the loop rather than to the store. A foundation is what
+// supplies the three things that call was missing: validation, exception mapping, and attribution
+// (docs/architecture-alignment.md).
+public partial class SessionService : ISessionService
+{
+    private readonly ISessionBroker sessionBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public SessionService(
+        ISessionBroker sessionBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.sessionBroker = sessionBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<AgentSession?> RetrieveSessionAsync(string sessionId) =>
+    TryCatch(async () =>
+    {
+        await ValueTask.CompletedTask;
+
+        return (AgentSession?)null;
+    });
+
+    public ValueTask RecordSessionAsync(AgentSession session) =>
+    TryCatch(async () =>
+    {
+        await ValueTask.CompletedTask;
+    });
+}

--- a/Standard.Agents/Services/Foundations/Sessions/SessionService.cs
+++ b/Standard.Agents/Services/Foundations/Sessions/SessionService.cs
@@ -31,14 +31,18 @@ public partial class SessionService : ISessionService
     public ValueTask<AgentSession?> RetrieveSessionAsync(string sessionId) =>
     TryCatch(async () =>
     {
-        await ValueTask.CompletedTask;
+        ValidateSessionId(sessionId);
 
-        return (AgentSession?)null;
+        // A conversation that has not started is not an error — null is the ordinary first
+        // prompt, and it has to stay distinguishable from a failure to read.
+        return await this.sessionBroker.SelectSessionAsync(sessionId);
     });
 
     public ValueTask RecordSessionAsync(AgentSession session) =>
     TryCatch(async () =>
     {
-        await ValueTask.CompletedTask;
+        ValidateSession(session);
+
+        await this.sessionBroker.UpsertSessionAsync(session);
     });
 }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -42,6 +42,7 @@ using Standard.Agents.Services.Foundations.Judges;
 using Standard.Agents.Services.Foundations.Knowledges;
 using Standard.Agents.Services.Foundations.Memorys;
 using Standard.Agents.Services.Foundations.Returns;
+using Standard.Agents.Services.Foundations.Sessions;
 using Standard.Agents.Services.Foundations.Skills;
 using Standard.Agents.Services.Orchestrations.Data;
 using Standard.Agents.Services.Orchestrations.Decision;
@@ -1207,9 +1208,13 @@ public sealed partial class StandardAgent : IAgent
             this.screenToolOutput ? gate : null,
             this.identityResolver);
 
+        var sessions = new SessionService(
+            this.sessionBroker ?? new NotConfiguredSessionBroker(),
+            logging);
+
         return new AgentCoordinationService(
             data, decision, direction, logging, this.maxTurns, new TimeBroker(), this.budget,
-            this.sessionBroker, this.maxHistoryTurns, this.compensateOnFailure);
+            sessions, this.maxHistoryTurns, this.compensateOnFailure);
     }
 
     // The catalog a "{{tools}}" marker in the agent's Data expands into. Only tools that


### PR DESCRIPTION
Step 1 of [`docs/architecture-alignment.md`](https://github.com/hassanhabib/The-Standard-Agent/blob/main/docs/architecture-alignment.md), fixing violation **C** — Coordination held `ISessionBroker` directly.

The cost of that was concrete, not stylistic. A full disk or a permission denied surfaced as an unmapped `IOException` and was attributed to the **loop**. `SessionService` supplies the three things the direct call was missing: validation, exception mapping, attribution. A store failure now arrives as `SessionDependencyException` naming the store.

- `RetrieveSessionAsync` returns `null` for a conversation that has not started — the ordinary first prompt is not an error, and it has to stay distinguishable from a failure to read.
- `RecordSessionAsync` rejects a session with no id. Writing one loses the conversation *silently*: nothing throws, the next prompt finds nothing, and the agent forgets with no error to explain it.
- Six exception models and the full `TryCatch` mapping, matching the `MemoryService` template exactly.

Twelve new tests — logic, both validations, and three that pin an IO error, an access denial and a service error to *session* failures rather than to whoever called them. All twelve fail in the FAIL commit.

**One thing this does not fix yet, stated plainly:** Coordination now reaches a *foundation* directly, still skipping the orchestration tier. That is step 8. What this PR buys is the wrapping — the part that was costing attribution.

399 tests, 30 vectors, Critical certified. No public API change.