### PR TITLE
CONFORMANCE: Pin The Boundary Of Run-Once

### DIFF
--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -3,7 +3,7 @@
 A **language-neutral** set of behavioral test vectors that any Standard-Agents
 implementation runs to self-certify against
 [`SPEC.md`](https://github.com/hassanhabib/The-Standard-Agent-Specs/blob/main/SPEC.md).
-Thirty vectors, four readiness profiles, every vector proven able to fail.
+Thirty-three vectors, four readiness profiles, every vector proven able to fail.
 
 The vectors are the executable half of the specification. Prose can be read two ways; a vector
 cannot, which is why "conformant" here means *this suite passes* rather than *we believe we
@@ -152,6 +152,7 @@ the deterministic core of the Standard.
 | `budget-stops-the-loop` | Exhaustion stops the loop and is distinguishable from a refusal |
 | `budget-bounds-tokens-on-any-protocol` | A token bound holds where the provider reports no usage (§4.10) |
 | `budget-bounds-cost-on-any-protocol` | A cost bound holds there too — cost is priced off the count |
+| `a-repeat-in-a-session-is-a-new-act` | Run-once is scoped to a run; a repeat in a later run performs (§4.9) |
 | `knowledge-retrieves-by-relevance` | Retrieval returns the passage that answers, not the first found |
 | `guardian-screens-once-per-prompt` | An unchanged prompt is screened once, not once per turn |
 | `open-circuit-falls-back-to-secondary` | An unhealthy provider degrades rather than fails (§4.10) |

--- a/conformance/profiles/enterprise.json
+++ b/conformance/profiles/enterprise.json
@@ -7,6 +7,7 @@
     "policy-authorizes-on-identity",
     "injected-instruction-in-tool-output-is-refused",
     "duplicate-effect-executes-once",
+    "a-repeat-in-a-session-is-a-new-act",
     "budget-stops-the-loop",
     "budget-bounds-tokens-on-any-protocol",
     "budget-bounds-cost-on-any-protocol",

--- a/conformance/vectors/33-a-repeat-in-a-session-is-a-new-act.json
+++ b/conformance/vectors/33-a-repeat-in-a-session-is-a-new-act.json
@@ -1,0 +1,19 @@
+{
+  "name": "a-repeat-in-a-session-is-a-new-act",
+  "description": "SPEC.md 4.9: run-once is scoped to a RUN. The same act proposed again in a later, separate run of the same session is a NEW act and performs again - which is required, because an agent must be able to send a second reminder or make a second payment when asked. The boundary matters in the other direction too: an at-least-once trigger that redelivers work already completed starts a new run, derives a new key, and performs the effect a second time. Run-once does not span completed runs, and a caller whose delivery may repeat MUST deduplicate at the trigger boundary. Session resumption extends run-once across an INTERRUPTED run only - see awaiting-approval-resumes-in-a-new-process.",
+  "generatorReplies": [
+    "ACTION: wire_transfer: 10000",
+    "FINAL: paid",
+    "ACTION: wire_transfer: 10000",
+    "FINAL: paid"
+  ],
+  "tools": { "wire_transfer": "transfer complete" },
+  "prompt": "pay invoice 7712",
+  "prompts": ["pay invoice 7712", "pay invoice 7712"],
+  "sessionId": "evt-7712",
+  "durableEffectLedger": true,
+  "expect": {
+    "result": "paid",
+    "toolRunCount": { "wire_transfer": 2 }
+  }
+}


### PR DESCRIPTION
Run-once is scoped to a **run**, and nothing said so. The key is derived from the run id, so an identical act proposed in a later run derives a different key and is performed again.

**That is correct behaviour.** An agent asked to send a second reminder, or to pay the same payee the same amount again, has to be able to — run-once spanning completed runs would make the second request impossible to express. But it was true only by inspection, and a contract nothing checks is a contract that drifts.

### Where it bites

An at-least-once bus, a webhook retry, a scheduler that fires twice: each is a second run with a second key, and **the effect goes out again.** Run-once does not span triggers.

### Established by experiment, not by reading

A scratch vector drove the same work twice through one session over a durable ledger:

```
FAIL  scratch-redelivery
        tool 'wire_transfer' ran 2 time(s), expected 1
```

The plausible fix — binding the trigger identity to the session id — was tried and **does not work.** Run continuity reuses an identity only when the session *did not deliver*, and a lost ack after successful processing is the commonest at-least-once case there is.

So `a-repeat-in-a-session-is-a-new-act` expects the tool to run **twice**, because that is what correct looks like. Sabotage-verified — dropping the `Delivered` guard from run resumption:

```
FAIL  a-repeat-in-a-session-is-a-new-act
        tool 'wire_transfer' ran 1 time(s), expected 2
```

Added to the **Enterprise** profile beside `duplicate-effect-executes-once`, which pins the other half — three proposals inside *one* run performing once. The two together say where the guarantee starts and where it stops.

Spec side: [The-Standard-Agent-Specs#22](https://github.com/hassanhabib/The-Standard-Agent-Specs/pull/22) — §4.9 gains the boundary and the caller's obligation, at SPEC 1.2.

**469 tests, 33 vectors, all four profiles CERTIFIED, zero warnings.**