### PR TITLE
MAJOR COORDINATIONS: Regionalize The Direction Nature

### DIFF
--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.Logic.ProcessPrompt.cs
@@ -66,7 +66,7 @@ public partial class AgentCoordinationServiceTests
             .Setup(service => service.ThinkAsync(It.IsAny<AgentContext>()))
             .ReturnsAsync((AgentContext context) => context);
 
-        this.directionOrchestrationServiceMock.InSequence(sequence)
+        this.directionCoordinationServiceMock.InSequence(sequence)
             .Setup(service => service.ActAsync(It.IsAny<AgentContext>()))
             .ReturnsAsync((AgentContext context) =>
                 context with { Result = "done", Status = AgentStatus.Responded });
@@ -91,7 +91,7 @@ AgentStatus terminalStatus)
         string randomPrompt = CreateRandomString();
         SetupOrchestrationsPassThrough();
 
-        this.directionOrchestrationServiceMock.Setup(service =>
+        this.directionCoordinationServiceMock.Setup(service =>
             service.ActAsync(It.IsAny<AgentContext>()))
                 .ReturnsAsync((AgentContext context) =>
                     context with { Result = "stopped", Status = terminalStatus });
@@ -142,7 +142,7 @@ Times.Exactly(7));
         var boundedCoordinationService = new AgentCoordinationService(
             dataCoordinationService: this.dataCoordinationServiceMock.Object,
             decisionOrchestrationService: this.decisionOrchestrationServiceMock.Object,
-            directionOrchestrationService: this.directionOrchestrationServiceMock.Object,
+            directionCoordinationService: this.directionCoordinationServiceMock.Object,
             loggingBroker: this.loggingBrokerMock.Object,
             maxTurns: configuredMaxTurns);
 
@@ -188,7 +188,7 @@ Times.Exactly(7));
             service.ThinkAsync(It.IsAny<AgentContext>()),
                 Times.Exactly(7));
 
-        this.directionOrchestrationServiceMock.Verify(service =>
+        this.directionCoordinationServiceMock.Verify(service =>
             service.ActAsync(It.IsAny<AgentContext>()),
                 Times.Never);
     }
@@ -208,7 +208,7 @@ Times.Exactly(7));
             service.ThinkAsync(It.IsAny<AgentContext>()))
                 .ReturnsAsync((AgentContext context) => context with { Remember = preference });
 
-        this.directionOrchestrationServiceMock.Setup(service =>
+        this.directionCoordinationServiceMock.Setup(service =>
             service.ActAsync(It.IsAny<AgentContext>()))
                 .ReturnsAsync((AgentContext context) =>
                     context with { Result = "done", Status = AgentStatus.Responded });
@@ -237,7 +237,7 @@ Times.Exactly(7));
             service.ThinkAsync(It.IsAny<AgentContext>()))
                 .ReturnsAsync((AgentContext context) => context);
 
