### PR TITLE
FOUNDATIONS: An Answer Has A Shape

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/ContractTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/ContractTests.cs
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Foundations.Skills;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// The agent answers with a string, and that is the entire client contract. Every consumer wiring
+// an agent into a workflow therefore writes a parser — which is exactly what the framework talked
+// them out of doing everywhere else. Native tool calling gives structured input TO tools; the
+// agent's own answer has always been prose.
+//
+// A schema check asks whether an answer is the right SHAPE, immediately beside the Judge asking
+// whether it is good ENOUGH. Same moment, same kind of verdict, so it is a third guardian rather
+// than a new concept — and a mismatch is a re-think, not a fault: it takes the Judge's revision
+// path with the validation error as the reason the draft was rejected.
+public class ContractTests
+{
+    private const string InvoiceSchema =
+        """{ "type": "object", "required": ["amount", "currency"] }""";
+
+    private static StandardAgent AgentAnswering(params string[] replies)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        int asked = 0;
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .OnBrain((_, _) =>
+            {
+                string reply = replies[Math.Min(asked, replies.Length - 1)];
+                asked++;
+
+                return ValueTask.FromResult(reply);
+            });
+    }
+
+    [Fact]
+    public async Task ShouldReturnTheAnswerWhenItSatisfiesTheContractAsync()
+    {
+        // given
+        StandardAgent agent = AgentAnswering(
+            """FINAL: { "amount": 100, "currency": "USD" }""")
+                .Contract(InvoiceSchema);
+
+        // when
+        string actualAnswer = await agent.ProcessPromptAsync("what is owed");
+
+        // then
+        actualAnswer.Should().Contain("\"amount\"").And.Contain("\"currency\"");
+    }
+
+    // The whole point: a shape violation is a revision signal, not an exception and not a silent
+    // pass. The model is told what was wrong and asked again within the turn budget.
+    [Fact]
+    public async Task ShouldReviseWhenTheAnswerDoesNotSatisfyTheContractAsync()
+    {
+        // given — prose first, then the shape that was asked for
+        StandardAgent agent = AgentAnswering(
+            "FINAL: The amount is one hundred US dollars.",
+            """FINAL: { "amount": 100, "currency": "USD" }""")
+                .Contract(InvoiceSchema)
+                .MaxTurns(5);
+
+        // when
+        string actualAnswer = await agent.ProcessPromptAsync("what is owed");
+
+        // then
+        actualAnswer.Should().Contain(
+            "\"amount\"",
+            because: "a draft that does not satisfy the contract is re-thought, and the second "
+                + "draft is the one the caller receives");
+
+        actualAnswer.Should().NotContain("one hundred US dollars");
+    }
+
+    // A model that never produces the shape must fail the way every other exhausted control fails:
+    // a graceful refusal, distinguishable from an answer. Never an exception, and never prose
+    // handed back as though it had satisfied a schema it did not.
+    [Fact]
+    public async Task ShouldRefuseWhenTheContractIsNeverSatisfiedAsync()
+    {
+        // given
+        StandardAgent agent = AgentAnswering("FINAL: The amount is one hundred US dollars.")
+            .Contract(InvoiceSchema)
+            .MaxTurns(3);
+
+        // when
+        string actualAnswer = await agent.ProcessPromptAsync("what is owed");
+
+        // then
+        actualAnswer.Should().NotBe(
+            "The amount is one hundred US dollars.",
+            because: "prose handed back unchanged is the failure this exists to prevent — a "
+                + "caller parsing the result would have no way to tell it never matched");
+
+        actualAnswer.Should().NotBeNullOrWhiteSpace(
+            because: "an exhausted contract refuses gracefully, the same as an exhausted "
+                + "revision budget, rather than throwing or returning nothing");
+    }
+
+    // Wide open by default: an agent given no contract is not constrained by having become
+    // checkable. Same rule as counting versus blocking in the budget.
+    [Fact]
+    public async Task ShouldNotConstrainAnAgentGivenNoContractAsync()
+    {
+        // given
+        StandardAgent agent = AgentAnswering("FINAL: The amount is one hundred US dollars.");
+
+        // when
+        string actualAnswer = await agent.ProcessPromptAsync("what is owed");
+
+        // then
+        actualAnswer.Should().Be("The amount is one hundred US dollars.");
+    }
+}

