### PR TITLE
INFRA: Supply Chain - Dependabot And CodeQL Watch Between Builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# The per-build vulnerability audit in dotnet.yml catches a known-bad dependency when a
+# build happens to run; this watches between builds and opens the upgrade PR itself. Every
+# Dependabot PR still walks through the same gates as any other change - zero warnings,
+# the full suite, certification.
+version: 2
+
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:23"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:41"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+# Static analysis for the classes of defect a test suite structurally cannot catch -
+# injection sinks, path traversal, insecure deserialization. Runs on every change to main
+# and weekly between changes, because a query pack update can find yesterday's code guilty.
+name: Standard.Agents CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '17 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Pulling Code
+      uses: actions/checkout@v4
+
+    # Same rule as dotnet.yml: global.json pins the SDK, so analysis compiles with the
+    # same compiler as the build it analyzes.
+    - name: Installing .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Initializing CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: csharp
+        build-mode: manual
+
+    - name: Restoring Packages
+      run: dotnet restore
+
+    - name: Building Solution
+      run: dotnet build --no-restore --configuration Release
+
+    - name: Analyzing
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:csharp"


### PR DESCRIPTION
### What does this PR do?
The per-build vulnerability audit in `dotnet.yml` catches a known-bad dependency only when a build happens to run. This adds the between-builds half: Dependabot watches nuget and the workflow actions weekly and opens upgrade PRs itself (each walking through the same zero-warning/full-suite/certification gates as any change), and CodeQL analyzes C# on every change to main plus a weekly re-analysis — covering the defect classes a test suite structurally cannot catch. CodeQL uses manual build mode with the SDK pinned by `global.json`, the same rule `dotnet.yml` follows.

### Category
- [x] INFRA

### Size
- [x] N/A (INFRA — no tests changed)

### Branch name follows Standard convention
- [x] `users/hassanhabib/INFRA-supply-chain-scanning-setup`

### TDD compliance
- [x] N/A — CI configuration only

### No sensitive data
- [x] No secrets in the diff; workflows use no secrets at all

### Quality gates
- [x] CI build runs on this PR; the CodeQL workflow itself runs on this PR as proof