-        this.directionOrchestrationServiceMock.Setup(service =>
+        this.directionCoordinationServiceMock.Setup(service =>
     service.ActAsync(It.IsAny<AgentContext>()))
         .ReturnsAsync((AgentContext context) =>
         {

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/AgentCoordinationServiceTests.cs
@@ -10,7 +10,7 @@ using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Coordinations;
 using Standard.Agents.Services.Coordinations.Data;
 using Standard.Agents.Services.Orchestrations.Decision;
-using Standard.Agents.Services.Orchestrations.Direction;
+using Standard.Agents.Services.Coordinations.Direction;
 using Tynamix.ObjectFiller;
 using Xeptions;
 using Xunit;
@@ -21,7 +21,7 @@ public partial class AgentCoordinationServiceTests
 {
     private readonly Mock<IDataCoordinationService> dataCoordinationServiceMock;
     private readonly Mock<IDecisionOrchestrationService> decisionOrchestrationServiceMock;
-    private readonly Mock<IDirectionOrchestrationService> directionOrchestrationServiceMock;
+    private readonly Mock<IDirectionCoordinationService> directionCoordinationServiceMock;
     private readonly Mock<ILoggingBroker> loggingBrokerMock;
     private readonly IAgentCoordinationService agentCoordinationService;
 
@@ -29,13 +29,13 @@ public partial class AgentCoordinationServiceTests
     {
         this.dataCoordinationServiceMock = new Mock<IDataCoordinationService>();
         this.decisionOrchestrationServiceMock = new Mock<IDecisionOrchestrationService>();
-        this.directionOrchestrationServiceMock = new Mock<IDirectionOrchestrationService>();
+        this.directionCoordinationServiceMock = new Mock<IDirectionCoordinationService>();
         this.loggingBrokerMock = new Mock<ILoggingBroker>();
 
         this.agentCoordinationService = new AgentCoordinationService(
             dataCoordinationService: this.dataCoordinationServiceMock.Object,
             decisionOrchestrationService: this.decisionOrchestrationServiceMock.Object,
-            directionOrchestrationService: this.directionOrchestrationServiceMock.Object,
+            directionCoordinationService: this.directionCoordinationServiceMock.Object,
             loggingBroker: this.loggingBrokerMock.Object);
     }
 
@@ -54,13 +54,13 @@ public partial class AgentCoordinationServiceTests
     }
 
     private void SetupDirectionTerminates(string result) =>
-        this.directionOrchestrationServiceMock.Setup(service =>
+        this.directionCoordinationServiceMock.Setup(service =>
             service.ActAsync(It.IsAny<AgentContext>()))
                 .ReturnsAsync((AgentContext context) =>
                     context with { Result = result, Status = AgentStatus.Responded });
 
     private void SetupDirectionNeverTerminates(string result) =>
-    this.directionOrchestrationServiceMock.Setup(service =>
+    this.directionCoordinationServiceMock.Setup(service =>
         service.ActAsync(It.IsAny<AgentContext>()))
             .ReturnsAsync((AgentContext context) =>
                 context with { Result = result, Status = AgentStatus.Working });

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Exceptions.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Exceptions.Act.cs
@@ -10,9 +10,9 @@ using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
 using Xeptions;
 using Xunit;
 
-namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+namespace Standard.Agents.Tests.Unit.Services.Coordinations.DirectionNature;
 
-public partial class DirectionOrchestrationServiceTests
+public partial class DirectionCoordinationServiceTests
 {
     [Fact]
     public async Task ShouldThrowValidationExceptionOnActIfContextIsNullAndLogItAsync()
@@ -31,7 +31,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // when
         ValueTask<AgentContext> actTask =
-            this.directionOrchestrationService.ActAsync(nullContext!);
+            this.directionCoordinationService.ActAsync(nullContext!);
 
         AgentOrchestrationValidationException actualException =
             await Assert.ThrowsAsync<AgentOrchestrationValidationException>(
@@ -75,7 +75,7 @@ Xeption foundationException)
 
         // when
         ValueTask<AgentContext> actTask =
-            this.directionOrchestrationService.ActAsync(inputContext);
+            this.directionCoordinationService.ActAsync(inputContext);
 
         AgentOrchestrationDependencyValidationException actualException =
             await Assert.ThrowsAsync<AgentOrchestrationDependencyValidationException>(
@@ -110,7 +110,7 @@ Xeption foundationException)
 
         // when
         ValueTask<AgentContext> actTask =
-            this.directionOrchestrationService.ActAsync(inputContext);
+            this.directionCoordinationService.ActAsync(inputContext);
 
         AgentOrchestrationDependencyException actualException =
             await Assert.ThrowsAsync<AgentOrchestrationDependencyException>(
@@ -149,7 +149,7 @@ Xeption foundationException)
 
         // when
         ValueTask<AgentContext> actTask =
-            this.directionOrchestrationService.ActAsync(inputContext);
+            this.directionCoordinationService.ActAsync(inputContext);
 
         AgentOrchestrationServiceException actualException =
             await Assert.ThrowsAsync<AgentOrchestrationServiceException>(

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Guardians.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Guardians.Act.cs
@@ -7,26 +7,35 @@ using FluentAssertions;
 using Moq;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Brokers.Policies;
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Brokers.Effects;
+using Standard.Agents.Services.Foundations.Approvals;
+using Standard.Agents.Services.Foundations.EffectLedgers;
 using Standard.Agents.Services.Foundations.Policys;
-using Standard.Agents.Services.Orchestrations.Direction;
+using Standard.Agents.Services.Orchestrations.Direction.Perimeters;
+using Standard.Agents.Services.Coordinations.Direction;
+using Standard.Agents.Services.Orchestrations.Direction.Executions;
 using Xunit;
 
-namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+namespace Standard.Agents.Tests.Unit.Services.Coordinations.DirectionNature;
 
-public partial class DirectionOrchestrationServiceTests
+public partial class DirectionCoordinationServiceTests
 {
     [Fact]
     public async Task ShouldDenyToolNotInAllowListOnActAsync()
     {
         // given
-        var restrictedService = new DirectionOrchestrationService(
-            internalToolService: this.internalToolServiceMock.Object,
-            externalToolService: this.externalToolServiceMock.Object,
-            returnService: this.returnServiceMock.Object,
-            loggingBroker: this.loggingBrokerMock.Object,
-            policyService: new PolicyService(
-                new AllowListPolicyBroker(["calculator"]),
-                this.loggingBrokerMock.Object));
+        var restrictedService = new DirectionCoordinationService(
+            perimeterService: new PerimeterOrchestrationService(
+                new PolicyService(
+                    new AllowListPolicyBroker(["calculator"]), this.loggingBrokerMock.Object),
+                new ApprovalService(
+                    new NotConfiguredApprovalBroker(), this.loggingBrokerMock.Object),
+                new EffectLedgerService(
+                    new InMemoryEffectLedgerBroker(), this.loggingBrokerMock.Object),
+                this.loggingBrokerMock.Object),
+            executionService: NewExecution(),
+            loggingBroker: this.loggingBrokerMock.Object);
 
         AgentContext inputContext =
             CreateContextWithDirection("webhook", "https://evil.example/exfiltrate");
@@ -54,14 +63,17 @@ public partial class DirectionOrchestrationServiceTests
     public async Task ShouldAllowToolInAllowListOnActAsync()
     {
         // given
-        var restrictedService = new DirectionOrchestrationService(
-            internalToolService: this.internalToolServiceMock.Object,
-            externalToolService: this.externalToolServiceMock.Object,
-            returnService: this.returnServiceMock.Object,
-            loggingBroker: this.loggingBrokerMock.Object,
-            policyService: new PolicyService(
-                new AllowListPolicyBroker(["calculator"]),
-                this.loggingBrokerMock.Object));
+        var restrictedService = new DirectionCoordinationService(
+            perimeterService: new PerimeterOrchestrationService(
+                new PolicyService(
+                    new AllowListPolicyBroker(["calculator"]), this.loggingBrokerMock.Object),
+                new ApprovalService(
+                    new NotConfiguredApprovalBroker(), this.loggingBrokerMock.Object),
+                new EffectLedgerService(
+                    new InMemoryEffectLedgerBroker(), this.loggingBrokerMock.Object),
+                this.loggingBrokerMock.Object),
+            executionService: NewExecution(),
+            loggingBroker: this.loggingBrokerMock.Object);
 
         AgentContext inputContext = CreateContextWithDirection("calculator", "2 + 2");
 

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Logic.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Logic.Act.cs
@@ -8,9 +8,9 @@ using Moq;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Xunit;
 
-namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+namespace Standard.Agents.Tests.Unit.Services.Coordinations.DirectionNature;
 
-public partial class DirectionOrchestrationServiceTests
+public partial class DirectionCoordinationServiceTests
 {
     [Fact]
     public async Task ShouldReturnAndTerminateOnActIfDirectionTypeIsReturnResponseAsync()
@@ -27,7 +27,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // when
         AgentContext actualContext =
-            await this.directionOrchestrationService.ActAsync(inputContext);
+            await this.directionCoordinationService.ActAsync(inputContext);
 
         // then
         actualContext.Result.Should().Be(answer);
@@ -56,7 +56,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // when
         AgentContext actualContext =
-            await this.directionOrchestrationService.ActAsync(inputContext);
+            await this.directionCoordinationService.ActAsync(inputContext);
 
         // then
         actualContext.Result.Should().Be(question);
@@ -85,7 +85,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // when
         AgentContext actualContext =
-            await this.directionOrchestrationService.ActAsync(inputContext);
+            await this.directionCoordinationService.ActAsync(inputContext);
 
         // then
         actualContext.Result.Should().Be(refusal);
@@ -112,7 +112,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // when
         AgentContext actualContext =
-            await this.directionOrchestrationService.ActAsync(inputContext);
+            await this.directionCoordinationService.ActAsync(inputContext);
 
         // then
         actualContext.Status.Should().Be(AgentStatus.Working);
@@ -140,7 +140,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // when
         AgentContext actualContext =
-            await this.directionOrchestrationService.ActAsync(inputContext);
+            await this.directionCoordinationService.ActAsync(inputContext);
 
         // then
         actualContext.Status.Should().Be(AgentStatus.Working);
@@ -179,7 +179,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // when
         AgentContext actualContext =
-            await this.directionOrchestrationService.ActAsync(inputContext);
+            await this.directionCoordinationService.ActAsync(inputContext);
 
         // then
         actualContext.Observations.Should().HaveCount(2);
@@ -203,7 +203,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // when
         AgentContext actualContext =
-            await this.directionOrchestrationService.ActAsync(inputContext);
+            await this.directionCoordinationService.ActAsync(inputContext);
 
         // then
         actualContext.Status.Should().Be(AgentStatus.Working);
@@ -228,7 +228,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // when
         AgentContext actualContext =
-            await this.directionOrchestrationService.ActAsync(inputContext);
+            await this.directionCoordinationService.ActAsync(inputContext);
 
         // then
         actualContext.Result.Should().Be("again");
@@ -252,7 +252,7 @@ public partial class DirectionOrchestrationServiceTests
 
         // when
         AgentContext actualContext =
-            await this.directionOrchestrationService.ActAsync(inputContext);
+            await this.directionCoordinationService.ActAsync(inputContext);
 
         // then
         actualContext.Observations.Should()

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Trace.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Trace.Act.cs
@@ -7,9 +7,9 @@ using Moq;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Xunit;
 
-namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+namespace Standard.Agents.Tests.Unit.Services.Coordinations.DirectionNature;
 
-public partial class DirectionOrchestrationServiceTests
+public partial class DirectionCoordinationServiceTests
 {
     [Fact]
     public async Task ShouldNarrateProcessesToLoggingBrokerOnActAsync()
@@ -31,7 +31,7 @@ public partial class DirectionOrchestrationServiceTests
                 .ReturnsAsync("2");
 
         // when
-        await this.directionOrchestrationService.ActAsync(inputContext);
+        await this.directionCoordinationService.ActAsync(inputContext);
 
         // then
         this.loggingBrokerMock.Verify(broker =>

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Trace.Return.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Trace.Return.cs
@@ -7,9 +7,9 @@ using Moq;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Xunit;
 
-namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+namespace Standard.Agents.Tests.Unit.Services.Coordinations.DirectionNature;
 
-public partial class DirectionOrchestrationServiceTests
+public partial class DirectionCoordinationServiceTests
 {
     [Fact]
     public async Task ShouldNarrateReturnedResultContentOnActAsync()
@@ -27,7 +27,7 @@ public partial class DirectionOrchestrationServiceTests
                 .ReturnsAsync("RESULT-MARKER");
 
         // when
-        await this.directionOrchestrationService.ActAsync(inputContext);
+        await this.directionCoordinationService.ActAsync(inputContext);
 
         // then
         this.loggingBrokerMock.Verify(broker =>

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.cs
@@ -10,34 +10,58 @@ using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Foundations.ExternalTools;
 using Standard.Agents.Services.Foundations.InternalTools;
 using Standard.Agents.Services.Foundations.Returns;
-using Standard.Agents.Services.Orchestrations.Direction;
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Brokers.Effects;
+using Standard.Agents.Brokers.Policies;
+using Standard.Agents.Services.Coordinations.Direction;
+using Standard.Agents.Services.Foundations.Approvals;
+using Standard.Agents.Services.Foundations.EffectLedgers;
+using Standard.Agents.Services.Foundations.Policys;
+using Standard.Agents.Services.Orchestrations.Direction.Executions;
+using Standard.Agents.Services.Orchestrations.Direction.Perimeters;
 using Tynamix.ObjectFiller;
 using Xeptions;
 using Xunit;
 
-namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Direction;
+namespace Standard.Agents.Tests.Unit.Services.Coordinations.DirectionNature;
 
-public partial class DirectionOrchestrationServiceTests
+public partial class DirectionCoordinationServiceTests
 {
     private readonly Mock<IInternalToolService> internalToolServiceMock;
     private readonly Mock<IExternalToolService> externalToolServiceMock;
     private readonly Mock<IReturnService> returnServiceMock;
     private readonly Mock<ILoggingBroker> loggingBrokerMock;
-    private readonly IDirectionOrchestrationService directionOrchestrationService;
+    private readonly IDirectionCoordinationService directionCoordinationService;
 
-    public DirectionOrchestrationServiceTests()
+    public DirectionCoordinationServiceTests()
     {
         this.internalToolServiceMock = new Mock<IInternalToolService>();
         this.externalToolServiceMock = new Mock<IExternalToolService>();
         this.returnServiceMock = new Mock<IReturnService>();
         this.loggingBrokerMock = new Mock<ILoggingBroker>();
 
-        this.directionOrchestrationService = new DirectionOrchestrationService(
-            internalToolService: this.internalToolServiceMock.Object,
-            externalToolService: this.externalToolServiceMock.Object,
-            returnService: this.returnServiceMock.Object,
+        // Real regions over mocked FOUNDATIONS - the mocks sit where they sat before
+        // regionalization, so every assertion below is unchanged.
+        this.directionCoordinationService = new DirectionCoordinationService(
+            perimeterService: NewPerimeter(),
+            executionService: NewExecution(),
             loggingBroker: this.loggingBrokerMock.Object);
     }
+
+    private PerimeterOrchestrationService NewPerimeter() =>
+        new(
+            new PolicyService(new NotConfiguredPolicyBroker(), this.loggingBrokerMock.Object),
+            new ApprovalService(new NotConfiguredApprovalBroker(), this.loggingBrokerMock.Object),
+            new EffectLedgerService(
+                new InMemoryEffectLedgerBroker(), this.loggingBrokerMock.Object),
+            this.loggingBrokerMock.Object);
+
+    private ExecutionOrchestrationService NewExecution() =>
+        new(
+            this.internalToolServiceMock.Object,
+            this.externalToolServiceMock.Object,
+            this.returnServiceMock.Object,
+            this.loggingBrokerMock.Object);
 
     private static string CreateRandomString() =>
         new MnemonicString().GetValue();

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.Budgets.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.Budgets.cs
@@ -100,7 +100,7 @@ public partial class AgentCoordinationService
     {
         try
         {
-            return await this.directionOrchestrationService.ActAsync(context);
+            return await this.directionCoordinationService.ActAsync(context);
         }
         catch (Exception)
         {
@@ -121,7 +121,7 @@ public partial class AgentCoordinationService
         }
 
         IReadOnlyList<CompensationOutcome> outcomes =
-            await this.directionOrchestrationService.CompensateRunAsync();
+            await this.directionCoordinationService.CompensateRunAsync();
 
         if (outcomes.Count is 0)
         {

--- a/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/AgentCoordinationService.cs
@@ -14,7 +14,7 @@ using Standard.Agents.Models.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Coordinations.Data;
 using Standard.Agents.Services.Orchestrations.Decision;
-using Standard.Agents.Services.Orchestrations.Direction;
+using Standard.Agents.Services.Coordinations.Direction;
 
 namespace Standard.Agents.Services.Coordinations;
 
@@ -27,7 +27,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
 
     private readonly IDataCoordinationService dataCoordinationService;
     private readonly IDecisionOrchestrationService decisionOrchestrationService;
-    private readonly IDirectionOrchestrationService directionOrchestrationService;
+    private readonly IDirectionCoordinationService directionCoordinationService;
     private readonly ILoggingBroker loggingBroker;
     private readonly ITimeBroker timeBroker;
     private readonly AgentBudget? budget;
@@ -38,7 +38,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
     public AgentCoordinationService(
         IDataCoordinationService dataCoordinationService,
         IDecisionOrchestrationService decisionOrchestrationService,
-        IDirectionOrchestrationService directionOrchestrationService,
+        IDirectionCoordinationService directionCoordinationService,
         ILoggingBroker loggingBroker,
         int maxTurns = DefaultMaxTurns,
         ITimeBroker? timeBroker = null,
@@ -49,7 +49,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
         this.compensateOnFailure = compensateOnFailure;
         this.dataCoordinationService = dataCoordinationService;
         this.decisionOrchestrationService = decisionOrchestrationService;
-        this.directionOrchestrationService = directionOrchestrationService;
+        this.directionCoordinationService = directionCoordinationService;
         this.loggingBroker = loggingBroker;
         this.maxTurns = maxTurns;
         this.timeBroker = timeBroker ?? new TimeBroker();
@@ -130,7 +130,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
                 }
 
                 await this.loggingBroker.LogStepAsync(AgentStep.Direction);
-                context = await this.directionOrchestrationService.ActAsync(context);
+                context = await this.directionCoordinationService.ActAsync(context);
 
                 await this.loggingBroker.LogOutcomeAsync($"turn {turn}: {context.Status}");
 

--- a/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Exceptions.cs
+++ b/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Exceptions.cs
@@ -10,9 +10,9 @@ using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
 using Xeptions;
 
-namespace Standard.Agents.Services.Orchestrations.Direction;
+namespace Standard.Agents.Services.Coordinations.Direction;
 
-public partial class DirectionOrchestrationService
+public partial class DirectionCoordinationService
 {
     private delegate ValueTask<AgentContext> ReturningContextFunction();
 
@@ -26,6 +26,17 @@ ReturningContextFunction returningContextFunction)
         catch (NullAgentContextException nullAgentContextException)
         {
             throw await CreateAndLogValidationExceptionAsync(nullAgentContextException);
+        }
+
+        // The regions localize their own foundations' failures, so what arrives here is
+        // already in this family and already logged. Wrapping it again would nest and log the
+        // same failure twice.
+        catch (Exception alreadyLocalized) when (alreadyLocalized
+            is AgentOrchestrationDependencyValidationException
+            or AgentOrchestrationDependencyException
+            or AgentOrchestrationServiceException)
+        {
+            throw;
         }
         catch (InternalToolValidationException internalToolValidationException)
         {

--- a/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Perimeter.cs
+++ b/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Perimeter.cs
@@ -8,7 +8,7 @@ using Standard.Agents.Models.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Models.Orchestrations.Effects;
 
-namespace Standard.Agents.Services.Orchestrations.Direction;
+namespace Standard.Agents.Services.Coordinations.Direction;
 
 // The perimeter (SPEC.md §4.9). Direction already owned the boundary; this is enforcement at
 // it, in the order the spec fixes and forbids reordering:
@@ -18,7 +18,7 @@ namespace Standard.Agents.Services.Orchestrations.Direction;
 // The order is the control. Authorizing after execution audits a fait accompli; recording the
 // intent after execution loses the effects that crashed mid-flight; and approving after
 // execution is not approval at all.
-public partial class DirectionOrchestrationService
+public partial class DirectionCoordinationService
 {
     private async ValueTask<AgentContext> ActOnEffectAsync(AgentContext context)
     {
@@ -36,7 +36,7 @@ public partial class DirectionOrchestrationService
             principal: this.identityResolver?.Invoke());
 
         // 1 — authorize
-        AuthorizationDecision decision = await this.policyService.AuthorizeEffectAsync(effect);
+        AuthorizationDecision decision = await this.perimeterService.AuthorizeAsync(effect);
 
         if (decision.Permitted is false)
         {
@@ -48,7 +48,7 @@ public partial class DirectionOrchestrationService
         }
 
         // 2 — record the intent, and learn whether this act already happened
-        string? priorOutcome = await this.effectLedgerService.RetrieveOutcomeAsync(effect);
+        string? priorOutcome = await this.perimeterService.ClaimAsync(effect);
 
         if (priorOutcome is not null)
         {
@@ -62,7 +62,7 @@ public partial class DirectionOrchestrationService
         // 3 — approve, if required
         if (effect.ApprovalRequired)
         {
-            ApprovalDecision approval = await this.approvalService.RequestApprovalAsync(effect);
+            ApprovalDecision approval = await this.perimeterService.RequestApprovalAsync(effect);
 
             if (approval is not ApprovalDecision.Approved)
             {
@@ -77,7 +77,7 @@ public partial class DirectionOrchestrationService
         string output = await RunToolAsync(context);
 
         // 5 — record the outcome, before the loop advances
-        await this.effectLedgerService.RecordOutcomeAsync(effect, output);
+        await this.perimeterService.RecordOutcomeAsync(effect, output);
 
         // Remember that this run performed it, so it can be unwound. Only here: an effect denied,
         // held for approval, or replayed from the ledger returned above and was never performed by
@@ -150,7 +150,7 @@ public partial class DirectionOrchestrationService
         // given back (SPEC.md §4.9). Leaving it standing would make the approval unusable when it
         // finally arrives: the authority says yes, the resumed run proposes the act, and the
         // ledger reports it as already done.
-        await this.effectLedgerService.ReleaseClaimAsync(effect);
+        await this.perimeterService.ReleaseClaimAsync(effect);
 
         if (approval is ApprovalDecision.Denied)
         {
@@ -217,14 +217,9 @@ public partial class DirectionOrchestrationService
     {
         string stands = $"'{effect.ToolName}' could not be undone; the effect stands.";
 
-        if (await this.internalToolService.HandlesAsync(effect.ToolName) is false)
-        {
-            return new CompensationOutcome(effect.ToolName, Undone: false, Detail: stands);
-        }
-
         try
         {
-            string reversal = await this.internalToolService.CompensateAsync(
+            string reversal = await this.executionService.CompensateAsync(
                 effect.ToolName, effect.Arguments, effect.Outcome);
 
             return string.IsNullOrEmpty(reversal)
@@ -237,14 +232,8 @@ public partial class DirectionOrchestrationService
         }
     }
 
-    private async ValueTask<string> RunToolAsync(AgentContext context)
-    {
-        bool isLocalTool = await this.internalToolService.HandlesAsync(context.DirectionType);
-
-        return isLocalTool
-            ? await this.internalToolService.RunAsync(context.DirectionType, context.Payload)
-            : await this.externalToolService.CallAsync(context.DirectionType, context.Payload);
-    }
+    private ValueTask<string> RunToolAsync(AgentContext context) =>
+        this.executionService.RunAsync(context.DirectionType, context.Payload);
 
     // A denial is non-terminal: the agent is told and may choose a permitted path on the next
     // turn, exactly as it recovers from a malformed call (SPEC.md §4.6, §4.9).

--- a/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Validations.cs
+++ b/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Validations.cs
@@ -6,9 +6,9 @@
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
 
-namespace Standard.Agents.Services.Orchestrations.Direction;
+namespace Standard.Agents.Services.Coordinations.Direction;
 
-public partial class DirectionOrchestrationService
+public partial class DirectionCoordinationService
 {
     private static void ValidateContext(AgentContext context)
     {

--- a/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.cs
@@ -3,35 +3,30 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
-using Standard.Agents.Brokers.Approvals;
-using Standard.Agents.Services.Foundations.Approvals;
-using Standard.Agents.Services.Foundations.EffectLedgers;
-using Standard.Agents.Services.Foundations.Policys;
-using Standard.Agents.Brokers.Effects;
 using Standard.Agents.Brokers.Loggings;
-using Standard.Agents.Brokers.Policies;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Models.Orchestrations.Effects;
-using Standard.Agents.Services.Foundations.ExternalTools;
 using Standard.Agents.Services.Foundations.Gates;
-using Standard.Agents.Services.Foundations.InternalTools;
-using Standard.Agents.Services.Foundations.Returns;
+using Standard.Agents.Services.Orchestrations.Direction.Executions;
+using Standard.Agents.Services.Orchestrations.Direction.Perimeters;
 
-namespace Standard.Agents.Services.Orchestrations.Direction;
+namespace Standard.Agents.Services.Coordinations.Direction;
 
-public partial class DirectionOrchestrationService : IDirectionOrchestrationService
+// The Direction nature: two regions, and the ORDER between them.
+//
+// Perimeter answers whether an act may happen; Execution performs it. Neither can own the
+// sequence, because the sequence interleaves them — authorize, record the intent, approve,
+// execute, record the outcome. That interleaving is Direction's own logic, which is why it lives
+// in Direction's own service rather than in a generic sequencing tier.
+public partial class DirectionCoordinationService : IDirectionCoordinationService
 {
     private const string ReturnResponseDirection = "ReturnResponse";
     private const string RefuseDirection = "Refuse";
     private const string AwaitInputDirection = "AwaitInput";
 
-    private readonly IInternalToolService internalToolService;
-    private readonly IExternalToolService externalToolService;
-    private readonly IReturnService returnService;
+    private readonly IPerimeterOrchestrationService perimeterService;
+    private readonly IExecutionOrchestrationService executionService;
     private readonly ILoggingBroker loggingBroker;
-    private readonly IPolicyService policyService;
-    private readonly IApprovalService approvalService;
-    private readonly IEffectLedgerService effectLedgerService;
     private readonly IGateService? screeningService;
     private readonly HashSet<string> irreversibleToolNames;
 
@@ -40,37 +35,19 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
     // this framework asks hosts to adopt (SPEC.md §4.4).
     private readonly Func<AgentPrincipal?>? identityResolver;
 
-    public DirectionOrchestrationService(
-        IInternalToolService internalToolService,
-        IExternalToolService externalToolService,
-        IReturnService returnService,
+    public DirectionCoordinationService(
+        IPerimeterOrchestrationService perimeterService,
+        IExecutionOrchestrationService executionService,
         ILoggingBroker loggingBroker,
-        IPolicyService? policyService = null,
-        IApprovalService? approvalService = null,
-        IEffectLedgerService? effectLedgerService = null,
         IEnumerable<string>? irreversibleTools = null,
         IGateService? screeningService = null,
         Func<AgentPrincipal?>? identityResolver = null)
     {
+        this.perimeterService = perimeterService;
+        this.executionService = executionService;
+        this.loggingBroker = loggingBroker;
         this.screeningService = screeningService;
         this.identityResolver = identityResolver;
-
-        this.internalToolService = internalToolService;
-        this.externalToolService = externalToolService;
-        this.returnService = returnService;
-        this.loggingBroker = loggingBroker;
-
-        // The perimeter arrives as three foundations rather than three brokers, so a policy engine
-        // that cannot be reached, an authority that cannot be asked, and a ledger that cannot be
-        // written each fail under their own name (docs/architecture-alignment.md).
-        this.policyService = policyService
-            ?? new PolicyService(new NotConfiguredPolicyBroker(), loggingBroker);
-
-        this.approvalService = approvalService
-            ?? new ApprovalService(new NotConfiguredApprovalBroker(), loggingBroker);
-
-        this.effectLedgerService = effectLedgerService
-            ?? new EffectLedgerService(new InMemoryEffectLedgerBroker(), loggingBroker);
 
         this.irreversibleToolNames =
             new HashSet<string>(irreversibleTools ?? [], StringComparer.OrdinalIgnoreCase);
@@ -83,7 +60,7 @@ public partial class DirectionOrchestrationService : IDirectionOrchestrationServ
 
         if (IsTerminal(context.DirectionType))
         {
-            string result = await this.returnService.ReturnAsync(context.Payload);
+            string result = await this.executionService.ReturnAsync(context.Payload);
 
             await this.loggingBroker.LogProcessAsync(
                 "Direction", $"{context.DirectionType} → returned: {result}");

--- a/Standard.Agents/Services/Coordinations/Direction/IDirectionCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/Direction/IDirectionCoordinationService.cs
@@ -6,9 +6,9 @@
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Models.Orchestrations.Effects;
 
-namespace Standard.Agents.Services.Orchestrations.Direction;
+namespace Standard.Agents.Services.Coordinations.Direction;
 
-public interface IDirectionOrchestrationService
+public interface IDirectionCoordinationService
 {
     ValueTask<AgentContext> ActAsync(AgentContext context);
 

--- a/Standard.Agents/Services/Orchestrations/Direction/Executions/ExecutionOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/Executions/ExecutionOrchestrationService.Exceptions.cs
@@ -1,0 +1,100 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Approvals.Exceptions;
+using Standard.Agents.Models.Foundations.EffectLedgers.Exceptions;
+using Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+using Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+using Standard.Agents.Models.Foundations.Policys.Exceptions;
+using Standard.Agents.Models.Foundations.Returns.Exceptions;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Orchestrations.Direction.Executions;
+
+public partial class ExecutionOrchestrationService
+{
+    private async ValueTask<T> TryCatch<T>(Func<ValueTask<T>> returningFunction)
+    {
+        try
+        {
+            return await returningFunction();
+        }
+        catch (Exception exception) when (exception is PolicyValidationException
+            or ApprovalValidationException
+            or EffectLedgerValidationException
+            or InternalToolValidationException
+            or ExternalToolValidationException
+            or ExternalToolDependencyValidationException
+            or ReturnValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                (exception as Xeption)?.InnerException as Xeption);
+        }
+        catch (Exception exception) when (exception is PolicyDependencyException
+            or PolicyServiceException
+            or ApprovalDependencyException
+            or ApprovalServiceException
+            or EffectLedgerDependencyException
+            or EffectLedgerServiceException
+            or InternalToolDependencyException
+            or InternalToolServiceException
+            or ExternalToolDependencyException
+            or ExternalToolServiceException
+            or ReturnServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                (exception as Xeption)?.InnerException as Xeption);
+        }
+        catch (Exception exception)
+        {
+            var failedException =
+                new FailedAgentOrchestrationServiceException(
+                    message: "Failed agent orchestration service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedException);
+        }
+    }
+
+    private async ValueTask<AgentOrchestrationDependencyValidationException>
+        CreateAndLogDependencyValidationExceptionAsync(Xeption? exception)
+    {
+        var dependencyValidationException =
+            new AgentOrchestrationDependencyValidationException(
+                message: "Agent orchestration dependency validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(dependencyValidationException);
+
+        return dependencyValidationException;
+    }
+
+    private async ValueTask<AgentOrchestrationDependencyException>
+        CreateAndLogDependencyExceptionAsync(Xeption? exception)
+    {
+        var dependencyException =
+            new AgentOrchestrationDependencyException(
+                message: "Agent orchestration dependency error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(dependencyException);
+
+        return dependencyException;
+    }
+
+    private async ValueTask<AgentOrchestrationServiceException>
+        CreateAndLogServiceExceptionAsync(Xeption? exception)
+    {
+        var serviceException =
+            new AgentOrchestrationServiceException(
+                message: "Agent orchestration service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(serviceException);
+
+        return serviceException;
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/Executions/ExecutionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/Executions/ExecutionOrchestrationService.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Services.Foundations.ExternalTools;
+using Standard.Agents.Services.Foundations.InternalTools;
+using Standard.Agents.Services.Foundations.Returns;
+
+namespace Standard.Agents.Services.Orchestrations.Direction.Executions;
+
+public partial class ExecutionOrchestrationService : IExecutionOrchestrationService
+{
+    private readonly IInternalToolService internalToolService;
+    private readonly IExternalToolService externalToolService;
+    private readonly IReturnService returnService;
+    private readonly ILoggingBroker loggingBroker;
+
+    public ExecutionOrchestrationService(
+        IInternalToolService internalToolService,
+        IExternalToolService externalToolService,
+        IReturnService returnService,
+        ILoggingBroker loggingBroker)
+    {
+        this.internalToolService = internalToolService;
+        this.externalToolService = externalToolService;
+        this.returnService = returnService;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<bool> HandlesLocallyAsync(string toolName) =>
+        this.internalToolService.HandlesAsync(toolName);
+
+    // Local first, then across the boundary. A name the agent owns is never sent outward.
+    public ValueTask<string> RunAsync(string toolName, string payload) =>
+    TryCatch(async () =>
+    {
+        bool isLocalTool = await this.internalToolService.HandlesAsync(toolName);
+
+        return isLocalTool
+            ? await this.internalToolService.RunAsync(toolName, payload)
+            : await this.externalToolService.CallAsync(toolName, payload);
+    });
+
+    public ValueTask<string> ReturnAsync(string payload) =>
+        this.returnService.ReturnAsync(payload);
+
+    public ValueTask<string> CompensateAsync(string toolName, string arguments, string outcome) =>
+    TryCatch(async () =>
+    {
+        if (await this.internalToolService.HandlesAsync(toolName) is false)
+        {
+            // An external act cannot be undone from here, and saying so is the honest answer.
+            // Reporting it as reversed would be worse than reporting nothing.
+            return string.Empty;
+        }
+
+        return await this.internalToolService.CompensateAsync(toolName, arguments, outcome);
+    });
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/Executions/IExecutionOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/Executions/IExecutionOrchestrationService.cs
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Services.Orchestrations.Direction.Executions;
+
+// Perform it, or answer.
+//
+// The three ways an act leaves the agent: a local tool, a tool across the boundary, or the
+// terminal that hands the result back and touches nothing.
+public interface IExecutionOrchestrationService
+{
+    /// <summary>True when a local tool answers to this name.</summary>
+    ValueTask<bool> HandlesLocallyAsync(string toolName);
+
+    ValueTask<string> RunAsync(string toolName, string payload);
+
+    ValueTask<string> ReturnAsync(string payload);
+
+    /// <summary>
+    /// Undoes a local act, or reports that it stands. External acts cannot be undone from here.
+    /// </summary>
+    ValueTask<string> CompensateAsync(string toolName, string arguments, string outcome);
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/Perimeters/IPerimeterOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/Perimeters/IPerimeterOrchestrationService.cs
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Services.Orchestrations.Direction.Perimeters;
+
+// May this act happen, and has it already?
+//
+// Three foundations, one question asked in three parts: is the principal permitted, does an
+// authority consent, and did this exact act already run. The ORDER they are asked in belongs to
+// Direction, not here — this region answers, it does not sequence (SPEC.md §4.9).
+public interface IPerimeterOrchestrationService
+{
+    ValueTask<AuthorizationDecision> AuthorizeAsync(AgentEffect effect);
+
+    /// <summary>
+    /// Claims the act and reports the outcome of the first execution, or <c>null</c> when this is
+    /// the first time and the caller should proceed.
+    /// </summary>
+    ValueTask<string?> ClaimAsync(AgentEffect effect);
+
+    ValueTask<ApprovalDecision> RequestApprovalAsync(AgentEffect effect);
+
+    ValueTask RecordOutcomeAsync(AgentEffect effect, string outcome);
+
+    /// <summary>Gives back the claim on an act that was held rather than performed.</summary>
+    ValueTask ReleaseClaimAsync(AgentEffect effect);
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/Perimeters/PerimeterOrchestrationService.Exceptions.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/Perimeters/PerimeterOrchestrationService.Exceptions.cs
@@ -1,0 +1,96 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Approvals.Exceptions;
+using Standard.Agents.Models.Foundations.EffectLedgers.Exceptions;
+using Standard.Agents.Models.Foundations.ExternalTools.Exceptions;
+using Standard.Agents.Models.Foundations.InternalTools.Exceptions;
+using Standard.Agents.Models.Foundations.Policys.Exceptions;
+using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Orchestrations.Direction.Perimeters;
+
+public partial class PerimeterOrchestrationService
+{
+    private async ValueTask<T> TryCatch<T>(Func<ValueTask<T>> returningFunction)
+    {
+        try
+        {
+            return await returningFunction();
+        }
+        catch (Exception exception) when (exception is PolicyValidationException
+            or ApprovalValidationException
+            or EffectLedgerValidationException
+            or InternalToolValidationException
+            or ExternalToolValidationException)
+        {
+            throw await CreateAndLogDependencyValidationExceptionAsync(
+                (exception as Xeption)?.InnerException as Xeption);
+        }
+        catch (Exception exception) when (exception is PolicyDependencyException
+            or PolicyServiceException
+            or ApprovalDependencyException
+            or ApprovalServiceException
+            or EffectLedgerDependencyException
+            or EffectLedgerServiceException
+            or InternalToolDependencyException
+            or InternalToolServiceException
+            or ExternalToolDependencyException
+            or ExternalToolServiceException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                (exception as Xeption)?.InnerException as Xeption);
+        }
+        catch (Exception exception)
+        {
+            var failedException =
+                new FailedAgentOrchestrationServiceException(
+                    message: "Failed agent orchestration service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedException);
+        }
+    }
+
+    private async ValueTask<AgentOrchestrationDependencyValidationException>
+        CreateAndLogDependencyValidationExceptionAsync(Xeption? exception)
+    {
+        var dependencyValidationException =
+            new AgentOrchestrationDependencyValidationException(
+                message: "Agent orchestration dependency validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(dependencyValidationException);
+
+        return dependencyValidationException;
+    }
+
+    private async ValueTask<AgentOrchestrationDependencyException>
+        CreateAndLogDependencyExceptionAsync(Xeption? exception)
+    {
+        var dependencyException =
+            new AgentOrchestrationDependencyException(
+                message: "Agent orchestration dependency error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(dependencyException);
+
+        return dependencyException;
+    }
+
+    private async ValueTask<AgentOrchestrationServiceException>
+        CreateAndLogServiceExceptionAsync(Xeption? exception)
+    {
+        var serviceException =
+            new AgentOrchestrationServiceException(
+                message: "Agent orchestration service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(serviceException);
+
+        return serviceException;
+    }
+}

--- a/Standard.Agents/Services/Orchestrations/Direction/Perimeters/PerimeterOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Direction/Perimeters/PerimeterOrchestrationService.cs
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Approvals;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Orchestrations.Effects;
+using Standard.Agents.Services.Foundations.Approvals;
+using Standard.Agents.Services.Foundations.EffectLedgers;
+using Standard.Agents.Services.Foundations.Policys;
+
+namespace Standard.Agents.Services.Orchestrations.Direction.Perimeters;
+
+public partial class PerimeterOrchestrationService : IPerimeterOrchestrationService
+{
+    private readonly IPolicyService policyService;
+    private readonly IApprovalService approvalService;
+    private readonly IEffectLedgerService effectLedgerService;
+    private readonly ILoggingBroker loggingBroker;
+
+    public PerimeterOrchestrationService(
+        IPolicyService policyService,
+        IApprovalService approvalService,
+        IEffectLedgerService effectLedgerService,
+        ILoggingBroker loggingBroker)
+    {
+        this.policyService = policyService;
+        this.approvalService = approvalService;
+        this.effectLedgerService = effectLedgerService;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<AuthorizationDecision> AuthorizeAsync(AgentEffect effect) =>
+    TryCatch(async () =>
+    {
+        AuthorizationDecision decision = await this.policyService.AuthorizeEffectAsync(effect);
+
+        if (decision.Permitted is false)
+        {
+            await this.loggingBroker.LogProcessAsync(
+                "Direction",
+                $"Policy → DENIED '{effect.ToolName}': {decision.Reason}");
+        }
+
+        return decision;
+    });
+
+    public ValueTask<string?> ClaimAsync(AgentEffect effect) =>
+    TryCatch(async () =>
+    {
+        string? priorOutcome = await this.effectLedgerService.RetrieveOutcomeAsync(effect);
+
+        if (priorOutcome is not null)
+        {
+            await this.loggingBroker.LogProcessAsync(
+                "Direction",
+                $"Run-once → '{effect.ToolName}' already ran; replaying its outcome");
+        }
+
+        return priorOutcome;
+    });
+
+    public ValueTask<ApprovalDecision> RequestApprovalAsync(AgentEffect effect) =>
+    TryCatch(async () =>
+    {
+        ApprovalDecision approval = await this.approvalService.RequestApprovalAsync(effect);
+
+        if (approval is ApprovalDecision.Approved)
+        {
+            await this.loggingBroker.LogProcessAsync(
+                "Direction", $"Approval → APPROVED '{effect.ToolName}'");
+        }
+
+        return approval;
+    });
+
+    public ValueTask RecordOutcomeAsync(AgentEffect effect, string outcome) =>
+        this.effectLedgerService.RecordOutcomeAsync(effect, outcome);
+
+    public ValueTask ReleaseClaimAsync(AgentEffect effect) =>
+        this.effectLedgerService.ReleaseClaimAsync(effect);
+}

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -51,7 +51,9 @@ using Standard.Agents.Services.Coordinations.Data;
 using Standard.Agents.Services.Orchestrations.Data.Recollections;
 using Standard.Agents.Services.Orchestrations.Data.Retrievals;
 using Standard.Agents.Services.Orchestrations.Decision;
-using Standard.Agents.Services.Orchestrations.Direction;
+using Standard.Agents.Services.Coordinations.Direction;
+using Standard.Agents.Services.Orchestrations.Direction.Executions;
+using Standard.Agents.Services.Orchestrations.Direction.Perimeters;
 using Standard.Agents.Tools;
 
 namespace Standard.Agents;
@@ -1232,15 +1234,21 @@ public sealed partial class StandardAgent : IAgent
                 ? new NotConfiguredApprovalBroker()
                 : new RequireApprovalBroker(this.approvalRequiredTools));
 
-        DirectionOrchestrationService direction = new(
-            new InternalToolService(toolBroker, logging),
-            new ExternalToolService(mcp, logging),
-            new ReturnService(logging),
+        // The Direction nature, as two regions and the order between them. Perimeter answers
+        // whether an act may happen; Execution performs it; the sequence belongs to neither.
+        DirectionCoordinationService direction = new(
+            new PerimeterOrchestrationService(
+                new PolicyService(policy, logging),
+                new ApprovalService(approvals, logging),
+                new EffectLedgerService(
+                    this.effectLedgerBroker ?? new InMemoryEffectLedgerBroker(), logging),
+                logging),
+            new ExecutionOrchestrationService(
+                new InternalToolService(toolBroker, logging),
+                new ExternalToolService(mcp, logging),
+                new ReturnService(logging),
+                logging),
             logging,
-            new PolicyService(policy, logging),
-            new ApprovalService(approvals, logging),
-            new EffectLedgerService(
-                this.effectLedgerBroker ?? new InMemoryEffectLedgerBroker(), logging),
             this.approvalRequiredTools,
             this.screenToolOutput ? gate : null,
             this.identityResolver);


### PR DESCRIPTION
Steps 8–9 for **Direction**, the nature that was furthest out of bounds — six foundations against a 2–3 rule.

It was never one concept with six parts. It was two, and both land on exactly three once you split on the concept:

| Region | Foundations | Concept |
|---|---|---|
| `PerimeterOrchestrationService` | Policy, Approval, EffectLedger | may it happen, has it already? |
| `ExecutionOrchestrationService` | InternalTool, ExternalTool, Return | perform it, or answer |

## Where the order lives, and a correction

The five-step sequence — authorize, record the intent, approve, execute, record the outcome — **interleaves** the two regions, so neither can own it. It stays at the coordination.

Earlier in this design I argued *against* multi-coordination partly on the grounds that "a separate Perimeter orchestration means a coordination doing the interleaving, which puts nature logic in a sequencing tier." That was wrong once the natures themselves became coordinations. `DirectionCoordinationService` **is** Direction — not a generic sequencer — so the order is at home there.

## One bug caught by a test

The Execution region owns `ReturnService`, so its `TryCatch` has to localize Return failures. I missed that on the first pass; a test that expected `AgentOrchestrationDependencyException` got the generic `AgentOrchestrationServiceException` instead — the exact symptom of a region not owning its own foundation''s failures.

## Tests

Real regions over **mocked foundations** — the mocks sit exactly where they sat before regionalization, so every assertion is unchanged and only the thing being constructed differs.

430 tests, 30 vectors, Critical certified, zero warnings. No public API change.