### PR TITLE
DOCUMENTATION: Enterprise Plan - Says Where The Program Actually Stands

### DIFF
--- a/docs/enterprise-plan.md
+++ b/docs/enterprise-plan.md
@@ -170,7 +170,9 @@ MOVEMENT I — TRUST                MOVEMENT II — CONTROL           MOVEMENT I
 | 0.25 Supply chain | **landed** | pinned SDK, warnings as errors, vulnerability and licence audit, secret scanning, SBOM, provenance; `docs/support.md` |
 | 1.0 Enterprise model | **landed** | sessions, cross-process run identity, durable run-once, compensation, native tool-call round-trip; vectors 25–29 |
 | 1.1 Audit of 1.0 | **landed** | identity reaches authorization, streamed path at parity, full principal, held effect on the session; vector 30; SPEC.md settles at 1.0 |
-| 1.2 Evals & hosting | next | — |
+| 1.2–1.4 Back on The Standard | **landed** | the architecture realignment (`1.2.0`), every-protocol usage measurement (`1.3.0`), tier adjacency enforced (`1.4.0`) — none of it planned here, all of it found by auditing |
+| 1.5–1.6.1 Structured output, permission, the sweep | **landed** | `.Contract` triad and scoped permission (`1.5.0`); the 2026-08-23 full sweep and its five fix passes (`1.5.1`–`1.6.1`); `docs/reviews/2026-08-23-full-sweep.md` |
+| 1.7 Evals & hosting | next | the one planned release still unshipped — displaced five times by audits that outranked it |
 
 **1.1 was not the release that was planned.** Auditing 1.0 against its own claims turned up two
 defects — `.Principal(...)` never reached the policy broker, and the streamed loop enforced neither
@@ -193,9 +195,12 @@ dotnet run --project Standard.Agents.Conformance -- --profile Enterprise   CERTI
 dotnet run --project Standard.Agents.Conformance -- --profile Critical     CERTIFIED   exit 0
 ```
 
-**All four certify**, across 29 vectors and 375 tests. Critical was written as the 1.1 target and
-is met at 1.0 — the three requirements that were outstanding (compensation, an effect outcome that
-survives a crash, a native tool call that round-trips) all landed rather than being deferred.
+**All four certify** — 41 vectors and 532 tests as of `1.6.1`. Critical was written as the 1.1
+target and is met at 1.0 — the three requirements that were outstanding (compensation, an effect
+outcome that survives a crash, a native tool call that round-trips) all landed rather than being
+deferred. One Critical-row claim stays honest by being named: **adversarial evaluation is not yet
+verified by anything** — it ships with the Evals & Hosting release, and until then the profile's
+description does not claim it.
 
 Measured, on `main`, against the two defects that opened this plan:
 
@@ -942,6 +947,9 @@ Three of them landed differently than written, and saying so is cheaper than pre
 ---
 
 ### 1.1.0.0 — Evals and Hosting
+
+> **Status:** planned as 1.1, displaced to 1.2 by the audit of 1.0, then displaced again by
+> everything 1.2–1.6.1 found. Unshipped as written, scope unchanged, now targeting **1.7.0.0**.
 
 > *Conformance pins contracts. Enterprises also need to pin quality — and to deploy the same
 > definition as a service.*

--- a/docs/sprint-plan.md
+++ b/docs/sprint-plan.md
@@ -1,5 +1,13 @@
 # The Standard Agent — Reach Plan
 
+> **Status, appended at `1.6.1`:** Sprint 1's step 1 shipped — structured output landed in
+> `1.5.0` exactly as §4 designs it (`ContractService` as the third guardian; `.Contract` /
+> `.UseContract` / `.OnContract`; a mismatch takes the revision path). Step 2's boundary loss
+> also closed in `1.5.0`: `IAgent.RunAsync` reports result **and** status, so a held sub-agent
+> no longer reads as an answer. Steps 3–4 (response caching, model escalation) and the package
+> items remain open; item 7, the evaluation harness, is the Evals & Hosting release the
+> enterprise plan still owes — targeting `1.7.0.0`.
+
 > The enterprise program ([enterprise-roadmap.md](enterprise-roadmap.md) /
 > [enterprise-plan.md](enterprise-plan.md)) asked *what must be true for an enterprise to trust
 > this agent*, and finished at `1.1.0.0`. The architecture program


### PR DESCRIPTION
### What does this PR do?
Brings the two planning documents up to reality. The enterprise plan's status table stopped at 1.1 with "Evals & hosting — next" five releases ago; it now records 1.2–1.6.1 as landed, corrects "29 vectors and 375 tests" to 1.6.1's 41 vectors and 532 tests, names the one Critical-row claim nothing verifies yet (adversarial evaluation), and retargets the unshipped Evals & Hosting release at 1.7.0.0. The reach plan gains a status note: structured output shipped in 1.5.0 exactly as its §4 designs, the sub-agent boundary loss closed in 1.5.0, and its item 7 is the same Evals & Hosting release.

### Category
- [x] DOCUMENTATION

### Size
- [x] N/A (documentation — no tests changed)

### Branch name follows Standard convention
- [x] `users/hassanhabib/DOCUMENTATION-enterprise-plan-update`

### TDD compliance
- [x] N/A — documentation only

### No sensitive data
- [x] No secrets, API keys, or connection strings in the diff

### Quality gates
- [x] CI build runs on this PR