### PR TITLE
RELEASES: A Release Can Be Cut From Anywhere The Notes Can

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,41 @@
+name: Standard.Agents Cut Release
+
+# Creates the version tag and the GitHub Release, taking the notes from a markdown file kept
+# in the repository — so release notes are reviewed like everything else, and a release can be
+# cut from any environment that can dispatch a workflow but cannot reach the Releases API.
+#
+# Publishing stays in release.yml. A release created with GITHUB_TOKEN does not fire the
+# `release` event (GitHub prevents workflows from triggering workflows through that token),
+# so after this succeeds, dispatch release.yml on the new tag to attach artifacts and publish.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The version tag to create (e.g. v1.6.1)"
+        required: true
+      name:
+        description: "The release title"
+        required: true
+      notes_path:
+        description: "Repository path of the markdown file holding the release notes"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  cut:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Pulling Code
+      uses: actions/checkout@v4
+
+    - name: Creating The Tag And The Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: >
+        gh release create "${{ inputs.tag }}"
+        --target "${{ github.sha }}"
+        --title "${{ inputs.name }}"
+        --notes-file "${{ inputs.notes_path }}"

--- a/docs/releases/v1.6.1.md
+++ b/docs/releases/v1.6.1.md
@@ -1,0 +1,40 @@
+The 2026-08-23 full sweep of `1.5.0`, and the five passes that fixed everything it found — each behaviour FAIL-first, each vector proven able to fail, each fix carrying its class sweep in the commit that closed it. The report ships in the repository: `docs/reviews/2026-08-23-full-sweep.md`.
+
+## The permission hotfix (1.5.1)
+
+Four silent grants in the feature shipped *for* permission, none of them new rules — all four violated SPEC 1.3 §4.9 as written.
+
+- **`PermissionMode.Deny` was never consulted.** Declared, documented (*"Denied. Nothing runs but what was named."*), and compared against nothing — the strictest disposition behaved exactly like `Open`. The perimeter gains step 1b: an act nothing named is refused before its intent is recorded, told and non-terminal like a policy denial.
+- **`Ask` with nobody wired to answer was consent.** Both approval brokers answered `Approved` where no human could have said yes. Waiting is not consent, and an absent authority is nothing but waiting — both now hold.
+- **One approval covered every later use of an unscoped tool.** `ScopeOf` defaults to empty (every MCP tool among them), so the grant key collapsed to the tool name: approving a $10 transfer silently approved the $10,000 one. An act with no named scope now remembers nothing and is asked about each time; run-once still spares the authority identical repeats.
+- **The streamed loop never screened tool output.** With `.ScreenToolOutput()` on, the injected result the batched path withholds sailed into the Brain whenever the caller streamed.
+
+## One loop, two projections (1.5.2)
+
+Six controls were enforced on one door and not the other — screening, the Contract, the revision reset, the approval hold's announcement, the Gate's route label (the mirror image: streamed only), and native tool calling, which **threw** on the streamed door. Every one had been introduced by editing one loop and not its twin.
+
+Each was closed FAIL-first; then the class: `RunManagementService` has exactly **one loop**, with `RunAsync` draining it and `StreamPromptAsync` yielding it. Unifying them surfaced a latent defect no test had ever seen: an async iterator's execution context does not survive a yield boundary, so the old streamed loop's ambient run identity — what run-once keys, approval grants, compensation and record attribution hang off — silently reverted to null after the first event. The loop is now a plain async method pumping a channel, and the run survives its own events.
+
+`LoopParityTests` replaces enumerated parity with **derived** parity: fourteen scenarios through both doors must produce the identical answer, tool executions, and entire decision-log trace — every control narrates itself, so a control added to one door only diverges without the test naming it.
+
+## Every turn is measured (1.5.3)
+
+On the text protocol only the **first** turn was ever measured: the token counts rode the context copy across turns exactly as `Status` did, and the loop re-billed turn 1's figure forever — the same shape as the eight-release hole `1.3.0` closed, introduced by the fix that closed it. One clear at Decision's entry now covers the whole class, and a rejected draft still costs: a revision loop the budget cannot see is where a run burns tokens fastest.
+
+Two vectors close the certification hole that let this ship — every budget vector used an impossible bound, so an implementation that counted nothing was certifiable. `a-budget-counts-every-turn` requires the bound to trip on real cumulative spend; `a-generous-budget-lets-the-run-finish` requires a run under a generous bound to complete.
+
+## The enforcement pass (1.6.0)
+
+A vector that cannot fail reports coverage. Six were strengthened and each proven able to fail by applying the very mutation it exists to catch — redaction's vector had passed with rehydration **deleted**, the scoped allow-list's with the scope check **inverted**. The harness now rejects unknown fields (a typo'd key silently deleted the assertion it carried) and asserts per-prompt outcomes.
+
+`TierDisciplineTests` gains the tool seam, which no rule scanned and which held a live inversion: `RememberTool` kept `IMemoryService`, composed into `ToolBroker` — a foundation transitively calling a foundation through a broker. A tool now holds a function, like any host tool. And **Redaction joins the capability matrix** it was missing from entirely: `.Redact(rules)`, `.UseRedaction(broker)`, `.OnRedaction(redact, rehydrate)`.
+
+## The documentation pass (1.6.1)
+
+The sweep's most common finding was the silence — a true statement with an unstated boundary. Now stated where a reader decides: run-once is scoped to a run and an at-least-once trigger **must** be deduplicated at the trigger boundary; nothing crosses the nesting seam; `.Risk()` classifies and does not enforce; `.Budget` meters the Brain. And verifying the docs rather than transcribing them caught one more defect: `.Knowledge(minScore:)` stored the floor and composition never passed it on.
+
+## Compatibility
+
+New public routines (`Redact(rules)`, `UseRedaction`, `OnRedaction`) and one converting `[Obsolete]` alias (`RememberTool`'s service constructor). **No contract removed, no field repurposed** — nothing written against `1.5.0` needs to move. Versions `1.5.1`–`1.6.0` were waypoints on this branch; `1.6.1` is the release that ships. Three items remain open by decision, not omission, named in the sweep report: what a turn-capped run is, the honest dependency-counting of `DirectionCoordinationService`, and the outer cancellation token stopping at the `AgentTool` seam.
+
+**532 tests, 41 vectors, all four readiness profiles CERTIFIED, zero warnings.**


### PR DESCRIPTION
The repository had exactly one way to cut a release: a person in the web UI. This adds the second — `cut-release.yml`, a dispatchable workflow that creates the version tag and the GitHub Release from a notes file kept in the repository, so the notes are reviewed like everything else and a release can be cut from any environment that can dispatch a workflow but cannot reach the Releases API.

Publishing stays where it was: a release created with `GITHUB_TOKEN` does not fire the `release` event, so `release.yml` is dispatched on the new tag afterwards — exactly what its own `workflow_dispatch` trigger exists for.

`docs/releases/v1.6.1.md` carries the notes for 1.6.1 — the five passes over the 2026-08-23 sweep — in the format every release before it used.