### PR TITLE
TOOLS: A Held Sub-Agent Is Not A Result

### DIFF
--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.Outcome.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.Outcome.cs
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Tools;
+
+// A nested agent runs its own full loop, so it can end every way a run can end — answered,
+// refused, held on an authority, out of turns. The outer agent sees one tool call and a string
+// back, and `IAgent` returns nothing but a string, so it cannot tell WHICH of those happened.
+//
+// That is fine for an answer and dangerous for everything else. A sub-agent held on an approval
+// returns "'wire_transfer' is waiting for approval before it can run." — prose that reads exactly
+// like a result. The outer agent takes it as the tool's output, carries on, and may report the
+// work as done when a human has not yet permitted it.
+//
+// Multi-agent is where enterprises are going, and the perimeter that Part 4 built stops at the
+// boundary of a single run. This is the seam it leaks through.
+public partial class AgentToolTests
+{
+    private static Mock<IAgent> AgentEnding(AgentStatus status, string result)
+    {
+        var nested = new Mock<IAgent>();
+
+        nested.Setup(agent => agent.ProcessPromptAsync(It.IsAny<string>()))
+            .ReturnsAsync(result);
+
+        nested.Setup(agent => agent.RunAsync(It.IsAny<string>()))
+            .ReturnsAsync(new AgentOutcome(Result: result, Status: status));
+
+        return nested;
+    }
+
+    [Fact]
+    public async Task ShouldReturnTheAnswerPlainlyWhenTheNestedAgentRespondedAsync()
+    {
+        // given
+        Mock<IAgent> nested = AgentEnding(AgentStatus.Responded, "the answer");
+        var agentTool = new AgentTool(name: "researcher", agent: nested.Object);
+
+        // when
+        string actualOutput = await agentTool.ExecuteAsync("go");
+
+        // then — an answer is an answer; nothing is added to it
+        actualOutput.Should().Be("the answer");
+    }
+
+    [Theory]
+    [InlineData(AgentStatus.AwaitingApproval)]
+    [InlineData(AgentStatus.AwaitingInput)]
+    [InlineData(AgentStatus.Refused)]
+    [InlineData(AgentStatus.Failed)]
+    public async Task ShouldMarkAnOutcomeThatIsNotAnAnswerAsync(AgentStatus status)
+    {
+        // given
+        Mock<IAgent> nested = AgentEnding(
+            status,
+            "'wire_transfer' is waiting for approval before it can run.");
+
+        var agentTool = new AgentTool(name: "settlement", agent: nested.Object);
+
+        // when
+        string actualOutput = await agentTool.ExecuteAsync("pay it");
+
+        // then — the outer agent must not be able to read this as a completed result
+        actualOutput.Should().StartWith(
+            "[did not complete]",
+            because: "a run that was held, refused or failed is not a tool result, and prose that "
+                + "merely mentions waiting is indistinguishable from an answer that mentions it");
+
+        actualOutput.Should().Contain(
+            status.ToString(),
+            because: "the outer agent has to know WHICH way it ended — held is not refused, and "
+                + "refused is not failed");
+
+        actualOutput.Should().Contain(
+            "waiting for approval",
+            because: "the inner agent's own words are what say why, and dropping them would "
+                + "leave the outer agent with a category and no reason");
+    }
+}

--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
@@ -3,7 +3,9 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Models.Orchestrations.Agents;
 using FluentAssertions;
 using Moq;
 using Standard.Agents.Tools;
@@ -37,8 +39,8 @@ public partial class AgentToolTests
         var nestedAgentMock = new Mock<IAgent>();
 
         nestedAgentMock.Setup(agent =>
-            agent.ProcessPromptAsync(randomInput))
-                .ReturnsAsync(randomAnswer);
+            agent.RunAsync(randomInput))
+                .ReturnsAsync(new AgentOutcome(randomAnswer, AgentStatus.Responded));
 
         var agentTool = new AgentTool(name: randomName, agent: nestedAgentMock.Object);
 
@@ -50,7 +52,7 @@ public partial class AgentToolTests
         agentTool.Name.Should().Be(randomName);
 
         nestedAgentMock.Verify(agent =>
-    agent.ProcessPromptAsync(randomInput),
+    agent.RunAsync(randomInput),
         Times.Once);
 
         nestedAgentMock.VerifyNoOtherCalls();
@@ -63,8 +65,8 @@ public partial class AgentToolTests
         var innerAgent = new Mock<IAgent>();
 
         innerAgent.Setup(agent =>
-            agent.ProcessPromptAsync(It.IsAny<string>()))
-                .ReturnsAsync("the capital is Paris");
+            agent.RunAsync(It.IsAny<string>()))
+                .ReturnsAsync(new AgentOutcome("the capital is Paris", AgentStatus.Responded));
 
         var researcher = new AgentTool(name: "researcher", agent: innerAgent.Object);
 