--- a/Standard.Agents.Tests.Unit/Acceptance/RevisionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/RevisionTests.cs
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// A rejected draft is a re-think signal, not a fault — the loop retries within the turn budget and
+// refuses gracefully only when the answer still cannot pass. That is what 1.2.0.0 said it built.
+//
+// The retry half was covered. The SUCCESS half was not: every test asserted that a permanently
+// rejected draft ends in a refusal, and none asserted that a draft rejected once and then accepted
+// is the answer the caller receives.
+//
+// It never was. Interpret carries the incoming context forward with `context with { ... }`, and
+// nothing resets Status, so a draft accepted on the second pass is still marked Revising when it
+// leaves Decision. The loop sees Revising, continues, and the run exhausts its turns — returning
+// "I can't help with that at the moment" for an answer that passed review.
+public class RevisionTests
+{
+    [Fact]
+    public async Task ShouldDeliverADraftThatPassesOnRevisionAsync()
+    {
+        // given — the Judge rejects the first draft and accepts every one after it
+        int judged = 0;
+
+        StandardAgent agent = new StandardAgent()
+            .OnBrain((_, _) => ValueTask.FromResult("FINAL: forty two"))
+            .OnJudge((_, _) =>
+            {
+                judged++;
+
+                return ValueTask.FromResult(judged == 1 ? "0.0" : "1.0");
+            })
+            .MaxTurns(4);
+
+        // when
+        string actualAnswer = await agent.ProcessPromptAsync("what is the answer");
+
+        // then
+        actualAnswer.Should().Be(
+            "forty two",
+            because: "a revision that passes review is an answer, and a loop that cannot deliver "
+                + "one has a retry it can never succeed at");
+
+        judged.Should().Be(
+            2,
+            because: "one rejection and one acceptance is the whole exchange — anything more is "
+                + "the loop spinning after the answer was already good");
+    }
+
+    // The other half, which was already covered and must stay true: a draft that never passes ends
+    // in a graceful refusal rather than an exception or an empty string.
+    [Fact]
+    public async Task ShouldRefuseWhenNoDraftEverPassesAsync()
+    {
+        // given
+        StandardAgent agent = new StandardAgent()
+            .OnBrain((_, _) => ValueTask.FromResult("FINAL: forty two"))
+            .OnJudge((_, _) => ValueTask.FromResult("0.0"))
+            .MaxTurns(3);
+
+        // when
+        string actualAnswer = await agent.ProcessPromptAsync("what is the answer");
+
+        // then
+        actualAnswer.Should().Be("I can't help with that at the moment.");
+    }
+}

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Capabilities.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Capabilities.cs
@@ -68,7 +68,9 @@ public class StandardAgentCapabilityTests
         new("EffectLedger", Local: "EffectLedger", External: "UseEffectLedger",
             Custom: "OnEffectLedger"),
 
-        new("Usage", Local: "Usage", External: "UseUsage", Custom: "OnUsage")
+        new("Usage", Local: "Usage", External: "UseUsage", Custom: "OnUsage"),
+
+        new("Contract", Local: "Contract", External: "UseContract", Custom: "OnContract")
     ];
 
     private static readonly string[] publicMethodNames =

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.cs
@@ -9,7 +9,9 @@ using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Foundations.Judges;
 using Standard.Agents.Models.Foundations.Usages;
 using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Brokers.Contracts;
 using Standard.Agents.Services.Foundations.Brains;
+using Standard.Agents.Services.Foundations.Contracts;
 using Standard.Agents.Services.Foundations.Gates;
 using Standard.Agents.Services.Foundations.Judges;
 using Standard.Agents.Services.Foundations.Usages;
@@ -56,6 +58,7 @@ public partial class DecisionCoordinationServiceTests
             guardianService: new GuardianOrchestrationService(
                 this.gateServiceMock.Object,
                 this.judgeServiceMock.Object,
+                new ContractService(new RuleContractBroker(), this.loggingBrokerMock.Object),
                 this.loggingBrokerMock.Object),
             loggingBroker: this.loggingBrokerMock.Object);
     }

--- a/Standard.Agents/Brokers/Contracts/FunctionContractBroker.cs
+++ b/Standard.Agents/Brokers/Contracts/FunctionContractBroker.cs
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Contracts;
+
+// The Custom mode's substrate: host-supplied validation, for rules a schema cannot express —
+// a total that must equal the sum of its lines, an account that must exist.
+public sealed class FunctionContractBroker : IContractBroker
+{
+    private readonly Func<string, string, ValueTask<string?>> validate;
+
+    public FunctionContractBroker(Func<string, string, ValueTask<string?>> validate) =>
+        this.validate = validate;
+
+    public ValueTask<string?> ValidateAsync(string answer, string schema) =>
+        this.validate(answer, schema);
+}

--- a/Standard.Agents/Brokers/Contracts/IContractBroker.cs
+++ b/Standard.Agents/Brokers/Contracts/IContractBroker.cs
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Contracts;
+
+// The liaison to whatever knows how to validate a document against a schema: a validator in the
+// box, a full JSON Schema library, or the host's own rules.
+public interface IContractBroker
+{
+    /// <summary>
+    /// Returns <c>null</c> when the answer satisfies the schema, and otherwise what is wrong with
+    /// it — in words a model can act on, because the text becomes the reason a draft was rejected.
+    /// </summary>
+    ValueTask<string?> ValidateAsync(string answer, string schema);
+}

