### PR TITLE
DOCUMENTATION: Governance - Security Policy, Contributing Guide, Code Of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Code of Conduct
+
+The Standard is people-first, and so is this repository. The license conditions this software
+on serving the survival, evolution, and fulfillment of mankind; the community around it is held
+to the same bar.
+
+## Expected
+
+- **Judge the work, never the person.** Reviews name what the code does and what the rule
+  says — `arch-050`, a failing test, a spec section — not what the author is.
+- **Teach on the way through.** The Standard is an educational project; a correction that
+  leaves the contributor knowing *why* is worth ten that do not.
+- **Fairness by measurement.** Contributions are weighed by the published category points, not
+  by title or tenure. An innovative idea from a first-time contributor outranks a mediocre one
+  from a veteran.
+- **Say the uncomfortable true thing** — a defect is a defect wherever it is found, including
+  in the maintainer's own commits — and say it plainly, in public, about the code.
+
+## Not tolerated
+
+Harassment, personal attacks, discrimination, sustained disruption, or publishing others'
+private information — anywhere the project convenes: issues, pull requests, discussions,
+reviews.
+
+## Enforcement
+
+Report conduct issues privately to the maintainer at hassanhabib@live.com. Reports are read by
+a human, kept confidential, and acted on — from a conversation, to removal of the offending
+content, to a ban for repeated or egregious harm. Maintainers who violate this code are held to
+it more strictly, not less.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing
+
+This repository follows [The Standard](https://github.com/hassanhabib/The-Standard) — the
+architecture, the testing discipline, and the contribution practices. The machine-readable form
+of those practices lives in
+[the-standard-skills](https://github.com/hassanhabib/the-standard-skills); what follows is the
+short version a contributor needs on day one.
+
+## The workflow
+
+Fork → branch → FAIL/PASS commits → pull request. Contributors never push to this repository
+directly; only the maintainer merges.
+
+## Branches
+
+```
+users/[username]/[CATEGORY]-[entity]-[action]
+```
+
+`[CATEGORY]` is UPPER-CASE from the Standard category list (FOUNDATIONS, BROKERS,
+ORCHESTRATIONS, COORDINATIONS, ACCEPTANCE, DOCUMENTATION, CONFIG, INFRA, RELEASES, …), sized
+MAJOR / MEDIUM / MINOR when modifying existing work (5+ / 3–4 / 1–2 tests). One operation per
+branch.
+
+```
+users/hassanhabib/FOUNDATIONS-approval-add
+users/hassanhabib/MINOR-DATA-agent-effect-add-scope
+```
+
+## Commits
+
+Test-driven work produces exactly two commits per behavior:
+
+```
+[FAIL]: ShouldRefuseAnActNothingNamedAsync
+[PASS]: The Perimeter Refuses An Act Nothing Named
+```
+
+A `[FAIL]` commit contains one test, **run and observed failing** — a test that never showed
+red proves nothing. A `[PASS]` commit contains the implementation, with the **full suite
+observed green** before committing. Non-TDD work commits as
+`CATEGORY: Description In Pascal Case`.
+
+Two house rules on top: a fix sweeps its class — grep for the same shape elsewhere and say so
+in the commit — and a test written after its implementation is sabotage-verified (break the
+code, watch the test fail, restore) with the commit saying so.
+
+## The bar a change must clear
+
+The build enforces most of this; the rest is reviewed:
+
+- **Zero warnings.** `TreatWarningsAsErrors` is on and stays on.
+- **All tests green, all four readiness profiles certified:**
+
+  ```bash
+  dotnet test
+  dotnet run --project Standard.Agents.Conformance -- --profile Critical
+  ```
+
+- **The tier rules hold** — `TierDisciplineTests` enforces the 2–3 rule, tier adjacency, and
+  that no broker sits above the foundation tier. Brokers carry no logic and no unit tests.
+- **The capability triad is complete** — Local (`.X`), External (`.UseX`), Custom (`.OnX`) —
+  or waived with a stated reason; the matrix test fails the build otherwise.
+- **A conformance vector, proven able to fail,** for any behavior another implementation of
+  the [spec](https://github.com/hassanhabib/The-Standard-Agent-Specs) must reproduce.
+- **Versioning per Standard Versioning** — `model . service/routine . fix/config . build` —
+  applied in the release commit, not per PR.
+
+## Pull requests
+
+Titled `CATEGORY: Entity - Description`, one category of work per PR, CI green before review.
+The description says what the change does and how you proved it; screenshots or pasted runner
+output are welcome. Link issues with `Closes #N` where one applies.
+
+## Questions
+
+Open a discussion or an issue — a well-described problem is halfway solved. For anything
+security-shaped, use [SECURITY.md](SECURITY.md) instead of a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+An agent framework's perimeter is only as trustworthy as the process behind it. This is that
+process.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a vulnerability.** Report it privately through
+[GitHub Security Advisories](https://github.com/hassanhabib/The-Standard-Agent/security/advisories/new)
+so a fix can ship before the details do.
+
+A useful report names:
+
+- the affected surface — a builder routine, a broker, the perimeter, the conformance harness;
+- the version (`Standard.Agents X.Y.Z`) it reproduces on;
+- what an attacker gains — the framework's own threat categories are a good frame: prompt
+  injection, tool authorization bypass, approval-scope escalation, redaction bypass,
+  cross-tenant exposure, guardian bypass;
+- a reproduction, ideally in the shape of a failing test or conformance vector, which is how
+  every defect in this repository is demonstrated.
+
+You will get an acknowledgment within **7 days** and a verdict — confirmed with a fix plan, or
+declined with the reasoning — within **30 days**. Credit is yours unless you ask otherwise.
+
+## What is in scope
+
+- The `Standard.Agents` package: the builder surface, the loop, the perimeter
+  (authorize → record → approve → run-once → record), guardians, redaction, budgets,
+  sessions, and the effect ledger.
+- The conformance harness and its vectors, where a hole lets a non-conforming
+  implementation certify.
+- The release pipeline in `.github/workflows/`.
+
+Out of scope: brokers **you** supply (your storage, your model endpoint, your approval
+authority), prompt-level jailbreaks of the model behind the Brain (report those to the model's
+provider), and the demo project.
+
+## Supported versions
+
+The latest release line receives security fixes. A fix advances the version per Standard
+Versioning (`model.service/routine.fix/config.build`) and ships with the release notes naming
+the advisory once it is public.
+
+## What every release already ships
+
+Per [docs/support.md](docs/support.md): a CycloneDX SBOM, signed build provenance, symbols with
+embedded sources, a transitive vulnerability audit and secret scan on every change, and a
+zero-warning build on the SDK pinned in `global.json`. The package is not Authenticode-signed;
+provenance attestation answers "did this come from that source, unmodified."


### PR DESCRIPTION
### What does this PR do?
Adds the three root governance files GitHub surfaces and enterprise procurement audits for. `SECURITY.md` routes vulnerability reports through private GitHub Security Advisories with named response windows (7-day acknowledgment, 30-day verdict), scopes what counts (the package, the conformance harness, the release pipeline — not user-supplied brokers or model jailbreaks), and points at the supply-chain guarantees `docs/support.md` already documents. `CONTRIBUTING.md` is the short form of the-standard-skills practices: forking workflow, `users/[username]/[CATEGORY]-[entity]-[action]` branches, `[FAIL]`/`[PASS]` commit discipline, and the bar the build enforces (zero warnings, four profiles, tier rules, capability triad, vectors proven able to fail). `CODE_OF_CONDUCT.md` holds the community to the people-first condition the TSSL license already places on the software, with private enforcement routing.

### Category
- [x] DOCUMENTATION

### Size
- [x] N/A (documentation — no tests changed)

### Branch name follows Standard convention
- [x] `users/hassanhabib/DOCUMENTATION-governance-create`

### TDD compliance
- [x] N/A — documentation only

### No sensitive data
- [x] No secrets, API keys, or connection strings in the diff

### Quality gates
- [x] CI build runs on this PR