### PR TITLE
MAJOR FOUNDATIONS: Add The Perimeter Foundations

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Foundations/Perimeter/PerimeterFoundationTests.Exceptions.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Perimeter/PerimeterFoundationTests.Exceptions.cs
@@ -101,6 +101,10 @@ public partial class PerimeterFoundationTests
                 expectedApprovalDependencyException))),
                     Times.Once);
 
+        this.approvalBrokerMock.Verify(broker =>
+            broker.RequestAsync(randomEffect),
+                Times.Once);
+
         this.approvalBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
@@ -144,6 +148,10 @@ public partial class PerimeterFoundationTests
                 expectedEffectLedgerDependencyException))),
                     Times.Once);
 
+        this.effectLedgerBrokerMock.Verify(broker =>
+            broker.InsertOutcomeAsync(randomEffect, randomOutcome),
+                Times.Once);
+
         this.effectLedgerBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
@@ -184,6 +192,10 @@ public partial class PerimeterFoundationTests
                 expectedEffectLedgerDependencyException))),
                     Times.Once);
 
+        this.effectLedgerBrokerMock.Verify(broker =>
+            broker.SelectOutcomeAsync(randomEffect),
+                Times.Once);
+
         this.effectLedgerBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();
     }
@@ -223,6 +235,10 @@ public partial class PerimeterFoundationTests
             broker.LogErrorAsync(It.Is(SameExceptionAs(
                 expectedPolicyServiceException))),
                     Times.Once);
+
+        this.policyBrokerMock.Verify(broker =>
+            broker.AuthorizeAsync(randomEffect),
+                Times.Once);
 
         this.policyBrokerMock.VerifyNoOtherCalls();
         this.loggingBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Perimeter/PerimeterFoundationTests.Exceptions.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Perimeter/PerimeterFoundationTests.Exceptions.cs
