### PR TITLE
DOCUMENTATION: The README Renders As The NuGet Package Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ![The Standard for Agents](https://raw.githubusercontent.com/hassanhabib/The-Standard-Agent/main/assets/the-standard-agent-cover.png)
 
-<div align="center">
-
 # The Standard AI Agent Framework
 
 **`Agent = Orchestration(Data, Decision, Direction)`**
@@ -15,8 +13,6 @@ The C# reference implementation of **[The Standard for Agents](https://github.co
 [![The Standard](https://img.shields.io/github/v/release/hassanhabib/The-Standard?filter=v2.50.0&style=default&label=Standard%20Version&color=2ea44f)](https://github.com/hassanhabib/The-Standard)
 [![The Standard Community](https://img.shields.io/discord/934130100008538142?style=default&color=%237289da&label=The%20Standard%20Community&logo=Discord)](https://discord.gg/vdPZ7hS52X)
 [![License: TSSL](https://img.shields.io/badge/license-TSSL%20v1.1-blue.svg)](https://github.com/hassanhabib/The-Standard-Agent/blob/main/LICENSE.txt)
-
-</div>
 
 ---
 
@@ -196,9 +192,9 @@ promise of the broker seam.
 
 ![The Standard for Agents — architecture: StandardAgent → RunManagement → the three nature Coordinations (Data, Decision, Direction) → six Orchestration regions → thirteen Foundation services → their twelve nature Brokers, with three utility and two decorating brokers beneath](https://raw.githubusercontent.com/hassanhabib/The-Standard-Agent/main/assets/the-standard-agent-architecture.png)
 
-<sub>The diagram is generated from
+*The diagram is generated from
 [`assets/the-standard-agent-architecture.svg`](https://github.com/hassanhabib/The-Standard-Agent/blob/main/assets/the-standard-agent-architecture.svg)
-— edit the SVG, re-render the PNG.</sub>
+— edit the SVG, re-render the PNG.*
 
 **The 1·3·9 is the agent.** One loop, three natures, nine foundations — and it is all you need to
 build one:

--- a/Standard.Agents.Tests.Unit/Packaging/PackageReadmeTests.cs
+++ b/Standard.Agents.Tests.Unit/Packaging/PackageReadmeTests.cs
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Packaging;
+
+// README.md is not only documentation. It is packed as PackageReadmeFile, so it IS the NuGet
+// package page — the first thing anyone considering the library reads.
+//
+// NuGet's markdown pipeline is not GitHub's. It renders raw HTML as literal text, so a
+// <div align="center"> wrapper that centres the title on GitHub prints the angle brackets on
+// NuGet, and the package page opened with a stray closing tag for several releases before anyone
+// looked. It also has no repository context, so a relative link resolves to nothing.
+//
+// Neither failure is visible from the repo, which is exactly why it is a test: the README renders
+// correctly on GitHub the whole time it is broken on the page that sells the package.
+public class PackageReadmeTests
+{
+    private static readonly string readmeText =
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "README.md"));
+
+    // HTML inside a fence is shown AS code on both renderers, which is correct and intended —
+    // the structure block and the C# samples are full of angle brackets. Only prose is at risk.
+    private static string Prose()
+    {
+        string withoutFences = Regex.Replace(readmeText, "```.*?```", string.Empty,
+            RegexOptions.Singleline);
+
+        return Regex.Replace(withoutFences, "`[^`\n]*`", string.Empty);
+    }
+
+    [Fact]
+    public void ShouldCarryNoRawHtmlSoTheNuGetPageDoesNotPrintTheTags()
+    {
+        // given
+        string prose = Prose();
+
+        // when
+        string[] tags = [.. Regex.Matches(prose, "</?[a-zA-Z][^>]*>").Select(match => match.Value)];
+
+        // then
+        tags.Should().BeEmpty(
+            because: "README.md is the NuGet package page, and NuGet renders raw HTML as literal "
+                + $"text — [{string.Join(", ", tags)}] would print on the page as written. "
+                + "Markdown has no centring, so there is nothing to swap it for: state it in "
+                + "markdown, or accept that it reads left-aligned.");
+    }
+
+    // The package page has no repository to resolve against, so every target must be absolute.
+    // Anchors are fine: they resolve within the rendered page itself.
+    [Fact]
+    public void ShouldLinkAbsolutelySoEveryTargetResolvesOffTheRepository()
+    {
+        // given
+        string prose = Prose();
+
+        // when
+        string[] relativeTargets =
+            [.. Regex.Matches(prose, @"\]\(([^)]+)\)")
+                .Select(match => match.Groups[1].Value)
+                .Where(target => Regex.IsMatch(target, "^(https?://|#)") is false)];
+
+        // then
+        relativeTargets.Should().BeEmpty(
+            because: "a relative target resolves against the repository, and the NuGet page has "
+                + $"no repository — [{string.Join(", ", relativeTargets)}] would be a dead link "
+                + "for every reader who arrives at the package rather than the repo.");
+    }
+}

--- a/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
+++ b/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
@@ -24,4 +24,11 @@
     <ProjectReference Include="..\Standard.Agents\Standard.Agents.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- The README ships as the NuGet package page, so it is an artifact under test rather than
+         just documentation. Copied next to the assembly so PackageReadmeTests can read the same
+         bytes that get packed. -->
+    <None Include="..\README.md" Link="README.md" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The NuGet page currently opens with its own markup printed as text:

```
<div align="center">

The Standard AI Agent Framework
...
</div>
```

`README.md` is packed as `PackageReadmeFile`, so it isn't documentation that also happens to ship — **it is the package page**, the first thing anyone considering the library reads. NuGet's markdown pipeline is not GitHub's: it renders raw HTML as literal text, and it has no repository to resolve a relative link against.

### There is no markdown centring

That's the honest answer to "some way to centralize without html" — markdown has no construct for it, on either renderer. The options were a second README written for NuGet alone, or one README that renders correctly everywhere. A second file is a file that drifts, so: **one README, no HTML.**

The cost is that the title and badges now read left-aligned on GitHub, which is the ordinary way a repo looks. The `<sub>` caption under the architecture diagram became italics — the only thing `<sub>` bought was size, and size wasn't what the line was for.

### Enforced by test, not by review

`PackageReadmeTests` — the same pattern as `TierDisciplineTests`, for the same reason. **The README renders perfectly on GitHub the entire time it is broken on the page that sells the package**, so nobody sees it by looking:

- `ShouldCarryNoRawHtmlSoTheNuGetPageDoesNotPrintTheTags` — HTML inside a fence is left alone, since that's shown as code on both renderers and correctly so. Only prose is at risk.
- `ShouldLinkAbsolutelySoEveryTargetResolvesOffTheRepository` — every link was already absolute, so this one passes as written. It's there to keep it that way.

The FAIL commit was run and observed failing on exactly `[<div align="center">, </div>, <sub>, </sub>]`.

Verified end to end: `dotnet pack` produces `Standard.Agents.1.2.0.nupkg`, and the `README.md` inside it contains zero HTML tags.

**434 tests, zero warnings.**