### PR TITLE
CONFIG: Critical Profile - Claims Only What Its Vectors Verify

### DIFF
--- a/conformance/profiles/critical.json
+++ b/conformance/profiles/critical.json
@@ -1,6 +1,6 @@
 {
   "name": "Critical",
-  "description": "Enterprise, plus conversation that survives a process, effects that can be unwound, and adversarial evaluation. The level a wire transfer needs.",
+  "description": "Enterprise, plus conversation that survives a process, effects that can be unwound, and an approval that resumes across processes. The level a wire transfer needs.",
   "inherits": "Enterprise",
   "requires": [
     "conversation-carries-history",


### PR DESCRIPTION
### What does this PR do?
The Critical profile's description promised "adversarial evaluation" while no adversarial suite exists — an unverified claim in the one artifact whose purpose is machine-verified claims. The description now names the approval-resumes-across-processes guarantee, which vectors 25–29 do verify. The adversarial words return with the suite that gates them (planned for the Evals & Hosting release).

### Category
- [x] CONFIG

### Size
- [x] N/A (CONFIG — one description line, no tests changed)

### Branch name follows Standard convention
- [x] `users/hassanhabib/CONFIG-critical-profile-honesty`

### TDD compliance
- [x] N/A — non-TDD CONFIG change; Critical profile re-certified after the edit (41/41 vectors, exit 0)

### No sensitive data
- [x] No secrets, API keys, or connection strings in the diff

### Quality gates
- [x] Critical profile certifies locally after the change
- [x] CI build runs on this PR