@@ -1,0 +1,230 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Models.Foundations.Approvals.Exceptions;
+using Standard.Agents.Models.Foundations.EffectLedgers.Exceptions;
+using Standard.Agents.Models.Foundations.Policys.Exceptions;
+using Standard.Agents.Models.Orchestrations.Effects;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Perimeter;
+
+// The reason these foundations exist. Each resource failure must arrive named after its own
+// resource — otherwise a full disk gets blamed on the orchestration that happened to ask.
+public partial class PerimeterFoundationTests
+{
+    [Fact]
+    public async Task ShouldThrowDependencyExceptionOnAuthorizeIfPolicyEngineIsUnreachableAsync()
+    {
+        // given
+        AgentEffect randomEffect = CreateRandomEffect();
+        var httpRequestException = new HttpRequestException();
+
+        var failedPolicyDependencyException =
+            new FailedPolicyDependencyException(
+                message: "Failed policy dependency error occurred, contact support.",
+                innerException: httpRequestException);
+
+        var expectedPolicyDependencyException =
+            new PolicyDependencyException(
+                message: "Policy dependency error occurred, contact support.",
+                innerException: failedPolicyDependencyException);
+
+        this.policyBrokerMock.Setup(broker =>
+            broker.AuthorizeAsync(It.IsAny<AgentEffect>()))
+                .ThrowsAsync(httpRequestException);
+
+        // when
+        ValueTask<AuthorizationDecision> authorizeTask =
+            this.policyService.AuthorizeEffectAsync(randomEffect);
+
+        PolicyDependencyException actualException =
+            await Assert.ThrowsAsync<PolicyDependencyException>(authorizeTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedPolicyDependencyException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedPolicyDependencyException))),
+                    Times.Once);
+
+        this.policyBrokerMock.Verify(broker =>
+            broker.AuthorizeAsync(randomEffect),
+                Times.Once);
+
+        this.policyBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // The most consequential of the three. An authority that cannot be reached is a dependency
+    // failure, never a verdict — a system that reads an outage as an answer will eventually read
+    // it as a yes.
+    [Fact]
+    public async Task ShouldThrowDependencyExceptionOnRequestApprovalIfAuthorityIsUnreachableAsync()
+    {
+        // given
+        AgentEffect randomEffect = CreateRandomEffect();
+        var httpRequestException = new HttpRequestException();
+
+        var failedApprovalDependencyException =
+            new FailedApprovalDependencyException(
+                message: "Failed approval dependency error occurred, contact support.",
+                innerException: httpRequestException);
+
+        var expectedApprovalDependencyException =
+            new ApprovalDependencyException(
+                message: "Approval dependency error occurred, contact support.",
+                innerException: failedApprovalDependencyException);
+
+        this.approvalBrokerMock.Setup(broker =>
+            broker.RequestAsync(It.IsAny<AgentEffect>()))
+                .ThrowsAsync(httpRequestException);
+
+        // when
+        ValueTask<ApprovalDecision> requestTask =
+            this.approvalService.RequestApprovalAsync(randomEffect);
+
+        ApprovalDependencyException actualException =
+            await Assert.ThrowsAsync<ApprovalDependencyException>(requestTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedApprovalDependencyException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedApprovalDependencyException))),
+                    Times.Once);
+
+        this.approvalBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // The failure that started the whole alignment: a full disk in the file-backed ledger,
+    // surfacing unmapped and attributed to Direction.
+    [Fact]
+    public async Task ShouldThrowDependencyExceptionOnRecordOutcomeIfDiskIsFullAsync()
+    {
+        // given
+        AgentEffect randomEffect = CreateRandomEffect();
+        string randomOutcome = CreateRandomString();
+        var ioException = new IOException();
+
+        var failedEffectLedgerDependencyException =
+            new FailedEffectLedgerDependencyException(
+                message: "Failed effect ledger dependency error occurred, contact support.",
+                innerException: ioException);
+
+        var expectedEffectLedgerDependencyException =
+            new EffectLedgerDependencyException(
+                message: "Effect ledger dependency error occurred, contact support.",
+                innerException: failedEffectLedgerDependencyException);
+
+        this.effectLedgerBrokerMock.Setup(broker =>
+            broker.InsertOutcomeAsync(It.IsAny<AgentEffect>(), It.IsAny<string>()))
+                .ThrowsAsync(ioException);
+
+        // when
+        ValueTask recordTask =
+            this.effectLedgerService.RecordOutcomeAsync(randomEffect, randomOutcome);
+
+        EffectLedgerDependencyException actualException =
+            await Assert.ThrowsAsync<EffectLedgerDependencyException>(recordTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedEffectLedgerDependencyException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedEffectLedgerDependencyException))),
+                    Times.Once);
+
+        this.effectLedgerBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowCriticalDependencyExceptionOnRetrieveOutcomeIfAccessDeniedAsync()
+    {
+        // given
+        AgentEffect randomEffect = CreateRandomEffect();
+        var unauthorizedAccessException = new UnauthorizedAccessException();
+
+        var failedEffectLedgerDependencyException =
+            new FailedEffectLedgerDependencyException(
+                message: "Failed effect ledger dependency error occurred, contact support.",
+                innerException: unauthorizedAccessException);
+
+        var expectedEffectLedgerDependencyException =
+            new EffectLedgerDependencyException(
+                message: "Effect ledger dependency error occurred, contact support.",
+                innerException: failedEffectLedgerDependencyException);
+
+        this.effectLedgerBrokerMock.Setup(broker =>
+            broker.SelectOutcomeAsync(It.IsAny<AgentEffect>()))
+                .ThrowsAsync(unauthorizedAccessException);
+
+        // when
+        ValueTask<string?> retrieveTask =
+            this.effectLedgerService.RetrieveOutcomeAsync(randomEffect);
+
+        EffectLedgerDependencyException actualException =
+            await Assert.ThrowsAsync<EffectLedgerDependencyException>(retrieveTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedEffectLedgerDependencyException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogCriticalAsync(It.Is(SameExceptionAs(
+                expectedEffectLedgerDependencyException))),
+                    Times.Once);
+
+        this.effectLedgerBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldThrowServiceExceptionOnAuthorizeIfServiceErrorOccursAsync()
+    {
+        // given
+        AgentEffect randomEffect = CreateRandomEffect();
+        var serviceException = new Exception();
+
+        var failedPolicyServiceException =
+            new FailedPolicyServiceException(
+                message: "Failed policy service error occurred, contact support.",
+                innerException: serviceException);
+
+        var expectedPolicyServiceException =
+            new PolicyServiceException(
+                message: "Policy service error occurred, contact support.",
+                innerException: failedPolicyServiceException);
+
+        this.policyBrokerMock.Setup(broker =>
+            broker.AuthorizeAsync(It.IsAny<AgentEffect>()))
+                .ThrowsAsync(serviceException);
+
+        // when
+        ValueTask<AuthorizationDecision> authorizeTask =
+            this.policyService.AuthorizeEffectAsync(randomEffect);
+
+        PolicyServiceException actualException =
+            await Assert.ThrowsAsync<PolicyServiceException>(authorizeTask.AsTask);
+
+        // then
+        actualException.Should().BeEquivalentTo(expectedPolicyServiceException);
+
+        this.loggingBrokerMock.Verify(broker =>
+            broker.LogErrorAsync(It.Is(SameExceptionAs(
+                expectedPolicyServiceException))),
+                    Times.Once);
+
+        this.policyBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Perimeter/PerimeterFoundationTests.Logic.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Perimeter/PerimeterFoundationTests.Logic.cs
@@ -1,0 +1,160 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Models.Orchestrations.Effects;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Perimeter;
+
+public partial class PerimeterFoundationTests
+{
+    [Fact]
+    public async Task ShouldAuthorizeEffectAsync()
+    {
+        // given
+        AgentEffect randomEffect = CreateRandomEffect();
+        AuthorizationDecision expectedDecision = AuthorizationDecision.Deny("not permitted");
+
+        this.policyBrokerMock.Setup(broker =>
+            broker.AuthorizeAsync(randomEffect))
+                .ReturnsAsync(expectedDecision);
+
+        // when — the decision must be the broker's, unchanged. A foundation that softened a
+        // denial would be deciding policy, which is not its job.
+        AuthorizationDecision actualDecision =
+            await this.policyService.AuthorizeEffectAsync(randomEffect);
+
+        // then
+        actualDecision.Should().BeEquivalentTo(expectedDecision);
+
+        this.policyBrokerMock.Verify(broker =>
+            broker.AuthorizeAsync(randomEffect),
+                Times.Once);
+
+        this.policyBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldRequestApprovalAsync()
+    {
+        // given
+        AgentEffect randomEffect = CreateRandomEffect();
+        ApprovalDecision expectedDecision = ApprovalDecision.Pending;
+
+        this.approvalBrokerMock.Setup(broker =>
+            broker.RequestAsync(randomEffect))
+                .ReturnsAsync(expectedDecision);
+
+        // when
+        ApprovalDecision actualDecision =
+            await this.approvalService.RequestApprovalAsync(randomEffect);
+
+        // then — Pending must survive the trip. Turning it into anything else here is the one
+        // mistake that would let an unanswered approval look like consent.
+        actualDecision.Should().Be(expectedDecision);
+
+        this.approvalBrokerMock.Verify(broker =>
+            broker.RequestAsync(randomEffect),
+                Times.Once);
+
+        this.approvalBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldRetrieveOutcomeAsync()
+    {
+        // given
+        AgentEffect randomEffect = CreateRandomEffect();
+        string randomOutcome = CreateRandomString();
+        string expectedOutcome = randomOutcome;
+
+        this.effectLedgerBrokerMock.Setup(broker =>
+            broker.SelectOutcomeAsync(randomEffect))
+                .ReturnsAsync(expectedOutcome);
+
+        // when
+        string? actualOutcome =
+            await this.effectLedgerService.RetrieveOutcomeAsync(randomEffect);
+
+        // then
+        actualOutcome.Should().Be(expectedOutcome);
+
+        this.effectLedgerBrokerMock.Verify(broker =>
+            broker.SelectOutcomeAsync(randomEffect),
+                Times.Once);
+
+        this.effectLedgerBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // An act that has not run yet returns null, and that has to stay distinct from a read that
+    // failed — one means proceed, the other means stop.
+    [Fact]
+    public async Task ShouldRetrieveNoOutcomeOnRetrieveOutcomeIfActIsNewAsync()
+    {
+        // given
+        AgentEffect randomEffect = CreateRandomEffect();
+
+        this.effectLedgerBrokerMock.Setup(broker =>
+            broker.SelectOutcomeAsync(randomEffect))
+                .ReturnsAsync((string?)null);
+
+        // when
+        string? actualOutcome =
+            await this.effectLedgerService.RetrieveOutcomeAsync(randomEffect);
+
+        // then
+        actualOutcome.Should().BeNull();
+
+        this.effectLedgerBrokerMock.Verify(broker =>
+            broker.SelectOutcomeAsync(randomEffect),
+                Times.Once);
+
+        this.effectLedgerBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldRecordOutcomeAsync()
+    {
+        // given
+        AgentEffect randomEffect = CreateRandomEffect();
+        string randomOutcome = CreateRandomString();
+
+        // when
+        await this.effectLedgerService.RecordOutcomeAsync(randomEffect, randomOutcome);
+
+        // then
+        this.effectLedgerBrokerMock.Verify(broker =>
+            broker.InsertOutcomeAsync(randomEffect, randomOutcome),
+                Times.Once);
+
+        this.effectLedgerBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ShouldReleaseClaimAsync()
+    {
+        // given
+        AgentEffect randomEffect = CreateRandomEffect();
+
+        // when
+        await this.effectLedgerService.ReleaseClaimAsync(randomEffect);
+
+        // then
+        this.effectLedgerBrokerMock.Verify(broker =>
+            broker.DeleteClaimAsync(randomEffect),
+                Times.Once);
+
+        this.effectLedgerBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Perimeter/PerimeterFoundationTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Perimeter/PerimeterFoundationTests.cs
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Linq.Expressions;
+using Moq;
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Brokers.Effects;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Policies;
+using Standard.Agents.Models.Orchestrations.Effects;
+using Standard.Agents.Services.Foundations.Approvals;
+using Standard.Agents.Services.Foundations.EffectLedgers;
+using Standard.Agents.Services.Foundations.Policys;
+using Tynamix.ObjectFiller;
+using Xeptions;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Perimeter;
+
+// The three perimeter foundations share one job: turn a resource failure into a failure named
+// after the resource. They are tested together because that is the property, and it is the same
+// property three times.
+public partial class PerimeterFoundationTests
+{
+    private readonly Mock<IPolicyBroker> policyBrokerMock;
+    private readonly Mock<IApprovalBroker> approvalBrokerMock;
+    private readonly Mock<IEffectLedgerBroker> effectLedgerBrokerMock;
+    private readonly Mock<ILoggingBroker> loggingBrokerMock;
+
+    private readonly IPolicyService policyService;
+    private readonly IApprovalService approvalService;
+    private readonly IEffectLedgerService effectLedgerService;
+
+    public PerimeterFoundationTests()
+    {
+        this.policyBrokerMock = new Mock<IPolicyBroker>();
+        this.approvalBrokerMock = new Mock<IApprovalBroker>();
+        this.effectLedgerBrokerMock = new Mock<IEffectLedgerBroker>();
+        this.loggingBrokerMock = new Mock<ILoggingBroker>();
+
+        this.policyService = new PolicyService(
+            policyBroker: this.policyBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+
+        this.approvalService = new ApprovalService(
+            approvalBroker: this.approvalBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+
+        this.effectLedgerService = new EffectLedgerService(
+            effectLedgerBroker: this.effectLedgerBrokerMock.Object,
+            loggingBroker: this.loggingBrokerMock.Object);
+    }
+
+    private static string CreateRandomString() =>
+        new MnemonicString().GetValue();
+
+    private static AgentEffect CreateRandomEffect() =>
+        AgentEffect.For(
+            runId: CreateRandomString(),
+            toolName: CreateRandomString(),
+            arguments: CreateRandomString());
+
+    private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
+        actualException => actualException.SameExceptionAs(expectedException);
+}

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Guardians.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Direction/DirectionOrchestrationServiceTests.Guardians.Act.cs
@@ -6,6 +6,8 @@
 using FluentAssertions;
 using Moq;
 using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Brokers.Policies;
+using Standard.Agents.Services.Foundations.Policys;
 using Standard.Agents.Services.Orchestrations.Direction;
 using Xunit;
 
@@ -22,7 +24,9 @@ public partial class DirectionOrchestrationServiceTests
             externalToolService: this.externalToolServiceMock.Object,
             returnService: this.returnServiceMock.Object,
             loggingBroker: this.loggingBrokerMock.Object,
-            allowedTools: ["calculator"]);
+            policyService: new PolicyService(
+                new AllowListPolicyBroker(["calculator"]),
+                this.loggingBrokerMock.Object));
 
         AgentContext inputContext =
             CreateContextWithDirection("webhook", "https://evil.example/exfiltrate");
@@ -55,7 +59,9 @@ public partial class DirectionOrchestrationServiceTests
             externalToolService: this.externalToolServiceMock.Object,
             returnService: this.returnServiceMock.Object,
             loggingBroker: this.loggingBrokerMock.Object,
-            allowedTools: ["calculator"]);
+            policyService: new PolicyService(
+                new AllowListPolicyBroker(["calculator"]),
+                this.loggingBrokerMock.Object));
 
         AgentContext inputContext = CreateContextWithDirection("calculator", "2 + 2");
 

--- a/Standard.Agents/Models/Foundations/Approvals/Exceptions/ApprovalDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Approvals/Exceptions/ApprovalDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Approvals.Exceptions;
+
+public class ApprovalDependencyException : Xeption
+{
+    public ApprovalDependencyException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Approvals/Exceptions/ApprovalServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Approvals/Exceptions/ApprovalServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Approvals.Exceptions;
+
+public class ApprovalServiceException : Xeption
+{
+    public ApprovalServiceException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Approvals/Exceptions/ApprovalValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Approvals/Exceptions/ApprovalValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Approvals.Exceptions;
+
+public class ApprovalValidationException : Xeption
+{
+    public ApprovalValidationException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Approvals/Exceptions/FailedApprovalDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Approvals/Exceptions/FailedApprovalDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Approvals.Exceptions;
+
+public class FailedApprovalDependencyException : Xeption
+{
+    public FailedApprovalDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Approvals/Exceptions/FailedApprovalServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Approvals/Exceptions/FailedApprovalServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Approvals.Exceptions;
+
+public class FailedApprovalServiceException : Xeption
+{
+    public FailedApprovalServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Approvals/Exceptions/InvalidApprovalException.cs
+++ b/Standard.Agents/Models/Foundations/Approvals/Exceptions/InvalidApprovalException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Approvals.Exceptions;
+
+public class InvalidApprovalException : Xeption
+{
+    public InvalidApprovalException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/EffectLedgerDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/EffectLedgerDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.EffectLedgers.Exceptions;
+
+public class EffectLedgerDependencyException : Xeption
+{
+    public EffectLedgerDependencyException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/EffectLedgerServiceException.cs
+++ b/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/EffectLedgerServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.EffectLedgers.Exceptions;
+
+public class EffectLedgerServiceException : Xeption
+{
+    public EffectLedgerServiceException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/EffectLedgerValidationException.cs
+++ b/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/EffectLedgerValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.EffectLedgers.Exceptions;
+
+public class EffectLedgerValidationException : Xeption
+{
+    public EffectLedgerValidationException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/FailedEffectLedgerDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/FailedEffectLedgerDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.EffectLedgers.Exceptions;
+
+public class FailedEffectLedgerDependencyException : Xeption
+{
+    public FailedEffectLedgerDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/FailedEffectLedgerServiceException.cs
+++ b/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/FailedEffectLedgerServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.EffectLedgers.Exceptions;
+
+public class FailedEffectLedgerServiceException : Xeption
+{
+    public FailedEffectLedgerServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/InvalidEffectLedgerException.cs
+++ b/Standard.Agents/Models/Foundations/EffectLedgers/Exceptions/InvalidEffectLedgerException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.EffectLedgers.Exceptions;
+
+public class InvalidEffectLedgerException : Xeption
+{
+    public InvalidEffectLedgerException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Policys/Exceptions/FailedPolicyDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Policys/Exceptions/FailedPolicyDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Policys.Exceptions;
+
+public class FailedPolicyDependencyException : Xeption
+{
+    public FailedPolicyDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Policys/Exceptions/FailedPolicyServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Policys/Exceptions/FailedPolicyServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Policys.Exceptions;
+
+public class FailedPolicyServiceException : Xeption
+{
+    public FailedPolicyServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Policys/Exceptions/InvalidPolicyException.cs
+++ b/Standard.Agents/Models/Foundations/Policys/Exceptions/InvalidPolicyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Policys.Exceptions;
+
+public class InvalidPolicyException : Xeption
+{
+    public InvalidPolicyException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Policys/Exceptions/PolicyDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Policys/Exceptions/PolicyDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Policys.Exceptions;
+
+public class PolicyDependencyException : Xeption
+{
+    public PolicyDependencyException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Policys/Exceptions/PolicyServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Policys/Exceptions/PolicyServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Policys.Exceptions;
+
+public class PolicyServiceException : Xeption
+{
+    public PolicyServiceException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Policys/Exceptions/PolicyValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Policys/Exceptions/PolicyValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Policys.Exceptions;
+
+public class PolicyValidationException : Xeption
+{
+    public PolicyValidationException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Services/Foundations/Approvals/ApprovalService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Approvals/ApprovalService.Exceptions.cs
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Approvals.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Approvals;
+
+public partial class ApprovalService
+{
+    private async ValueTask<T> TryCatch<T>(Func<ValueTask<T>> returningFunction)
+    {
+        try
+        {
+            return await returningFunction();
+        }
+        catch (InvalidApprovalException invalidException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidException);
+        }
+        catch (UnauthorizedAccessException unauthorizedAccessException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(unauthorizedAccessException);
+        }
+        catch (IOException ioException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(ioException);
+        }
+        catch (HttpRequestException httpRequestException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(httpRequestException);
+        }
+        catch (Exception exception)
+        {
+            var failedServiceException =
+                new FailedApprovalServiceException(
+                    message: "Failed approval service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedServiceException);
+        }
+    }
+
+    private async ValueTask TryCatch(Func<ValueTask> returningNothingFunction)
+    {
+        await TryCatch(async () =>
+        {
+            await returningNothingFunction();
+
+            return true;
+        });
+    }
+
+    private async ValueTask<ApprovalValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption? exception)
+    {
+        var validationException =
+            new ApprovalValidationException(
+                message: "Approval validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(validationException);
+
+        return validationException;
+    }
+
+    private async ValueTask<ApprovalDependencyException>
+        CreateAndLogCriticalDependencyExceptionAsync(Exception exception)
+    {
+        var dependencyException = Wrap(exception);
+
+        await this.loggingBroker.LogCriticalAsync(dependencyException);
+
+        return dependencyException;
+    }
+
+    private async ValueTask<ApprovalDependencyException> CreateAndLogDependencyExceptionAsync(
+        Exception exception)
+    {
+        var dependencyException = Wrap(exception);
+
+        await this.loggingBroker.LogErrorAsync(dependencyException);
+
+        return dependencyException;
+    }
+
+    private static ApprovalDependencyException Wrap(Exception exception) =>
+        new(
+            message: "Approval dependency error occurred, contact support.",
+            innerException: new FailedApprovalDependencyException(
+                message: "Failed approval dependency error occurred, contact support.",
+                innerException: exception));
+
+    private async ValueTask<ApprovalServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption? exception)
+    {
+        var serviceException =
+            new ApprovalServiceException(
+                message: "Approval service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(serviceException);
+
+        return serviceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Approvals/ApprovalService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Approvals/ApprovalService.Validations.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Approvals.Exceptions;
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Services.Foundations.Approvals;
+
+public partial class ApprovalService
+{
+    // An act with no name cannot be judged, and judging it anyway would return a decision about
+    // nothing that the perimeter would then act on (SPEC.md §4.9).
+    private static void ValidateEffect(AgentEffect effect)
+    {
+        if (effect is null || string.IsNullOrWhiteSpace(effect.ToolName))
+        {
+            throw new InvalidApprovalException(
+                message: "Invalid approval. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Approvals/ApprovalService.cs
+++ b/Standard.Agents/Services/Foundations/Approvals/ApprovalService.cs
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Services.Foundations.Approvals;
+
+// Human approval, as a foundation.
+//
+// This one matters most of the three. An approval broker reaches a person — a queue, a ticket, a
+// chat prompt — and when that is unreachable the honest answer is a dependency failure, never a
+// decision. A raw exception escaping into Direction risks being read as "not approved", and a
+// system that treats an outage as a verdict is a system that will one day treat it as a yes.
+public partial class ApprovalService : IApprovalService
+{
+    private readonly IApprovalBroker approvalBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public ApprovalService(
+        IApprovalBroker approvalBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.approvalBroker = approvalBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<ApprovalDecision> RequestApprovalAsync(AgentEffect effect) =>
+    TryCatch(async () =>
+    {
+        await ValueTask.CompletedTask;
+
+        return ApprovalDecision.Approved;
+    });
+}

--- a/Standard.Agents/Services/Foundations/Approvals/ApprovalService.cs
+++ b/Standard.Agents/Services/Foundations/Approvals/ApprovalService.cs
@@ -31,8 +31,10 @@ public partial class ApprovalService : IApprovalService
     public ValueTask<ApprovalDecision> RequestApprovalAsync(AgentEffect effect) =>
     TryCatch(async () =>
     {
-        await ValueTask.CompletedTask;
+        ValidateEffect(effect);
 
-        return ApprovalDecision.Approved;
+        // Pending must survive the trip untouched. Turning an unanswered request into anything
+        // else here is the one mistake that would let silence look like consent.
+        return await this.approvalBroker.RequestAsync(effect);
     });
 }

--- a/Standard.Agents/Services/Foundations/Approvals/IApprovalService.cs
+++ b/Standard.Agents/Services/Foundations/Approvals/IApprovalService.cs
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Services.Foundations.Approvals;
+
+public interface IApprovalService
+{
+    /// <summary>
+    /// Asks an authority to permit this act. <c>Pending</c> is not consent (SPEC.md §4.9).
+    /// </summary>
+    ValueTask<ApprovalDecision> RequestApprovalAsync(AgentEffect effect);
+}

--- a/Standard.Agents/Services/Foundations/EffectLedgers/EffectLedgerService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/EffectLedgers/EffectLedgerService.Exceptions.cs
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.EffectLedgers.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.EffectLedgers;
+
+public partial class EffectLedgerService
+{
+    private async ValueTask<T> TryCatch<T>(Func<ValueTask<T>> returningFunction)
+    {
+        try
+        {
+            return await returningFunction();
+        }
+        catch (InvalidEffectLedgerException invalidException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidException);
+        }
+        catch (UnauthorizedAccessException unauthorizedAccessException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(unauthorizedAccessException);
+        }
+        catch (IOException ioException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(ioException);
+        }
+        catch (HttpRequestException httpRequestException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(httpRequestException);
+        }
+        catch (Exception exception)
+        {
+            var failedServiceException =
+                new FailedEffectLedgerServiceException(
+                    message: "Failed effect ledger service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedServiceException);
+        }
+    }
+
+    private async ValueTask TryCatch(Func<ValueTask> returningNothingFunction)
+    {
+        await TryCatch(async () =>
+        {
+            await returningNothingFunction();
+
+            return true;
+        });
+    }
+
+    private async ValueTask<EffectLedgerValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption? exception)
+    {
+        var validationException =
+            new EffectLedgerValidationException(
+                message: "Effect ledger validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(validationException);
+
+        return validationException;
+    }
+
+    private async ValueTask<EffectLedgerDependencyException>
+        CreateAndLogCriticalDependencyExceptionAsync(Exception exception)
+    {
+        var dependencyException = Wrap(exception);
+
+        await this.loggingBroker.LogCriticalAsync(dependencyException);
+
+        return dependencyException;
+    }
+
+    private async ValueTask<EffectLedgerDependencyException> CreateAndLogDependencyExceptionAsync(
+        Exception exception)
+    {
+        var dependencyException = Wrap(exception);
+
+        await this.loggingBroker.LogErrorAsync(dependencyException);
+
+        return dependencyException;
+    }
+
+    private static EffectLedgerDependencyException Wrap(Exception exception) =>
+        new(
+            message: "Effect ledger dependency error occurred, contact support.",
+            innerException: new FailedEffectLedgerDependencyException(
+                message: "Failed effect ledger dependency error occurred, contact support.",
+                innerException: exception));
+
+    private async ValueTask<EffectLedgerServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption? exception)
+    {
+        var serviceException =
+            new EffectLedgerServiceException(
+                message: "Effect ledger service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(serviceException);
+
+        return serviceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/EffectLedgers/EffectLedgerService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/EffectLedgers/EffectLedgerService.Validations.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.EffectLedgers.Exceptions;
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Services.Foundations.EffectLedgers;
+
+public partial class EffectLedgerService
+{
+    // An act with no name cannot be judged, and judging it anyway would return a decision about
+    // nothing that the perimeter would then act on (SPEC.md §4.9).
+    private static void ValidateEffect(AgentEffect effect)
+    {
+        if (effect is null || string.IsNullOrWhiteSpace(effect.ToolName))
+        {
+            throw new InvalidEffectLedgerException(
+                message: "Invalid effect ledger. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/EffectLedgers/EffectLedgerService.cs
+++ b/Standard.Agents/Services/Foundations/EffectLedgers/EffectLedgerService.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Effects;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Services.Foundations.EffectLedgers;
+
+// Run-once, as a foundation.
+//
+// This is the one that motivated the whole alignment: a full disk in the file-backed ledger
+// surfaced as a raw IOException and got attributed to Direction, so the trace blamed the
+// orchestration for a storage failure (docs/architecture-alignment.md).
+public partial class EffectLedgerService : IEffectLedgerService
+{
+    private readonly IEffectLedgerBroker effectLedgerBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public EffectLedgerService(
+        IEffectLedgerBroker effectLedgerBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.effectLedgerBroker = effectLedgerBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<string?> RetrieveOutcomeAsync(AgentEffect effect) =>
+    TryCatch(async () =>
+    {
+        await ValueTask.CompletedTask;
+
+        return (string?)null;
+    });
+
+    public ValueTask RecordOutcomeAsync(AgentEffect effect, string outcome) =>
+    TryCatch(async () =>
+    {
+        await ValueTask.CompletedTask;
+    });
+
+    public ValueTask ReleaseClaimAsync(AgentEffect effect) =>
+    TryCatch(async () =>
+    {
+        await ValueTask.CompletedTask;
+    });
+}

--- a/Standard.Agents/Services/Foundations/EffectLedgers/EffectLedgerService.cs
+++ b/Standard.Agents/Services/Foundations/EffectLedgers/EffectLedgerService.cs
@@ -30,20 +30,26 @@ public partial class EffectLedgerService : IEffectLedgerService
     public ValueTask<string?> RetrieveOutcomeAsync(AgentEffect effect) =>
     TryCatch(async () =>
     {
-        await ValueTask.CompletedTask;
+        ValidateEffect(effect);
 
-        return (string?)null;
+        // Null means this act has not run and the caller should proceed. It has to stay distinct
+        // from a read that failed: one means go, the other means stop.
+        return await this.effectLedgerBroker.SelectOutcomeAsync(effect);
     });
 
     public ValueTask RecordOutcomeAsync(AgentEffect effect, string outcome) =>
     TryCatch(async () =>
     {
-        await ValueTask.CompletedTask;
+        ValidateEffect(effect);
+
+        await this.effectLedgerBroker.InsertOutcomeAsync(effect, outcome);
     });
 
     public ValueTask ReleaseClaimAsync(AgentEffect effect) =>
     TryCatch(async () =>
     {
-        await ValueTask.CompletedTask;
+        ValidateEffect(effect);
+
+        await this.effectLedgerBroker.DeleteClaimAsync(effect);
     });
 }

--- a/Standard.Agents/Services/Foundations/EffectLedgers/IEffectLedgerService.cs
+++ b/Standard.Agents/Services/Foundations/EffectLedgers/IEffectLedgerService.cs
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Services.Foundations.EffectLedgers;
+
+public interface IEffectLedgerService
+{
+    /// <summary>
+    /// Claims this act and reports whether it already happened — <c>null</c> when this is the
+    /// first time and the caller should proceed (SPEC.md §4.9).
+    /// </summary>
+    ValueTask<string?> RetrieveOutcomeAsync(AgentEffect effect);
+
+    /// <summary>Records what the act produced, before the loop advances.</summary>
+    ValueTask RecordOutcomeAsync(AgentEffect effect, string outcome);
+
+    /// <summary>
+    /// Gives back the claim on an act that was held rather than performed. A held act is one that
+    /// still has to be able to happen.
+    /// </summary>
+    ValueTask ReleaseClaimAsync(AgentEffect effect);
+}

--- a/Standard.Agents/Services/Foundations/Policys/IPolicyService.cs
+++ b/Standard.Agents/Services/Foundations/Policys/IPolicyService.cs
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Services.Foundations.Policys;
+
+public interface IPolicyService
+{
+    /// <summary>May this act happen, and if not, why not (SPEC.md §4.9)?</summary>
+    ValueTask<AuthorizationDecision> AuthorizeEffectAsync(AgentEffect effect);
+}

--- a/Standard.Agents/Services/Foundations/Policys/PolicyService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Policys/PolicyService.Exceptions.cs
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Policys.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Policys;
+
+public partial class PolicyService
+{
+    private async ValueTask<T> TryCatch<T>(Func<ValueTask<T>> returningFunction)
+    {
+        try
+        {
+            return await returningFunction();
+        }
+        catch (InvalidPolicyException invalidException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidException);
+        }
+        catch (UnauthorizedAccessException unauthorizedAccessException)
+        {
+            throw await CreateAndLogCriticalDependencyExceptionAsync(unauthorizedAccessException);
+        }
+        catch (IOException ioException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(ioException);
+        }
+        catch (HttpRequestException httpRequestException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(httpRequestException);
+        }
+        catch (Exception exception)
+        {
+            var failedServiceException =
+                new FailedPolicyServiceException(
+                    message: "Failed policy service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedServiceException);
+        }
+    }
+
+    private async ValueTask TryCatch(Func<ValueTask> returningNothingFunction)
+    {
+        await TryCatch(async () =>
+        {
+            await returningNothingFunction();
+
+            return true;
+        });
+    }
+
+    private async ValueTask<PolicyValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption? exception)
+    {
+        var validationException =
+            new PolicyValidationException(
+                message: "Policy validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(validationException);
+
+        return validationException;
+    }
+
+    private async ValueTask<PolicyDependencyException>
+        CreateAndLogCriticalDependencyExceptionAsync(Exception exception)
+    {
+        var dependencyException = Wrap(exception);
+
+        await this.loggingBroker.LogCriticalAsync(dependencyException);
+
+        return dependencyException;
+    }
+
+    private async ValueTask<PolicyDependencyException> CreateAndLogDependencyExceptionAsync(
+        Exception exception)
+    {
+        var dependencyException = Wrap(exception);
+
+        await this.loggingBroker.LogErrorAsync(dependencyException);
+
+        return dependencyException;
+    }
+
+    private static PolicyDependencyException Wrap(Exception exception) =>
+        new(
+            message: "Policy dependency error occurred, contact support.",
+            innerException: new FailedPolicyDependencyException(
+                message: "Failed policy dependency error occurred, contact support.",
+                innerException: exception));
+
+    private async ValueTask<PolicyServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption? exception)
+    {
+        var serviceException =
+            new PolicyServiceException(
+                message: "Policy service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(serviceException);
+
+        return serviceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Policys/PolicyService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Policys/PolicyService.Validations.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Policys.Exceptions;
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Services.Foundations.Policys;
+
+public partial class PolicyService
+{
+    // An act with no name cannot be judged, and judging it anyway would return a decision about
+    // nothing that the perimeter would then act on (SPEC.md §4.9).
+    private static void ValidateEffect(AgentEffect effect)
+    {
+        if (effect is null || string.IsNullOrWhiteSpace(effect.ToolName))
+        {
+            throw new InvalidPolicyException(
+                message: "Invalid policy. Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Policys/PolicyService.cs
+++ b/Standard.Agents/Services/Foundations/Policys/PolicyService.cs
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Policies;
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Services.Foundations.Policys;
+
+// Authorization, as a foundation rather than as a broker reached from Direction.
+//
+// A policy engine is usually somewhere else — a rules service, an OPA sidecar, a database. When it
+// is unreachable, that has to arrive as a POLICY failure. Reached directly from Direction it
+// arrived as an unmapped HttpRequestException blamed on the orchestration, which is a trace that
+// sends someone to read the wrong code (docs/architecture-alignment.md).
+public partial class PolicyService : IPolicyService
+{
+    private readonly IPolicyBroker policyBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public PolicyService(
+        IPolicyBroker policyBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.policyBroker = policyBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<AuthorizationDecision> AuthorizeEffectAsync(AgentEffect effect) =>
+    TryCatch(async () =>
+    {
+        await ValueTask.CompletedTask;
+
+        return AuthorizationDecision.Allow();
+    });
+}

--- a/Standard.Agents/Services/Foundations/Policys/PolicyService.cs
+++ b/Standard.Agents/Services/Foundations/Policys/PolicyService.cs
@@ -31,8 +31,10 @@ public partial class PolicyService : IPolicyService
     public ValueTask<AuthorizationDecision> AuthorizeEffectAsync(AgentEffect effect) =>
     TryCatch(async () =>
     {
-        await ValueTask.CompletedTask;
+        ValidateEffect(effect);
 
-        return AuthorizationDecision.Allow();
+        // The broker's decision, unchanged. A foundation that softened a denial would be
+        // deciding policy, which is not its job.
+        return await this.policyBroker.AuthorizeAsync(effect);
     });
 }

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.Perimeter.cs
@@ -36,7 +36,7 @@ public partial class DirectionOrchestrationService
             principal: this.identityResolver?.Invoke());
 
         // 1 — authorize
-        AuthorizationDecision decision = await this.policyBroker.AuthorizeAsync(effect);
+        AuthorizationDecision decision = await this.policyService.AuthorizeEffectAsync(effect);
 
         if (decision.Permitted is false)
         {
@@ -48,7 +48,7 @@ public partial class DirectionOrchestrationService
         }
 
         // 2 — record the intent, and learn whether this act already happened
-        string? priorOutcome = await this.effectLedgerBroker.SelectOutcomeAsync(effect);
+        string? priorOutcome = await this.effectLedgerService.RetrieveOutcomeAsync(effect);
 
         if (priorOutcome is not null)
         {
@@ -62,7 +62,7 @@ public partial class DirectionOrchestrationService
         // 3 — approve, if required
         if (effect.ApprovalRequired)
         {
-            ApprovalDecision approval = await this.approvalBroker.RequestAsync(effect);
+            ApprovalDecision approval = await this.approvalService.RequestApprovalAsync(effect);
 
             if (approval is not ApprovalDecision.Approved)
             {
@@ -77,7 +77,7 @@ public partial class DirectionOrchestrationService
         string output = await RunToolAsync(context);
 
         // 5 — record the outcome, before the loop advances
-        await this.effectLedgerBroker.InsertOutcomeAsync(effect, output);
+        await this.effectLedgerService.RecordOutcomeAsync(effect, output);
 
         // Remember that this run performed it, so it can be unwound. Only here: an effect denied,
         // held for approval, or replayed from the ledger returned above and was never performed by
@@ -150,7 +150,7 @@ public partial class DirectionOrchestrationService
         // given back (SPEC.md §4.9). Leaving it standing would make the approval unusable when it
         // finally arrives: the authority says yes, the resumed run proposes the act, and the
         // ledger reports it as already done.
-        await this.effectLedgerBroker.DeleteClaimAsync(effect);
+        await this.effectLedgerService.ReleaseClaimAsync(effect);
 
         if (approval is ApprovalDecision.Denied)
         {

--- a/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/DirectionOrchestrationService.cs
@@ -4,6 +4,9 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Services.Foundations.Approvals;
+using Standard.Agents.Services.Foundations.EffectLedgers;
+using Standard.Agents.Services.Foundations.Policys;
 using Standard.Agents.Brokers.Effects;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Policies;
@@ -26,9 +29,9 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
     private readonly IExternalToolService externalToolService;
     private readonly IReturnService returnService;
     private readonly ILoggingBroker loggingBroker;
-    private readonly IPolicyBroker policyBroker;
-    private readonly IApprovalBroker approvalBroker;
-    private readonly IEffectLedgerBroker effectLedgerBroker;
+    private readonly IPolicyService policyService;
+    private readonly IApprovalService approvalService;
+    private readonly IEffectLedgerService effectLedgerService;
     private readonly IGateService? screeningService;
     private readonly HashSet<string> irreversibleToolNames;
 
@@ -42,10 +45,9 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
         IExternalToolService externalToolService,
         IReturnService returnService,
         ILoggingBroker loggingBroker,
-        IEnumerable<string>? allowedTools = null,
-        IPolicyBroker? policyBroker = null,
-        IApprovalBroker? approvalBroker = null,
-        IEffectLedgerBroker? effectLedgerBroker = null,
+        IPolicyService? policyService = null,
+        IApprovalService? approvalService = null,
+        IEffectLedgerService? effectLedgerService = null,
         IEnumerable<string>? irreversibleTools = null,
         IGateService? screeningService = null,
         Func<AgentPrincipal?>? identityResolver = null)
@@ -58,15 +60,17 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
         this.returnService = returnService;
         this.loggingBroker = loggingBroker;
 
-        // The allow-list is now expressed as a policy, so the simple answer and an external
-        // policy engine travel one seam and a denial carries a reason either way (SPEC.md §4.9).
-        this.policyBroker = policyBroker
-            ?? (allowedTools is null
-                ? new NotConfiguredPolicyBroker()
-                : new AllowListPolicyBroker(allowedTools));
+        // The perimeter arrives as three foundations rather than three brokers, so a policy engine
+        // that cannot be reached, an authority that cannot be asked, and a ledger that cannot be
+        // written each fail under their own name (docs/architecture-alignment.md).
+        this.policyService = policyService
+            ?? new PolicyService(new NotConfiguredPolicyBroker(), loggingBroker);
 
-        this.approvalBroker = approvalBroker ?? new NotConfiguredApprovalBroker();
-        this.effectLedgerBroker = effectLedgerBroker ?? new InMemoryEffectLedgerBroker();
+        this.approvalService = approvalService
+            ?? new ApprovalService(new NotConfiguredApprovalBroker(), loggingBroker);
+
+        this.effectLedgerService = effectLedgerService
+            ?? new EffectLedgerService(new InMemoryEffectLedgerBroker(), loggingBroker);
 
         this.irreversibleToolNames =
             new HashSet<string>(irreversibleTools ?? [], StringComparer.OrdinalIgnoreCase);

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -42,6 +42,9 @@ using Standard.Agents.Services.Foundations.Judges;
 using Standard.Agents.Services.Foundations.Knowledges;
 using Standard.Agents.Services.Foundations.Memorys;
 using Standard.Agents.Services.Foundations.Returns;
+using Standard.Agents.Services.Foundations.Approvals;
+using Standard.Agents.Services.Foundations.EffectLedgers;
+using Standard.Agents.Services.Foundations.Policys;
 using Standard.Agents.Services.Foundations.Sessions;
 using Standard.Agents.Services.Foundations.Skills;
 using Standard.Agents.Services.Orchestrations.Data;
@@ -1192,18 +1195,27 @@ public sealed partial class StandardAgent : IAgent
             logging,
             RenderToolDefinitions(allTools));
 
+        // The allow-list is expressed as a policy, so the simple answer and an external policy
+        // engine travel one seam and a denial carries a reason either way (SPEC.md §4.9).
+        IPolicyBroker policy = this.policyBroker
+            ?? (this.allowedTools is null
+                ? new NotConfiguredPolicyBroker()
+                : new AllowListPolicyBroker(this.allowedTools));
+
+        IApprovalBroker approvals = this.approvalBroker
+            ?? (this.approvalRequiredTools is null
+                ? new NotConfiguredApprovalBroker()
+                : new RequireApprovalBroker(this.approvalRequiredTools));
+
         DirectionOrchestrationService direction = new(
             new InternalToolService(toolBroker, logging),
             new ExternalToolService(mcp, logging),
             new ReturnService(logging),
             logging,
-            this.allowedTools,
-            this.policyBroker,
-            this.approvalBroker
-                ?? (this.approvalRequiredTools is null
-                    ? null
-                    : new RequireApprovalBroker(this.approvalRequiredTools)),
-            this.effectLedgerBroker,
+            new PolicyService(policy, logging),
+            new ApprovalService(approvals, logging),
+            new EffectLedgerService(
+                this.effectLedgerBroker ?? new InMemoryEffectLedgerBroker(), logging),
             this.approvalRequiredTools,
             this.screenToolOutput ? gate : null,
             this.identityResolver);


### PR DESCRIPTION
Steps 2–4 of [`docs/architecture-alignment.md`](https://github.com/hassanhabib/The-Standard-Agent/blob/main/docs/architecture-alignment.md), closing violations **B** and **C**.

`PolicyService`, `ApprovalService` and `EffectLedgerService` wrap their brokers; Direction holds the three services instead. **The only brokers left above the foundation tier are Logging and Time**, both utilities by design.

**One branch for three services.** They fix one violation, they arrive together, and none is useful alone — Direction cannot stop holding brokers until all three exist.

Each service returns its broker''s answer **untouched**, and that is the one property worth guarding:

- A foundation that softened a policy denial would be *deciding policy*, which is not its job.
- A foundation that turned an unreachable authority into a verdict would eventually turn an outage into a **yes**. An authority that cannot be asked is a dependency failure, never an answer.

The three exception tests name the failures that motivated the whole alignment: an unreachable policy engine, an unreachable authority, and the full disk in the file-backed ledger that used to surface as a raw `IOException` blamed on Direction.

The allow-list moved to composition, where it was always a policy in disguise.

**Also fixed four of my own tests.** They called `VerifyNoOtherCalls()` without first verifying the broker call, so they failed against the real implementation for a reason that had nothing to do with it — worth naming, because a test that fails for the wrong reason is worse than one that doesn''t exist.

410 tests, 30 vectors, Critical certified. No public API change.