### PR TITLE
CONFORMANCE: Certify That A Budget Bounds Every Protocol

### DIFF
--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -52,7 +52,15 @@ public sealed record Vector(
     int? MaxTurns = null,
 
     // Budget, retrieval and degradation (SPEC.md §4.2, §4.10).
+    //
+    // Wall-clock was the only bound a vector could express, which meant the TOKEN and COST bounds
+    // were certified by nothing. An implementation could report no usage at all on the text
+    // protocol, enforce neither bound, and still pass every vector and claim the Enterprise
+    // profile — which is exactly what this one did until 1.3.0.
     double? BudgetMaxWallClockSeconds = null,
+    int? BudgetMaxTokens = null,
+    decimal? BudgetMaxCostUsd = null,
+    decimal BudgetCostPerThousandTokens = 0m,
     Dictionary<string, string>? Knowledge = null,
     string? FallbackReply = null,
     int FailuresBeforeOpen = 3,

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -375,6 +375,16 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
             agent.Budget(maxWallClock: TimeSpan.FromSeconds(seconds));
         }
 
+        // Set together rather than in three branches: .Budget replaces the whole bound, so
+        // calling it twice would silently drop whichever was configured first.
+        if (vector.BudgetMaxTokens is not null || vector.BudgetMaxCostUsd is not null)
+        {
+            agent.Budget(
+                maxTokens: vector.BudgetMaxTokens,
+                maxCostUsd: vector.BudgetMaxCostUsd,
+                costPerThousandTokens: vector.BudgetCostPerThousandTokens);
+        }
+
         // A real session store, in a folder unique to this vector, so conversation is certified
         // against something that actually persists rather than an in-memory stand-in that could
         // never demonstrate resumption.

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -1314,17 +1314,24 @@ public sealed partial class StandardAgent : IAgent
     // tool to the model. A tool without one stays callable but unadvertised, so declaring tools
     // as data does not quietly widen what the Brain may reach for.
     private static IReadOnlyList<ToolDefinition> RenderToolDefinitions(IEnumerable<ITool> tools) =>
-        [.. tools
-            .Where(tool => string.IsNullOrWhiteSpace(tool.Description) is false)
+        [.. Advertised(tools)
             .Select(tool => new ToolDefinition(tool.Name, tool.Description, tool.Parameters))];
 
     private static string RenderToolCatalog(IEnumerable<ITool> tools)
     {
-        IEnumerable<string> describedTools = tools
-            .Where(tool => string.IsNullOrWhiteSpace(tool.Description) is false)
+        IEnumerable<string> describedTools = Advertised(tools)
             .Select(tool => $"- {tool.Name} — {tool.Description} parameters: {tool.Parameters}");
 
         return string.Join("\n", describedTools);
     }
+
+    // What the model may be told about, in ONE place. The rule (SPEC.md §6.1: a description is
+    // the opt-in, and a tool without one stays callable but unadvertised) was written out twice —
+    // once for the text catalog Data renders into the prompt, once for the definitions Decision
+    // hands the native brain. Two copies of a rule about what the model is allowed to see is two
+    // chances to widen it by half, and a model told about a tool in the prompt but not in the
+    // schema — or the reverse — behaves differently on each protocol for no stated reason.
+    private static IEnumerable<ITool> Advertised(IEnumerable<ITool> tools) =>
+        tools.Where(tool => string.IsNullOrWhiteSpace(tool.Description) is false);
 
 }

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -150,6 +150,8 @@ the deterministic core of the Standard.
 | `cancellation-stops-the-loop` | A cancelled run stops at a turn boundary and is not an answer |
 | `transient-failure-recovers` | Retry by error category, not by matching a message (§4.10) |
 | `budget-stops-the-loop` | Exhaustion stops the loop and is distinguishable from a refusal |
+| `budget-bounds-tokens-on-any-protocol` | A token bound holds where the provider reports no usage (§4.10) |
+| `budget-bounds-cost-on-any-protocol` | A cost bound holds there too — cost is priced off the count |
 | `knowledge-retrieves-by-relevance` | Retrieval returns the passage that answers, not the first found |
 | `guardian-screens-once-per-prompt` | An unchanged prompt is screened once, not once per turn |
 | `open-circuit-falls-back-to-secondary` | An unhealthy provider degrades rather than fails (§4.10) |
@@ -190,3 +192,11 @@ Two in this suite were vacuous when first written and were caught this way —
 `knowledge-retrieves-by-relevance` passed with the ranking inverted, and
 `redaction-covers-every-model-call` passed while only the Brain's input was being recorded. Both
 were rewritten. If you add a vector, break the thing it covers first.
