### PR TITLE
MAJOR MANAGEMENTS: Rename The Loop To Run Management Service

### DIFF
--- a/Standard.Agents.Tests.Unit/Architecture/TierDisciplineTests.cs
+++ b/Standard.Agents.Tests.Unit/Architecture/TierDisciplineTests.cs
@@ -93,11 +93,19 @@ public class TierDisciplineTests
                 + "belongs in a decorating broker at composition.");
     }
 
+    // Every tier above foundations, named explicitly. A tier missing from this list is a tier
+    // nobody is checking - which is how the loop briefly escaped the rule when it moved from
+    // Coordinations to Managements.
+    private static IEnumerable<Type> ServicesAboveFoundations() =>
+        ServicesUnder("Orchestrations")
+            .Concat(ServicesUnder("Coordinations"))
+            .Concat(ServicesUnder("Managements"));
+
     public static TheoryData<string> ServicesAboveTheFoundationTier()
     {
         var services = new TheoryData<string>();
 
-        foreach (Type service in ServicesUnder("Orchestrations").Concat(ServicesUnder("Coordinations")))
+        foreach (Type service in ServicesAboveFoundations())
         {
             services.Add(service.Name);
         }
@@ -112,9 +120,7 @@ public class TierDisciplineTests
     public void ShouldTakeNoBrokerAboveTheFoundationTierBeyondTheUtilities(string serviceName)
     {
         // given
-        Type service = ServicesUnder("Orchestrations")
-            .Concat(ServicesUnder("Coordinations"))
-            .Single(type => type.Name == serviceName);
+        Type service = ServicesAboveFoundations().Single(type => type.Name == serviceName);
 
         // when
         string[] resourceBrokers =

--- a/Standard.Agents.Tests.Unit/Services/Managements/RunManagementServiceTests.Exceptions.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Managements/RunManagementServiceTests.Exceptions.ProcessPrompt.cs
@@ -10,9 +10,9 @@ using Standard.Agents.Models.Orchestrations.Agents;
 using Xeptions;
 using Xunit;
 
-namespace Standard.Agents.Tests.Unit.Services.Coordinations;
+namespace Standard.Agents.Tests.Unit.Services.Managements;
 
-public partial class AgentCoordinationServiceTests
+public partial class RunManagementServiceTests
 {
     [Theory]
     [InlineData(null)]
@@ -90,15 +90,15 @@ Xeption orchestrationException)
         string randomPrompt = CreateRandomString();
         var serviceException = new Exception();
 
-        var failedAgentCoordinationServiceException =
-            new FailedAgentCoordinationServiceException(
+        var failedRunManagementServiceException =
+            new FailedRunManagementServiceException(
                 message: "Failed agent coordination service error occurred, contact support.",
                 innerException: serviceException);
 
         var expectedException =
-            new AgentCoordinationServiceException(
+            new RunManagementServiceException(
                 message: "Agent coordination service error occurred, contact support.",
-                innerException: failedAgentCoordinationServiceException);
+                innerException: failedRunManagementServiceException);
 
         this.dataCoordinationServiceMock.Setup(service =>
             service.RecallAsync(It.IsAny<AgentContext>()))
@@ -108,8 +108,8 @@ Xeption orchestrationException)
         ValueTask<string> processTask =
             this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
 
-        AgentCoordinationServiceException actualException =
-            await Assert.ThrowsAsync<AgentCoordinationServiceException>(
+        RunManagementServiceException actualException =
+            await Assert.ThrowsAsync<RunManagementServiceException>(
                 processTask.AsTask);
 
         // then

--- a/Standard.Agents.Tests.Unit/Services/Managements/RunManagementServiceTests.Logic.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Managements/RunManagementServiceTests.Logic.ProcessPrompt.cs
@@ -6,12 +6,12 @@
 using FluentAssertions;
 using Moq;
 using Standard.Agents.Models.Orchestrations.Agents;
-using Standard.Agents.Services.Coordinations;
+using Standard.Agents.Services.Managements;
 using Xunit;
 
-namespace Standard.Agents.Tests.Unit.Services.Coordinations;
+namespace Standard.Agents.Tests.Unit.Services.Managements;
 
-public partial class AgentCoordinationServiceTests
+public partial class RunManagementServiceTests
 {
     [Fact]
     public async Task ShouldProcessPromptAsync()
@@ -139,7 +139,7 @@ Times.Exactly(7));
         string randomPrompt = CreateRandomString();
         int configuredMaxTurns = 3;
 
-        var boundedCoordinationService = new AgentCoordinationService(
+        var boundedCoordinationService = new RunManagementService(
             dataCoordinationService: this.dataCoordinationServiceMock.Object,
             decisionCoordinationService: this.decisionCoordinationServiceMock.Object,
             directionCoordinationService: this.directionCoordinationServiceMock.Object,

--- a/Standard.Agents.Tests.Unit/Services/Managements/RunManagementServiceTests.Trace.Outcome.cs
+++ b/Standard.Agents.Tests.Unit/Services/Managements/RunManagementServiceTests.Trace.Outcome.cs
@@ -6,9 +6,9 @@
 using Moq;
 using Xunit;
 
-namespace Standard.Agents.Tests.Unit.Services.Coordinations;
+namespace Standard.Agents.Tests.Unit.Services.Managements;
 
-public partial class AgentCoordinationServiceTests
+public partial class RunManagementServiceTests
 {
     [Fact]
     public async Task ShouldNarrateRunOutcomeOnProcessPromptAsync()

--- a/Standard.Agents.Tests.Unit/Services/Managements/RunManagementServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Managements/RunManagementServiceTests.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
-using Standard.Agents.Services.Coordinations;
+using Standard.Agents.Services.Managements;
 using Standard.Agents.Services.Coordinations.Data;
 using Standard.Agents.Services.Coordinations.Decision;
 using Standard.Agents.Services.Coordinations.Direction;
@@ -15,24 +15,24 @@ using Tynamix.ObjectFiller;
 using Xeptions;
 using Xunit;
 
-namespace Standard.Agents.Tests.Unit.Services.Coordinations;
+namespace Standard.Agents.Tests.Unit.Services.Managements;
 
-public partial class AgentCoordinationServiceTests
+public partial class RunManagementServiceTests
 {
     private readonly Mock<IDataCoordinationService> dataCoordinationServiceMock;
     private readonly Mock<IDecisionCoordinationService> decisionCoordinationServiceMock;
     private readonly Mock<IDirectionCoordinationService> directionCoordinationServiceMock;
     private readonly Mock<ILoggingBroker> loggingBrokerMock;
-    private readonly IAgentCoordinationService agentCoordinationService;
+    private readonly IRunManagementService agentCoordinationService;
 
-    public AgentCoordinationServiceTests()
+    public RunManagementServiceTests()
     {
         this.dataCoordinationServiceMock = new Mock<IDataCoordinationService>();
         this.decisionCoordinationServiceMock = new Mock<IDecisionCoordinationService>();
         this.directionCoordinationServiceMock = new Mock<IDirectionCoordinationService>();
         this.loggingBrokerMock = new Mock<ILoggingBroker>();
 
-        this.agentCoordinationService = new AgentCoordinationService(
+        this.agentCoordinationService = new RunManagementService(
             dataCoordinationService: this.dataCoordinationServiceMock.Object,
             decisionCoordinationService: this.decisionCoordinationServiceMock.Object,
             directionCoordinationService: this.directionCoordinationServiceMock.Object,

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationServiceException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/AgentCoordinationServiceException.cs
@@ -7,9 +7,9 @@ using Xeptions;
 
 namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
 
-public class AgentCoordinationServiceException : Xeption
+public class RunManagementServiceException : Xeption
 {
-    public AgentCoordinationServiceException(string message, Xeption? innerException)
+    public RunManagementServiceException(string message, Xeption? innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Models/Coordinations/Agents/Exceptions/FailedAgentCoordinationServiceException.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/Exceptions/FailedAgentCoordinationServiceException.cs
@@ -7,9 +7,9 @@ using Xeptions;
 
 namespace Standard.Agents.Models.Coordinations.Agents.Exceptions;
 
-public class FailedAgentCoordinationServiceException : Xeption
+public class FailedRunManagementServiceException : Xeption
 {
-    public FailedAgentCoordinationServiceException(string message, Exception innerException)
+    public FailedRunManagementServiceException(string message, Exception innerException)
         : base(message, innerException)
     { }
 }

--- a/Standard.Agents/Services/Managements/IRunManagementService.cs
+++ b/Standard.Agents/Services/Managements/IRunManagementService.cs
@@ -5,9 +5,9 @@
 
 using Standard.Agents.Models.Clients.Agents;
 
-namespace Standard.Agents.Services.Coordinations;
+namespace Standard.Agents.Services.Managements;
 
-public interface IAgentCoordinationService
+public interface IRunManagementService
 {
     ValueTask<string> ProcessPromptAsync(string prompt);
 

--- a/Standard.Agents/Services/Managements/RunManagementService.Budgets.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.Budgets.cs
@@ -7,9 +7,9 @@ using Standard.Agents.Models.Coordinations.Agents;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Models.Orchestrations.Effects;
 
-namespace Standard.Agents.Services.Coordinations;
+namespace Standard.Agents.Services.Managements;
 
-public partial class AgentCoordinationService
+public partial class RunManagementService
 {
     // Exhaustion and cancellation are reported distinguishably from a refusal. SPEC.md §4.10: a
     // caller that cannot tell "I will not" from "I ran out" cannot decide whether to retry, and

--- a/Standard.Agents/Services/Managements/RunManagementService.Exceptions.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.Exceptions.cs
@@ -7,9 +7,9 @@ using Standard.Agents.Models.Coordinations.Agents.Exceptions;
 using Standard.Agents.Models.Orchestrations.Agents.Exceptions;
 using Xeptions;
 
-namespace Standard.Agents.Services.Coordinations;
+namespace Standard.Agents.Services.Managements;
 
-public partial class AgentCoordinationService
+public partial class RunManagementService
 {
     private delegate ValueTask<string> ReturningStringFunction();
 
@@ -45,13 +45,13 @@ public partial class AgentCoordinationService
         }
         catch (Exception exception)
         {
-            var failedAgentCoordinationServiceException =
-                new FailedAgentCoordinationServiceException(
+            var failedRunManagementServiceException =
+                new FailedRunManagementServiceException(
                     message: "Failed agent coordination service error occurred, contact support.",
                     innerException: exception);
 
             throw await CreateAndLogServiceExceptionAsync(
-                failedAgentCoordinationServiceException);
+                failedRunManagementServiceException);
         }
     }
 
@@ -95,11 +95,11 @@ public partial class AgentCoordinationService
         return agentCoordinationDependencyException;
     }
 
-    private async ValueTask<AgentCoordinationServiceException> CreateAndLogServiceExceptionAsync(
+    private async ValueTask<RunManagementServiceException> CreateAndLogServiceExceptionAsync(
         Xeption? exception)
     {
         var agentCoordinationServiceException =
-            new AgentCoordinationServiceException(
+            new RunManagementServiceException(
                 message: "Agent coordination service error occurred, contact support.",
                 innerException: exception);
 

--- a/Standard.Agents/Services/Managements/RunManagementService.Sessions.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.Sessions.cs
@@ -7,14 +7,14 @@ using Standard.Agents.Models.Brokers.Sessions;
 using Standard.Agents.Models.Loggings;
 using Standard.Agents.Models.Orchestrations.Agents;
 
-namespace Standard.Agents.Services.Coordinations;
+namespace Standard.Agents.Services.Managements;
 
 // Conversation and resumption (SPEC.md §4.11).
 //
 // Invariant 4 still holds: the instance is stateless across prompts. What persists is the
 // session, and it lives in a broker outside the agent — which is what lets a pause be resumed by
 // a different process, long after the instance that created it is gone.
-public partial class AgentCoordinationService
+public partial class RunManagementService
 {
     // Read before the run begins, because a resumed run must keep the identity the interrupted
     // one had. Nothing is logged here: there is no run yet to credit the record to.

--- a/Standard.Agents/Services/Managements/RunManagementService.Validations.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.Validations.cs
@@ -5,9 +5,9 @@
 
 using Standard.Agents.Models.Coordinations.Agents.Exceptions;
 
-namespace Standard.Agents.Services.Coordinations;
+namespace Standard.Agents.Services.Managements;
 
-public partial class AgentCoordinationService
+public partial class RunManagementService
 {
     private static void ValidatePrompt(string prompt)
     {

--- a/Standard.Agents/Services/Managements/RunManagementService.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.cs
@@ -16,9 +16,9 @@ using Standard.Agents.Services.Coordinations.Data;
 using Standard.Agents.Services.Coordinations.Decision;
 using Standard.Agents.Services.Coordinations.Direction;
 
-namespace Standard.Agents.Services.Coordinations;
+namespace Standard.Agents.Services.Managements;
 
-public partial class AgentCoordinationService : IAgentCoordinationService
+public partial class RunManagementService : IRunManagementService
 {
     private const int DefaultMaxTurns = 7;
 
@@ -35,7 +35,7 @@ public partial class AgentCoordinationService : IAgentCoordinationService
     private readonly int maxTurns;
     private readonly bool compensateOnFailure;
 
-    public AgentCoordinationService(
+    public RunManagementService(
         IDataCoordinationService dataCoordinationService,
         IDecisionCoordinationService decisionCoordinationService,
         IDirectionCoordinationService directionCoordinationService,

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -33,7 +33,7 @@ using Standard.Agents.Models.Foundations.Skills;
 using Standard.Agents.Models.Orchestrations.Effects;
 using Standard.Agents.Models.Loggings;
 using Standard.Agents.Prompts;
-using Standard.Agents.Services.Coordinations;
+using Standard.Agents.Services.Managements;
 using Standard.Agents.Services.Foundations.Brains;
 using Standard.Agents.Services.Foundations.ExternalTools;
 using Standard.Agents.Services.Foundations.Gates;
@@ -112,7 +112,7 @@ public sealed partial class StandardAgent : IAgent
     private int maxHistoryTurns = 20;
     private Func<AgentPrincipal?>? identityResolver;
 
-    private IAgentCoordinationService? agent;
+    private IRunManagementService? agent;
 
     /// <summary>
     /// Creates an agent with nothing configured yet — set it up with the builder methods
@@ -1028,7 +1028,7 @@ public sealed partial class StandardAgent : IAgent
     // Composes once and reuses. Guarded because one agent serves prompts concurrently
     // (SPEC.md §4.4) and an unguarded `??=` lets two arriving prompts each build a graph —
     // two brokers over one audit sink, two of everything, one silently discarded.
-    private IAgentCoordinationService ResolveAgent()
+    private IRunManagementService ResolveAgent()
     {
         lock (this.compositionLock)
         {
@@ -1074,7 +1074,7 @@ public sealed partial class StandardAgent : IAgent
     private static string ComposeGuardianRubric(params string[] parts) =>
         string.Join("\n\n", parts.Where(part => string.IsNullOrWhiteSpace(part) is false));
 
-    private IAgentCoordinationService Compose()
+    private IRunManagementService Compose()
     {
         ValidateComposition();
 
@@ -1261,7 +1261,7 @@ public sealed partial class StandardAgent : IAgent
             this.screenToolOutput ? gate : null,
             this.identityResolver);
 
-        return new AgentCoordinationService(
+        return new RunManagementService(
             data, decision, direction, logging, this.maxTurns, new TimeBroker(), this.budget,
             this.maxHistoryTurns, this.compensateOnFailure);
     }


### PR DESCRIPTION
Step 10. Once the three natures became coordinations, the loop sits at the tier above them — and The Standard calls that **Management**.

**`RunManagementService`**, not `LoopManagementService` or `AgentManagementService`.

`{Entity}{Tier}Service` wants the thing being managed. A loop is a control structure; one step further down that road and you get `WhileManagementService`. The entity is already named in the spec and the code — `AgentRun`, `runId` on every audit record, §4.4''s *"each invocation MUST establish its own run identity."* It is also unambiguous where "loop" is not: there are **two** loops in there, the turn loop and the Judge revision loop.

## The rename found a hole in the tier test

`TierDisciplineTests` scanned `Orchestrations` and `Coordinations` **by name**. The moment the loop moved to `Managements` it stopped being checked — and the only sign was the test count dropping by one, 432 to 431.

That is the same class of thing the test exists to catch: a rule that quietly stops applying. The tiers above foundations are now named in one place with a comment saying why, so adding a tier and forgetting to check it is a visible edit rather than an absence.

432 tests, 30 vectors, Critical certified, zero warnings. No public API change — `IAgentCoordinationService` was never a public contract (`docs/support.md`), and `StandardAgent` is untouched.