--- a/Standard.Agents/Brokers/Contracts/RuleContractBroker.cs
+++ b/Standard.Agents/Brokers/Contracts/RuleContractBroker.cs
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.Json;
+
+namespace Standard.Agents.Brokers.Contracts;
+
+// The Local mode: a validator in the box, so an answer can be held to a shape without the core
+// taking a dependency.
+//
+// It covers the subset a model actually gets wrong — is it JSON at all, is it the right kind of
+// thing, are the required members present, and are their types right. It does NOT implement JSON
+// Schema: no $ref, no allOf/anyOf/oneOf, no pattern, no numeric bounds, no nested validation past
+// the first level.
+//
+// That boundary is stated rather than discovered, because a partial validator claiming
+// completeness is worse than no validator: it would report an answer as conforming to a schema it
+// was never checked against. A host that needs the whole specification supplies a real library
+// through .UseContract.
+public sealed class RuleContractBroker : IContractBroker
+{
+    public ValueTask<string?> ValidateAsync(string answer, string schema)
+    {
+        if (string.IsNullOrWhiteSpace(schema))
+        {
+            return ValueTask.FromResult<string?>(null);
+        }
+
+        JsonElement schemaRoot;
+
+        try
+        {
+            schemaRoot = JsonDocument.Parse(schema).RootElement;
+        }
+        catch (JsonException)
+        {
+            // The schema is the host's, not the model's. A broken one is a configuration error and
+            // must not be reported as the model's failure, or every revision chases a fault the
+            // model cannot fix.
+            throw new ArgumentException(
+                "The contract schema is not valid JSON.", nameof(schema));
+        }
+
+        JsonElement answerRoot;
+
+        try
+        {
+            answerRoot = JsonDocument.Parse(answer).RootElement;
+        }
+        catch (JsonException)
+        {
+            return ValueTask.FromResult<string?>(
+                "the answer is not valid JSON; reply with JSON only and no surrounding prose");
+        }
+
+        return ValueTask.FromResult(Check(answerRoot, schemaRoot));
+    }
+
+    private static string? Check(JsonElement answer, JsonElement schema)
+    {
+        if (schema.TryGetProperty("type", out JsonElement expectedType)
+            && expectedType.ValueKind is JsonValueKind.String
+            && Matches(answer.ValueKind, expectedType.GetString()) is false)
+        {
+            return $"expected {expectedType.GetString()} but the answer was "
+                + $"{Describe(answer.ValueKind)}";
+        }
+
+        if (answer.ValueKind is not JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (schema.TryGetProperty("required", out JsonElement required)
+            && required.ValueKind is JsonValueKind.Array)
+        {
+            foreach (JsonElement member in required.EnumerateArray())
+            {
+                string? name = member.GetString();
+
+                if (string.IsNullOrEmpty(name) is false
+                    && answer.TryGetProperty(name, out _) is false)
+                {
+                    return $"the required member '{name}' is missing";
+                }
+            }
+        }
+
+        if (schema.TryGetProperty("properties", out JsonElement properties)
+            && properties.ValueKind is JsonValueKind.Object)
+        {
+            foreach (JsonProperty property in properties.EnumerateObject())
+            {
+                if (answer.TryGetProperty(property.Name, out JsonElement value)
+                    && property.Value.TryGetProperty("type", out JsonElement memberType)
+                    && memberType.ValueKind is JsonValueKind.String
+                    && Matches(value.ValueKind, memberType.GetString()) is false)
+                {
+                    return $"member '{property.Name}' should be {memberType.GetString()} but was "
+                        + $"{Describe(value.ValueKind)}";
+                }
+            }
+        }
+
+        return null;
+    }
+
+    // "integer" is deliberately looser than JSON Schema requires: System.Text.Json does not
+    // distinguish 1 from 1.0, and rejecting a whole number because it arrived as a double would
+    // send the model into a revision it cannot satisfy.
+    private static bool Matches(JsonValueKind kind, string? expected) =>
+        expected switch
+        {
+            "object" => kind is JsonValueKind.Object,
+            "array" => kind is JsonValueKind.Array,
+            "string" => kind is JsonValueKind.String,
+            "number" or "integer" => kind is JsonValueKind.Number,
+            "boolean" => kind is JsonValueKind.True or JsonValueKind.False,
+            "null" => kind is JsonValueKind.Null,
+            _ => true,
+        };
+
+    private static string Describe(JsonValueKind kind) =>
+        kind switch
+        {
+            JsonValueKind.Object => "an object",
+            JsonValueKind.Array => "an array",
+            JsonValueKind.String => "a string",
+            JsonValueKind.Number => "a number",
+            JsonValueKind.True or JsonValueKind.False => "a boolean",
+            JsonValueKind.Null => "null",
+            _ => "nothing",
+        };
+}

--- a/Standard.Agents/Models/Foundations/Contracts/ContractVerdict.cs
+++ b/Standard.Agents/Models/Foundations/Contracts/ContractVerdict.cs
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Foundations.Contracts;
+
+/// <summary>
+/// Whether an answer is the right <i>shape</i>, beside the Judge's verdict on whether it is good
+/// enough. Both are verdicts on a draft at the same moment, which is why this is a guardian and
+/// not a new concept.
+/// </summary>
+/// <param name="Satisfied">Whether the answer matches the schema it was held to.</param>
+/// <param name="Reason">
+/// What is wrong with it, in words a model can act on. This is fed back as the reason a draft was
+/// rejected, so "expected an object" is worth more than "invalid" — a revision the model cannot
+/// aim at is a turn spent for nothing.
+/// </param>
+public record ContractVerdict(bool Satisfied, string Reason)
+{
+    /// <summary>The verdict when no contract was configured: everything satisfies nothing.</summary>
+    public static ContractVerdict Unconstrained { get; } =
+        new ContractVerdict(Satisfied: true, Reason: string.Empty);
+}

--- a/Standard.Agents/Models/Foundations/Contracts/Exceptions/ContractDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Contracts/Exceptions/ContractDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Contracts.Exceptions;
+
+public class ContractDependencyException : Xeption
+{
+    public ContractDependencyException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Contracts/Exceptions/ContractServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Contracts/Exceptions/ContractServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Contracts.Exceptions;
+
+public class ContractServiceException : Xeption
+{
+    public ContractServiceException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Contracts/Exceptions/ContractValidationException.cs
+++ b/Standard.Agents/Models/Foundations/Contracts/Exceptions/ContractValidationException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Contracts.Exceptions;
+
+public class ContractValidationException : Xeption
+{
+    public ContractValidationException(string message, Xeption? innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Contracts/Exceptions/FailedContractDependencyException.cs
+++ b/Standard.Agents/Models/Foundations/Contracts/Exceptions/FailedContractDependencyException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Contracts.Exceptions;
+
+public class FailedContractDependencyException : Xeption
+{
+    public FailedContractDependencyException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Contracts/Exceptions/FailedContractServiceException.cs
+++ b/Standard.Agents/Models/Foundations/Contracts/Exceptions/FailedContractServiceException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Contracts.Exceptions;
+
+public class FailedContractServiceException : Xeption
+{
+    public FailedContractServiceException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+}

--- a/Standard.Agents/Models/Foundations/Contracts/Exceptions/InvalidContractException.cs
+++ b/Standard.Agents/Models/Foundations/Contracts/Exceptions/InvalidContractException.cs
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Foundations.Contracts.Exceptions;
+
+public class InvalidContractException : Xeption
+{
+    public InvalidContractException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Services/Coordinations/Decision/DecisionCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/Decision/DecisionCoordinationService.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Foundations.Gates;
+using Standard.Agents.Models.Foundations.Contracts;
 using Standard.Agents.Models.Foundations.Judges;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Services.Orchestrations.Decision.Guardians;
@@ -47,14 +48,20 @@ public partial class DecisionCoordinationService : IDecisionCoordinationService
     private readonly IGuardianOrchestrationService guardianService;
     private readonly ILoggingBroker loggingBroker;
 
+    // The shape every answer is held to, or empty. Configuration rather than a collaborator — it
+    // is a string the host chose, and the foundation treats an empty one as no check at all.
+    private readonly string contractSchema;
+
     public DecisionCoordinationService(
         IInferenceOrchestrationService inferenceService,
         IGuardianOrchestrationService guardianService,
-        ILoggingBroker loggingBroker)
+        ILoggingBroker loggingBroker,
+        string? contractSchema = null)
     {
         this.inferenceService = inferenceService;
         this.guardianService = guardianService;
         this.loggingBroker = loggingBroker;
+        this.contractSchema = contractSchema ?? string.Empty;
     }
 
     // The loop screens what a tool returned before it can become an observation. It asks here
@@ -137,8 +144,47 @@ public partial class DecisionCoordinationService : IDecisionCoordinationService
             };
         }
 
-        return decided;
+        // The shape check runs after the Judge and not before it, deliberately: a draft that is
+        // wrong on the merits should be told that, not told its punctuation is off. Two rejections
+        // in one turn would spend a turn teaching the model the lesser of them.
+        ContractVerdict shape =
+            await this.guardianService.CheckShapeAsync(decided.Payload, this.contractSchema);
+
+        if (shape.Satisfied is false)
+        {
+            // A rejection the trace does not explain is a turn nobody can account for. The Judge's
+            // rejections were already narrated; this one says which guardian refused and why.
+            await this.loggingBroker.LogProcessAsync(
+                "Decision",
+                $"Contract → REJECTED: {shape.Reason}");
+
+            return context with
+            {
+                Observations =
+                [
+                    .. context.Observations,
+                    ShapeFeedback(shape, decided.Payload)
+                ],
+
+                Status = AgentStatus.Revising
+            };
+        }
+
+        // Every guardian has passed, so this draft is an answer — and it must stop carrying the
+        // Revising it inherited from the turn that rejected the last one. Interpret builds the
+        // decided context with `context with { ... }`, which copies Status forward, so without
+        // this a draft accepted on the second pass leaves Decision still marked Revising, the loop
+        // continues, and the run exhausts its turns refusing an answer that had already passed.
+        return decided.Status is AgentStatus.Revising
+            ? decided with { Status = AgentStatus.Working }
+            : decided;
     });
+
+    // Aimed, not scolding. A revision the model cannot act on is a turn spent for nothing, so the
+    // validator's complaint is repeated verbatim rather than summarised into "invalid".
+    private static string ShapeFeedback(ContractVerdict verdict, string draft) =>
+        $"A previous draft was rejected because {verdict.Reason}. Reply with JSON matching the "
+            + $"required shape and nothing else. The draft was: {draft}";
 
     private static string RevisionFeedback(Judgement judgement, string draft) =>
         string.IsNullOrWhiteSpace(judgement.Reason)

--- a/Standard.Agents/Services/Foundations/Contracts/ContractService.Exceptions.cs
+++ b/Standard.Agents/Services/Foundations/Contracts/ContractService.Exceptions.cs
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Contracts;
+using Standard.Agents.Models.Foundations.Contracts.Exceptions;
+using Xeptions;
+
+namespace Standard.Agents.Services.Foundations.Contracts;
+
+public partial class ContractService
+{
+    private delegate ValueTask<ContractVerdict> ReturningVerdictFunction();
+
+    private async ValueTask<ContractVerdict> TryCatch(
+        ReturningVerdictFunction returningVerdictFunction)
+    {
+        try
+        {
+            return await returningVerdictFunction();
+        }
+        catch (InvalidContractException invalidContractException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(invalidContractException);
+        }
+
+        // A malformed SCHEMA is the host's error, not the model's, and the distinction is
+        // load-bearing: reported as a model failure it would send every draft into a revision
+        // chasing a fault no reply can fix, until the turn budget runs out.
+        catch (ArgumentException)
+        {
+            throw await CreateAndLogValidationExceptionAsync(
+                new InvalidContractException(
+                    message: "Invalid contract, the schema is not valid JSON. "
+                        + "Please correct the error and try again."));
+        }
+        catch (HttpRequestException httpRequestException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                new FailedContractDependencyException(
+                    message: "Failed contract dependency error occurred, contact support.",
+                    innerException: httpRequestException));
+        }
+        catch (TaskCanceledException taskCanceledException)
+        {
+            throw await CreateAndLogDependencyExceptionAsync(
+                new FailedContractDependencyException(
+                    message: "Failed contract dependency error occurred, contact support.",
+                    innerException: taskCanceledException));
+        }
+        catch (Exception exception)
+        {
+            var failedContractServiceException =
+                new FailedContractServiceException(
+                    message: "Failed contract service error occurred, contact support.",
+                    innerException: exception);
+
+            throw await CreateAndLogServiceExceptionAsync(failedContractServiceException);
+        }
+    }
+
+    private async ValueTask<ContractValidationException> CreateAndLogValidationExceptionAsync(
+        Xeption exception)
+    {
+        var contractValidationException =
+            new ContractValidationException(
+                message: "Contract validation error occurred, fix the error and try again.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(contractValidationException);
+
+        return contractValidationException;
+    }
+
+    private async ValueTask<ContractDependencyException> CreateAndLogDependencyExceptionAsync(
+        Xeption exception)
+    {
+        var contractDependencyException =
+            new ContractDependencyException(
+                message: "Contract dependency error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(contractDependencyException);
+
+        return contractDependencyException;
+    }
+
+    private async ValueTask<ContractServiceException> CreateAndLogServiceExceptionAsync(
+        Xeption exception)
+    {
+        var contractServiceException =
+            new ContractServiceException(
+                message: "Contract service error occurred, contact support.",
+                innerException: exception);
+
+        await this.loggingBroker.LogErrorAsync(contractServiceException);
+
+        return contractServiceException;
+    }
+}

--- a/Standard.Agents/Services/Foundations/Contracts/ContractService.Validations.cs
+++ b/Standard.Agents/Services/Foundations/Contracts/ContractService.Validations.cs
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Contracts.Exceptions;
+
+namespace Standard.Agents.Services.Foundations.Contracts;
+
+public partial class ContractService
+{
+    // Empty is a legitimate answer to check — a model that said nothing has not satisfied a
+    // schema, and reporting that honestly is the point. Null is a caller that lost the draft it
+    // meant to validate, and treating it as an empty answer would report a bug as a model failure.
+    private static void ValidateAnswer(string answer)
+    {
+        if (answer is null)
+        {
+            throw new InvalidContractException(
+                message: "Invalid contract, answer is required. "
+                    + "Please correct the error and try again.");
+        }
+    }
+}

--- a/Standard.Agents/Services/Foundations/Contracts/ContractService.cs
+++ b/Standard.Agents/Services/Foundations/Contracts/ContractService.cs
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Contracts;
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Foundations.Contracts;
+
+namespace Standard.Agents.Services.Foundations.Contracts;
+
+// Whether an answer is the right SHAPE — the question the client contract could never answer.
+//
+// ProcessPromptAsync returns a string, so every consumer wiring an agent into a workflow wrote a
+// parser, which is the thing this framework talked them out of doing everywhere else. Native tool
+// calling gives structured input TO tools; the agent's own answer was always prose.
+//
+// It sits beside the Judge rather than anywhere else because it is the same kind of verdict at the
+// same moment: the Judge asks whether a draft is good enough, this asks whether it is the right
+// shape, and both run before a draft becomes an answer.
+public partial class ContractService : IContractService
+{
+    private readonly IContractBroker contractBroker;
+    private readonly ILoggingBroker loggingBroker;
+
+    public ContractService(
+        IContractBroker contractBroker,
+        ILoggingBroker loggingBroker)
+    {
+        this.contractBroker = contractBroker;
+        this.loggingBroker = loggingBroker;
+    }
+
+    public ValueTask<ContractVerdict> CheckAsync(string answer, string schema) =>
+    TryCatch(async () =>
+    {
+        ValidateAnswer(answer);
+
+        // No schema is not a failed check, it is no check. An agent given no contract is not
+        // constrained by having become checkable — the same rule as counting always being on
+        // while blocking is not.
+        if (string.IsNullOrWhiteSpace(schema))
+        {
+            return ContractVerdict.Unconstrained;
+        }
+
+        string? complaint = await this.contractBroker.ValidateAsync(answer, schema);
+
+        return string.IsNullOrWhiteSpace(complaint)
+            ? ContractVerdict.Unconstrained
+            : new ContractVerdict(Satisfied: false, Reason: complaint);
+    });
+}

--- a/Standard.Agents/Services/Foundations/Contracts/IContractService.cs
+++ b/Standard.Agents/Services/Foundations/Contracts/IContractService.cs
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Contracts;
+
+namespace Standard.Agents.Services.Foundations.Contracts;
+
+public interface IContractService
+{
+    /// <summary>
+    /// Whether an answer is the shape it was held to, and when it is not, what a model should do
+    /// about it.
+    /// </summary>
+    ValueTask<ContractVerdict> CheckAsync(string answer, string schema);
+}

--- a/Standard.Agents/Services/Orchestrations/Decision/Guardians/GuardianOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/Guardians/GuardianOrchestrationService.cs
@@ -6,6 +6,8 @@
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Models.Foundations.Judges;
 using Standard.Agents.Models.Loggings;
+using Standard.Agents.Models.Foundations.Contracts;
+using Standard.Agents.Services.Foundations.Contracts;
 using Standard.Agents.Services.Foundations.Gates;
 using Standard.Agents.Services.Foundations.Judges;
 
@@ -15,15 +17,18 @@ public partial class GuardianOrchestrationService : IGuardianOrchestrationServic
 {
     private readonly IGateService gateService;
     private readonly IJudgeService judgeService;
+    private readonly IContractService contractService;
     private readonly ILoggingBroker loggingBroker;
 
     public GuardianOrchestrationService(
         IGateService gateService,
         IJudgeService judgeService,
+        IContractService contractService,
         ILoggingBroker loggingBroker)
     {
         this.gateService = gateService;
         this.judgeService = judgeService;
+        this.contractService = contractService;
         this.loggingBroker = loggingBroker;
     }
 
@@ -63,4 +68,10 @@ public partial class GuardianOrchestrationService : IGuardianOrchestrationServic
 
     public ValueTask<Judgement> EvaluateAsync(string task, string candidate) =>
         TryCatch(async () => await this.judgeService.EvaluateAsync(task, candidate));
+
+    // The third guardian. The Gate asks whether a task may be attempted, the Judge whether a draft
+    // is good enough, and this whether it is the right SHAPE — the same kind of verdict at the same
+    // moment, which is why it belongs here rather than becoming a new concept.
+    public ValueTask<ContractVerdict> CheckShapeAsync(string answer, string schema) =>
+        TryCatch(async () => await this.contractService.CheckAsync(answer, schema));
 }

--- a/Standard.Agents/Services/Orchestrations/Decision/Guardians/IGuardianOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/Guardians/IGuardianOrchestrationService.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using Standard.Agents.Models.Foundations.Contracts;
 using Standard.Agents.Models.Foundations.Judges;
 
 namespace Standard.Agents.Services.Orchestrations.Decision.Guardians;
@@ -26,4 +27,10 @@ public interface IGuardianOrchestrationService
 
     /// <summary>Scores a draft against the task it is meant to answer (SPEC.md §4.2).</summary>
     ValueTask<Judgement> EvaluateAsync(string task, string candidate);
+
+    /// <summary>
+    /// Checks a draft against the shape it was held to. Satisfied when no contract is configured —
+    /// an agent given none is not constrained by having become checkable.
+    /// </summary>
+    ValueTask<ContractVerdict> CheckShapeAsync(string answer, string schema);
 }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Standard.Agents.Brokers.Audits;
 using Standard.Agents.Brokers.Approvals;
 using Standard.Agents.Brokers.Classifiers;
+using Standard.Agents.Brokers.Contracts;
 using Standard.Agents.Brokers.Effects;
 using Standard.Agents.Brokers.Policies;
 using Standard.Agents.Brokers.Files;
@@ -36,6 +37,7 @@ using Standard.Agents.Models.Loggings;
 using Standard.Agents.Prompts;
 using Standard.Agents.Services.Managements;
 using Standard.Agents.Services.Foundations.Brains;
+using Standard.Agents.Services.Foundations.Contracts;
 using Standard.Agents.Services.Foundations.ExternalTools;
 using Standard.Agents.Services.Foundations.Gates;
 using Standard.Agents.Services.Foundations.InternalTools;
@@ -120,6 +122,7 @@ public sealed partial class StandardAgent : IAgent
     // Wide open by default: an agent given no contract is not constrained by having become
     // checkable, the same way counting is always on and blocking is not.
     private string? contractSchema;
+    private IContractBroker? contractBroker;
     private int maxHistoryTurns = 20;
     private Func<AgentPrincipal?>? identityResolver;
 
@@ -972,6 +975,27 @@ public sealed partial class StandardAgent : IAgent
         Set(() => this.contractSchema = jsonSchema);
 
     /// <summary>
+    /// Validates answers with a real JSON Schema library — the <b>External</b> mode. The in-box
+    /// validator covers the subset a model actually gets wrong; use this when you need the whole
+    /// specification.
+    /// </summary>
+    /// <param name="broker">The contract broker to validate with.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent UseContract(IContractBroker broker) =>
+        Set(() => this.contractBroker = broker);
+
+    /// <summary>
+    /// Validates answers with your own code — the <b>Custom</b> mode, for rules a schema cannot
+    /// express: a total that must equal the sum of its lines, an account that must exist. Return
+    /// <c>null</c> when the answer is acceptable, or what is wrong with it in words a model can
+    /// act on.
+    /// </summary>
+    /// <param name="validate">Given the answer and the schema, returns the complaint or null.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent OnContract(Func<string, string, ValueTask<string?>> validate) =>
+        Set(() => this.contractBroker = new FunctionContractBroker(validate));
+
+    /// <summary>
     /// Counts tokens with a provider's own tokenizer — the <b>External</b> mode. Use this when
     /// the numbers have to reconcile against an invoice rather than only hold a bound.
     /// </summary>
@@ -1281,8 +1305,10 @@ public sealed partial class StandardAgent : IAgent
             new GuardianOrchestrationService(
                 gate,
                 new JudgeService(new RedactingVerifierBroker(verifier, redaction), logging),
+                new ContractService(this.contractBroker ?? new RuleContractBroker(), logging),
                 logging),
-            logging);
+            logging,
+            this.contractSchema);
 
         // The allow-list is expressed as a policy, so the simple answer and an external policy
         // engine travel one seam and a denial carries a reason either way (SPEC.md §4.9).

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -116,6 +116,10 @@ public sealed partial class StandardAgent : IAgent
     // So the default is a counter rather than a no-op: an agent with no budget is wide open and
     // still measurable, and .Budget() alone is enough to make a bound real on any endpoint.
     private IUsageBroker usageBroker = new RatioUsageBroker();