@@ -111,7 +113,7 @@ public partial class AgentToolTests
         actualResult.Should().Be("Paris");
 
         innerAgent.Verify(agent =>
-    agent.ProcessPromptAsync(prompt: "capital of France"),
+    agent.RunAsync("capital of France"),
         Times.Once);
     }
 
@@ -123,7 +125,7 @@ public partial class AgentToolTests
         var nestedFailure = new InvalidOperationException(message: "inner agent failed");
 
         nestedAgentMock.Setup(agent =>
-            agent.ProcessPromptAsync(It.IsAny<string>()))
+            agent.RunAsync(It.IsAny<string>()))
                 .ThrowsAsync(nestedFailure);
 
         var agentTool = new AgentTool(name: "nested", agent: nestedAgentMock.Object);
@@ -151,8 +153,8 @@ public partial class AgentToolTests
         var nestedAgentMock = new Mock<IAgent>();
 
         nestedAgentMock.Setup(agent =>
-            agent.ProcessPromptAsync(expectedHandoffPrompt))
-                .ReturnsAsync(randomAnswer);
+            agent.RunAsync(expectedHandoffPrompt))
+                .ReturnsAsync(new AgentOutcome(randomAnswer, AgentStatus.Responded));
 
         var agentTool = new AgentTool(
             name: "researcher",
@@ -166,7 +168,7 @@ public partial class AgentToolTests
         actualOutput.Should().Be(randomAnswer);
 
         nestedAgentMock.Verify(agent =>
-            agent.ProcessPromptAsync(expectedHandoffPrompt),
+            agent.RunAsync(expectedHandoffPrompt),
                 Times.Once);
 
         nestedAgentMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/AgentToolTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Standard.Agents.Tests.Unit.Tools;
 
-public class AgentToolTests
+public partial class AgentToolTests
 {
     private static string CreateRandomString() =>
         new MnemonicString().GetValue();

--- a/Standard.Agents/IAgent.cs
+++ b/Standard.Agents/IAgent.cs
@@ -4,12 +4,31 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
 
 namespace Standard.Agents;
 
 public interface IAgent
 {
     ValueTask<string> ProcessPromptAsync(string prompt);
+
+    /// <summary>
+    /// The same run, reported with <b>how it ended</b> as well as what it produced. A run can end
+    /// answered, refused, held on an authority, or out of turns, and only the first makes the
+    /// result an answer — a caller given nothing but the string cannot tell them apart.
+    /// </summary>
+    /// <remarks>
+    /// The default assumes the run answered, which is exactly what a caller of
+    /// <see cref="ProcessPromptAsync"/> already assumes, so an existing implementation keeps
+    /// working and is no less accurate than it was. An implementation that knows better — and
+    /// every implementation that runs the loop does — should override it. Nesting reads this
+    /// (<c>AgentTool</c>), so an agent that leaves the default will have its held runs reported to
+    /// an outer agent as answers.
+    /// </remarks>
+    async ValueTask<AgentOutcome> RunAsync(string prompt) =>
+        new AgentOutcome(
+            Result: await ProcessPromptAsync(prompt),
+            Status: AgentStatus.Responded);
 
     IAsyncEnumerable<AgentStreamEvent> StreamPromptAsync(
         string prompt,

--- a/Standard.Agents/Models/Clients/Agents/AgentOutcome.cs
+++ b/Standard.Agents/Models/Clients/Agents/AgentOutcome.cs
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Agents;
+
+namespace Standard.Agents.Models.Clients.Agents;
+
+/// <summary>
+/// How a run ended, and what it produced.
+/// </summary>
+/// <param name="Result">The answer, or the reason there is not one.</param>
+/// <param name="Status">
+/// Which way it ended. <see cref="AgentStatus.Responded"/> is the only one that makes the result an
+/// answer — a run that was held on an authority, refused, or ran out of turns produced prose about
+/// why, and a caller that cannot tell those apart will eventually report held work as done.
+/// </param>
+public record AgentOutcome(string Result, AgentStatus Status);

--- a/Standard.Agents/Services/Managements/IRunManagementService.cs
+++ b/Standard.Agents/Services/Managements/IRunManagementService.cs
@@ -18,6 +18,16 @@ public interface IRunManagementService
         string sessionId,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// The same run, reported with <b>how it ended</b>. Every <c>ProcessPromptAsync</c> above is
+    /// this with the answer projected out of it — which is all a caller wants until the agent is
+    /// nested inside another one, where "held" and "answered" have to be told apart.
+    /// </summary>
+    ValueTask<AgentOutcome> RunAsync(
+        string prompt,
+        string sessionId,
+        CancellationToken cancellationToken);
+
     IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
         string prompt,
         CancellationToken cancellationToken = default);

--- a/Standard.Agents/Services/Managements/RunManagementService.Budgets.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.Budgets.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Models.Coordinations.Agents;
+using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Models.Orchestrations.Effects;
 
@@ -65,7 +66,10 @@ public partial class RunManagementService
         return false;
     }
 
-    private async ValueTask<string> StopAsync(
+    // The status was taken and never used: a cancelled or budget-exhausted run reported its
+    // message and left how it ended inside this method. Nothing above could tell "I ran out" from
+    // an answer, which is the same flattening that let a held sub-agent read like a result.
+    private async ValueTask<AgentOutcome> StopAsync(
         AgentContext context,
         string message,
         AgentStatus status)
@@ -74,9 +78,11 @@ public partial class RunManagementService
 
         string unwound = await UnwindAsync();
 
-        return string.IsNullOrEmpty(unwound)
+        string result = string.IsNullOrEmpty(unwound)
             ? message
             : $"{message} {unwound}";
+
+        return new AgentOutcome(result, status);
     }
 
     // An async iterator cannot put a catch clause around a yield, so the streamed loop unwinds

--- a/Standard.Agents/Services/Managements/RunManagementService.Exceptions.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.Exceptions.cs
@@ -11,13 +11,13 @@ namespace Standard.Agents.Services.Managements;
 
 public partial class RunManagementService
 {
-    private delegate ValueTask<string> ReturningStringFunction();
+    private delegate ValueTask<T> ReturningFunction<T>();
 
-    private async ValueTask<string> TryCatch(ReturningStringFunction returningStringFunction)
+    private async ValueTask<T> TryCatch<T>(ReturningFunction<T> returningFunction)
     {
         try
         {
-            return await returningStringFunction();
+            return await returningFunction();
         }
         catch (InvalidAgentException invalidAgentException)
         {

--- a/Standard.Agents/Services/Managements/RunManagementService.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.cs
@@ -71,7 +71,16 @@ public partial class RunManagementService : IRunManagementService
         CancellationToken cancellationToken) =>
         ProcessPromptAsync(prompt, string.Empty, cancellationToken);
 
-    public ValueTask<string> ProcessPromptAsync(
+    public async ValueTask<string> ProcessPromptAsync(
+        string prompt,
+        string sessionId,
+        CancellationToken cancellationToken) =>
+        (await RunAsync(prompt, sessionId, cancellationToken)).Result;
+
+    // The same run, reported with how it ended. ProcessPromptAsync projects the answer out of it,
+    // because a caller who only wants the string should not have to know there was more — and a
+    // caller who nests this agent inside another one cannot do without it (AgentTool).
+    public ValueTask<AgentOutcome> RunAsync(
         string prompt,
         string sessionId,
         CancellationToken cancellationToken) =>
@@ -169,7 +178,7 @@ public partial class RunManagementService : IRunManagementService
             {
                 await this.loggingBroker.LogOutcomeAsync($"done: {context.Status}");
 
-                return $"{context.Result} {unwound}".Trim();
+                return new AgentOutcome($"{context.Result} {unwound}".Trim(), context.Status);
             }
         }
 
@@ -192,7 +201,7 @@ public partial class RunManagementService : IRunManagementService
         // Appended before the call returns, so the next prompt sees it (SPEC.md §4.11).
         await SaveSessionAsync(context, completed: true);
 
-        return context.Result;
+        return new AgentOutcome(context.Result, context.Status);
     });
 
     public IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -820,6 +820,21 @@ public sealed partial class StandardAgent : IAgent
     }
 
     /// <summary>
+    /// Runs the agent and reports <b>how the run ended</b> as well as what it produced. Only
+    /// <c>AgentStatus.Responded</c> makes the result an answer — a run held on an authority,
+    /// refused, cancelled or out of turns produced prose about why, and the two read alike.
+    /// </summary>
+    /// <remarks>
+    /// This is what nesting uses. <c>AgentTool</c> reads it so an outer agent cannot mistake a
+    /// sub-agent that was held for one that finished, which the string on its own could never tell
+    /// it.
+    /// </remarks>
+    /// <param name="prompt">What to work on.</param>
+    /// <returns>The answer, and how the run ended.</returns>
+    public async ValueTask<AgentOutcome> RunAsync(string prompt) =>
+        await ResolveAgent().RunAsync(prompt, string.Empty, CancellationToken.None);
+
+    /// <summary>
     /// Runs the agent on a prompt and stops when <paramref name="cancellationToken"/> is
     /// cancelled — at the next turn boundary at the latest, so no effect is left half-recorded
     /// (SPEC.md §4.10). A cancelled run returns a message saying so rather than an answer.

--- a/Standard.Agents/Tools/AgentTool.cs
+++ b/Standard.Agents/Tools/AgentTool.cs
@@ -3,6 +3,9 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+
 namespace Standard.Agents.Tools;
 
 public sealed class AgentTool : ITool
@@ -40,6 +43,29 @@ public sealed class AgentTool : ITool
     // The nested agent runs its own full loop — its own Recall, Think, Act, its own
     // turn cap, its own guardians. The outer agent sees one tool call and a string
     // back, and cannot tell whether a function or a mind answered it.
-    public async ValueTask<string> ExecuteAsync(string input) =>
-        await this.agent.ProcessPromptAsync(this.handoff.Replace(InputPlaceholder, input));
+    //
+    // What it MUST be able to tell is whether the mind finished. A run that was held on an
+    // authority, refused, or ran out of turns produced prose explaining why, and prose explaining
+    // why reads exactly like prose answering the question. Returned unmarked, an outer agent can
+    // report work as done that a human has not yet permitted — which is the perimeter of Part 4
+    // leaking at the one seam it never covered, because every control there is scoped to a run and
+    // a sub-agent is a different run.
+    public async ValueTask<string> ExecuteAsync(string input)
+    {
+        AgentOutcome outcome =
+            await this.agent.RunAsync(this.handoff.Replace(InputPlaceholder, input));
+
+        // An answer is an answer. Nothing is added to it, because anything added is text the outer
+        // model has to reason past on the path that is working correctly.
+        if (outcome.Status is AgentStatus.Responded)
+        {
+            return outcome.Result;
+        }
+
+        // Marked, categorised, and still carrying the sub-agent's own words. The marker is what
+        // makes it unmistakable, the status is what says WHICH way it ended — held is not refused
+        // and refused is not failed — and the reason is why, which a category alone cannot give.
+        return $"[did not complete] the sub-agent '{Name}' ended {outcome.Status}: "
+            + outcome.Result;
+    }
 }