+
+The sharper lesson is what a **missing** vector costs, because nothing here goes red for one.
+Until `1.4.0` the only budget a vector could express was wall-clock, so the token and cost bounds
+were certified by nothing at all. This implementation reported no usage on the text protocol,
+enforced neither bound, and passed every vector and every profile — Enterprise included, which
+claims budgets by name — for eight releases. Anyone building to these vectors in another language
+would have reproduced that exactly and been entitled to the same badge. A suite that cannot
+express a bound cannot certify it, and silence reads as coverage.

--- a/conformance/profiles/enterprise.json
+++ b/conformance/profiles/enterprise.json
@@ -8,6 +8,8 @@
     "injected-instruction-in-tool-output-is-refused",
     "duplicate-effect-executes-once",
     "budget-stops-the-loop",
+    "budget-bounds-tokens-on-any-protocol",
+    "budget-bounds-cost-on-any-protocol",
     "guardian-screens-once-per-prompt",
     "open-circuit-falls-back-to-secondary",
     "knowledge-retrieves-by-relevance"

--- a/conformance/vectors/31-budget-bounds-tokens-on-any-protocol.json
+++ b/conformance/vectors/31-budget-bounds-tokens-on-any-protocol.json
@@ -1,0 +1,12 @@
+{
+  "name": "budget-bounds-tokens-on-any-protocol",
+  "description": "SPEC.md 4.10: a token budget bounds a run on EVERY protocol, not only where a provider volunteers its own usage numbers. The text protocol reports no usage, so an implementation that measures only what providers report enforces nothing here - the run adds zero to its spend every turn and the bound never trips, while the Enterprise profile goes on claiming budgets. An implementation MUST count what it cannot be told. The Brain here loops through tool calls forever; only the token bound can stop it.",
+  "generatorReplies": ["ACTION: nonexistent_tool: keep going"],
+  "tools": {},
+  "prompt": "loop forever and spend everything",
+  "maxTurns": 50,
+  "budgetMaxTokens": 40,
+  "expect": {
+    "resultContains": "token budget"
+  }
+}

--- a/conformance/vectors/32-budget-bounds-cost-on-any-protocol.json
+++ b/conformance/vectors/32-budget-bounds-cost-on-any-protocol.json
@@ -1,0 +1,13 @@
+{
+  "name": "budget-bounds-cost-on-any-protocol",
+  "description": "SPEC.md 4.10: a cost budget is priced off the token count, so a protocol that contributes no tokens contributes no cost and the bound silently never applies. Separate from the token vector because they fail independently: an implementation can carry a token count and still never price it. The Brain loops through tool calls forever; only the cost bound can stop it.",
+  "generatorReplies": ["ACTION: nonexistent_tool: keep going"],
+  "tools": {},
+  "prompt": "loop forever and spend everything",
+  "maxTurns": 50,
+  "budgetMaxCostUsd": 0.0001,
+  "budgetCostPerThousandTokens": 1.0,
+  "expect": {
+    "resultContains": "cost budget"
+  }
+}


### PR DESCRIPTION
The token budget fix shipped in `1.3.0` was pinned by C# acceptance tests and **nothing else**. The vector model could only express a wall-clock bound, so the token and cost bounds were certified by nothing at all.

That matters more than a missing test usually does. **Anyone building this SDK in another language against these vectors would have reproduced the original defect exactly** — reporting no usage on the text protocol, enforcing neither bound — and been entitled to the same Enterprise badge, which lists budgets by name. A suite that cannot express a bound cannot certify it, and silence reads as coverage.

### The vectors

`BudgetMaxTokens`, `BudgetMaxCostUsd` and `BudgetCostPerThousandTokens` on the vector model, wired in the runner. Set together rather than in three branches, because `.Budget` replaces the whole bound and calling it twice would silently drop whichever was configured first.

**Two vectors rather than one.** Cost is priced off the token count, but the two fail independently — an implementation can carry a count and still never price it.

Both **sabotage-verified**: measurement reverted to reported-only (exactly the pre-`1.3.0` behaviour), both watched failing, break reverted.

```
FAIL  budget-bounds-tokens-on-any-protocol
FAIL  budget-bounds-cost-on-any-protocol
30 passed, 2 failed
```

`CONFORMANCE.md` now records what a *missing* vector costs, because nothing goes red for one — the lesson the two vacuous vectors before it did not teach.

### Also in here

The rule that a description is what advertises a tool (§6.1) was written out twice — once for the text catalog Data renders into the prompt, once for the definitions Decision hands the native brain. Two copies of a rule about what the model may see is two chances to widen it by half, and a model told about a tool in the prompt but not in the schema behaves differently per protocol for no stated reason. One `Advertised()` now, used by both.

Spec side: [The-Standard-Agent-Specs#21](https://github.com/hassanhabib/The-Standard-Agent-Specs/pull/21) raises SPEC to 1.1 with the requirement stated outright.

**469 tests, 32 vectors, all four profiles CERTIFIED, zero warnings.**