+
+    // Wide open by default: an agent given no contract is not constrained by having become
+    // checkable, the same way counting is always on and blocking is not.
+    private string? contractSchema;
     private int maxHistoryTurns = 20;
     private Func<AgentPrincipal?>? identityResolver;
 
@@ -956,6 +960,16 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent Usage(double charactersPerToken = 4.0) =>
         Set(() => this.usageBroker = new RatioUsageBroker(charactersPerToken));
+
+    /// <summary>
+    /// Requires every answer to satisfy a JSON schema — the <b>Local</b> mode, validated in the
+    /// box. A draft that does not match is re-thought with the validation error as the reason it
+    /// was rejected: never faulted, and never handed back as though it had matched.
+    /// </summary>
+    /// <param name="jsonSchema">The shape every answer must take.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Contract(string jsonSchema) =>
+        Set(() => this.contractSchema = jsonSchema);
 
     /// <summary>
     /// Counts tokens with a provider's own tokenizer — the <b>External</b> mode. Use this when

--- a/docs/sprint-plan.md
+++ b/docs/sprint-plan.md
@@ -1,0 +1,124 @@
+# The Standard Agent — Reach Plan
+
+> The enterprise program ([enterprise-roadmap.md](enterprise-roadmap.md) /
+> [enterprise-plan.md](enterprise-plan.md)) asked *what must be true for an enterprise to trust
+> this agent*, and finished at `1.1.0.0`. The architecture program
+> ([architecture-alignment.md](architecture-alignment.md)) put the shape back on The Standard and
+> finished at `1.4.0.0`.
+>
+> This plan asks a different question: **what stands between "architecturally the best thing in
+> this space" and "the thing people actually reach for."**
+
+---
+
+## 1 · The finding
+
+An audit of the framework against what an enterprise-grade agent framework needs found the
+perimeter, the failure semantics, the profiles, the spec and the architecture enforcement to be
+strong — and the gaps to sit at the two ends: **the beginner's on-ramp** and **the ecosystem
+around the core.**
+
+The core is close to complete. What is missing is mostly *packages*, and one real hole in the
+client contract.
+
+## 2 · The ranked backlog
+
+Ranked by adoption impact per unit of work. The repo column is why this matters for sequencing —
+**most of the top of this list cannot be built in this repository.**
+
+| # | Item | Nature / tier | Repo | Size |
+|---|---|---|---|---|
+| 1 | **Vector knowledge package** — embeddings, hybrid search, chunking | Data · broker | package | M |
+| 2 | **Structured output** — a typed, validated answer | Decision · new foundation | **core** | M |
+| 3 | **OpenTelemetry package** — `Turn → Step → Process` as spans | utility · broker | package | S |
+| 4 | **Sub-agent boundary** — status flattening, no streaming through | Direction · `AgentTool` | **core** | M |
+| 5 | **Hosting package** — `AddStandardAgent()`, principal, cancellation, SSE | exposer | package | S |
+| 6 | **Provider packages** — Azure OpenAI, Anthropic, Bedrock | Decision · broker | packages | S each |
+| 7 | **Evaluation harness** — golden sets, behavioural diff per skillset version | new project | **core repo** | M |
+| 8 | **Response caching** — a decorating broker | broker | **core** | S |
+| 9 | **Model escalation** — cheap first, escalate on Judge rejection | Decision | **core** | S–M |
+| 10 | **Per-tenant quota** — bound a tenant, not just a prompt | *scope undecided* | — | — |
+
+**Struck from the original list: skills authoring tooling.** The PeerLLM registry and
+`Standard.Agents.Data.Skills.PeerLLM` already cover authoring, versioning, sharing and
+distribution. What remains splits two ways and neither is a new item:
+
+- **Publish-time conflict linting** belongs in the portal. The framework already detects
+  contradictory skills through the Gate's `DetectConflictAsync`, but at *runtime* — you find out
+  two skills conflict when a customer hits it. The same rubric run across a skillset at publish is
+  a portal feature with the machinery already built, and no prompt registry does it.
+- **Behavioural diff** is item 7, not a separate thing.
+
+Those two combine into the reason item 7 is worth more than its rank suggests: **versioned
+skillsets plus a golden set answers "did v4 of this skillset make the agent worse?"** The registry
+supplies the versioning; the harness supplies the judgement.
+
+**Deliberately not on this list**, for the same reason triggers are not in the framework: rate
+limiting (the gateway's), encryption at rest (the store's), tenant isolation enforcement (the
+broker you supply), parallel tool execution (one act per turn is a perimeter decision, not a
+performance oversight).
+
+## 3 · Sprint 1 — what this repository can actually build
+
+Items 1, 3, 5 and 6 are separate packages and separate repositories. That leaves the core work, in
+this order:
+
+| Step | Item | Why this order |
+|---|---|---|
+| 1 | **Structured output** (#2) | The only real gap in the client contract, and the one every integrator hits |
+| 2 | **Sub-agent boundary** (#4) | Multi-agent is the enterprise destination and the boundary loses information |
+| 3 | **Response caching** (#8) | Small, fits the decorating-broker pattern exactly, real money |
+| 4 | **Model escalation** (#9) | The Judge already produces the signal; cheapest quality/cost win there is |
+
+Item 7 is a new project in this repo and is a sprint of its own.
+
+## 4 · Structured output — the design
+
+**The gap.** `ProcessPromptAsync` returns `string`. That is the entire client contract, so every
+consumer wiring an agent into a workflow writes a parser — which is exactly what the framework
+talked them out of doing everywhere else. Native tool calling gives structured input *to tools*;
+the agent's own answer is always prose.
+
+**Where it belongs.** A schema check asks *is this answer the right shape*, immediately beside the
+Judge's *is this answer good enough*. Both are verdicts on a draft before it becomes an answer, at
+the same moment, so it is **Decision, Guardian region** — a third guardian of a different kind.
+
+That keeps every count honest:
+
+| | before | after |
+|---|---|---|
+| Guardian orchestration | Gate, Judge (2) | Gate, Judge, Contract (3) ✔ |
+| Decision foundations | Brain, Usage, Gate, Judge (4) | + Contract (5) |
+| Foundations total | 14 | 15 |
+
+**The broker is the validator.** A JSON Schema validator is a real external resource, which is what
+makes this a foundation rather than loose logic — and it answers the triad without straining:
+
+- **Local** — a minimal in-box validator (types, required, enum). Keeps the core dependency-free.
+- **External** — `.UseContract(broker)` for a full JSON Schema library.
+- **Custom** — `.OnContract(delegate)` for your own validation.
+
+**The schema travels as a JSON string**, following `ToolDefinition.ParametersJson`, which already
+sets that precedent. A typed `T` overload with schema generation can follow in a package; it needs
+reflection and does not belong in a dependency-free core.
+
+**A mismatch is a re-think, not a fault.** The Judge revision loop already models exactly this: a
+rejection sets `AgentStatus.Revising` and the loop re-asks within the turn budget, and when it
+still cannot pass, it refuses gracefully rather than throwing. A schema failure takes the same
+path, with the validation error fed back as the revision reason so the model knows what to fix.
+
+## 5 · Definition of done
+
+The bar this repository already holds itself to, restated so nothing slips:
+
+- **FAIL/PASS TDD**, and the FAIL commit is a test *run and observed failing*. Where a test is
+  written after the code, it is **sabotage-verified** instead and the commit says so.
+- **Brokers carry no unit tests.** They are thin liaisons.
+- **The triad is complete** — Local, External, Custom — or the capability matrix test fails the
+  build.
+- **The tier rules hold**: one nature broker per foundation, nothing above the foundation tier
+  takes a broker, two-to-three of the tier directly below.
+- **A conformance vector**, proven able to fail, for anything another language must reproduce.
+- **The spec says it** if an implementer would otherwise guess. Three gaps this year were silences,
+  not wrong statements.
+- Zero warnings, all four profiles certified.


### PR DESCRIPTION
Sprint 1, step 1 of [`docs/sprint-plan.md`](docs/sprint-plan.md) — plus a pre-existing defect found on the way.

### The gap

`ProcessPromptAsync` returns `string`. That is the entire client contract, so every consumer wiring an agent into a workflow writes a parser — exactly what this framework talked them out of doing everywhere else. Native tool calling gives structured input **to tools**; the agent's own answer was always prose.

### Where it goes

A schema check asks whether an answer is the right **shape**, beside the Judge asking whether it is good **enough** — same moment, same kind of verdict. So it is a **third guardian**, not a new concept.

| | before | after |
|---|---|---|
| Guardian orchestration | Gate, Judge (2) | Gate, Judge, Contract (3), yes |
| Decision foundations | 4 | 5 |
| Foundations total | 14 | 15 |

Every tier rule still holds — `TierDisciplineTests` 46/46.

### The triad

- `.Contract(schema)` — **Local**, validated in the box
- `.UseContract(broker)` — **External**, a real JSON Schema library
- `.OnContract(delegate)` — **Custom**, for rules a schema cannot express: a total that must equal the sum of its lines, an account that must exist

`RuleContractBroker` covers the subset a model actually gets wrong and **says in the file that it is not JSON Schema** — no `$ref`, no `allOf`, no `pattern`, no nested validation. A partial validator claiming completeness would report an answer as conforming to a schema it was never checked against.

Two judgement calls worth review:
- **`integer` is deliberately looser than the spec.** `System.Text.Json` does not distinguish `1` from `1.0`, and rejecting a whole number for arriving as a double would send the model into a revision it cannot satisfy.
- **A malformed schema is the host's error**, mapped as validation. Reported as the model's, every draft would chase a fault no reply can fix until the turn budget ran out.

The shape check runs **after** the Judge: a draft wrong on the merits should be told that, not told its punctuation is off.

### The defect found on the way — worth reading on its own

**A revision that passes review never delivered.** `Interpret` builds the decided context with `context with { ... }`, which copies `Status` forward, and nothing reset it. So a draft accepted on the second pass left Decision still marked `Revising`, the loop continued, and the run exhausted its turns — handing back *"I can't help with that at the moment"* for an answer that had **passed**.

Reachable with nothing but a Judge, and it predates this work. 1.2.0.0 said a rejection is a re-think signal and the coordinator retries within the turn budget; the retry existed and could never succeed. Every test covered permanent rejection; none covered rejection-then-acceptance.

Proven with a probe: a Judge scripted to reject once and accept every time after was judged **four** times against a four-turn cap and still returned the refusal. Committed as its own FAIL so the fix is not buried inside a feature.

Also: the trace now says which guardian refused and why. A rejection it cannot explain is a turn nobody can account for.

**479 tests, 33 vectors, all four profiles CERTIFIED, zero warnings.**