### PR DESCRIPTION
Sprint 1, step 2 of [`docs/sprint-plan.md`](docs/sprint-plan.md).

### The leak

A nested agent runs its own full loop, so it ends every way a run can end — answered, refused, held on an authority, out of turns. `IAgent` returned nothing but a `string`, so **the outer agent could not tell which happened.**

Fine for an answer. Dangerous for the rest. A sub-agent held on an approval returns:

> `'wire_transfer' is waiting for approval before it can run.`

Prose that reads exactly like a result. The outer agent takes it as the tool's output, carries on, and can report the work as done while a human has not yet permitted it.

**That is the Part 4 perimeter leaking at the one seam it never covered** — identity, approval, run-once and screening are all scoped to a run, and a sub-agent is a different run.

### The fix

`IAgent.RunAsync` returns result **and** status, as a **default interface member** so nothing implementing `IAgent` today breaks. The default reports `Responded` — precisely what a caller of `ProcessPromptAsync` already assumes, so an existing implementation is no less accurate than it was. The remarks say plainly that any implementation running the loop should override it, and that nesting reads this.

`AgentTool` returns an answer **plainly**, with nothing added — anything added is text the outer model has to reason past on the path that works. Everything else comes back `[did not complete] … ended {Status}: {reason}`: the marker makes it unmistakable, the status says *which* way (held is not refused, refused is not failed), and the sub-agent's own words say why.

### Two things found on the way up

The outcome had to survive the whole way, and it didn't:

- **`RunManagementService` returned only a string.** It now returns an `AgentOutcome`, and `ProcessPromptAsync` projects the answer out of it — all three existing overloads unchanged for callers who only wanted the string. `TryCatch` became generic to carry it.
- **`StopAsync` took a `status` parameter and never used it.** A cancelled or budget-exhausted run reported its message and left how it ended inside the method — the same flattening one tier down, and the reason `.Budget` exhaustion could be told from a refusal only by reading the text.

### Not in scope, and named rather than left

**Streaming through a sub-agent still isn't possible**, and can't be without a different tool contract: `ITool.ExecuteAsync` returns a `string`, so a tool fundamentally cannot stream. That's a design question, not an oversight, and it deserves its own change rather than being bundled here.

**The outer run does not halt** when an inner one is held — it is *told*, unmistakably, and can re-plan. Halting the outer run would require a tool to influence run status, which is a public `ITool` change. Worth deciding deliberately.

**484 tests, 33 vectors, all four profiles CERTIFIED, zero warnings.**