### PR TITLE
CONFIG: Package - Targets The net8.0 LTS Enterprises Actually Run

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,12 +14,15 @@ jobs:
     - name: Pulling Code
       uses: actions/checkout@v4
 
-    # No dotnet-version here on purpose: global.json pins the SDK, so CI and a developer's
-    # machine compile with the same one. A version named in two places drifts in one of them.
+    # global.json pins the SDK, so CI and a developer's machine compile with the same one.
+    # A version named in two places drifts in one of them. The 8.0 line below is a runtime,
+    # not a second compiler: the package multi-targets net8.0, and the unit suite runs on
+    # both targets, so the runner needs somewhere to run the net8.0 half.
     - name: Installing .NET
       uses: actions/setup-dotnet@v4
       with:
         global-json-file: global.json
+        dotnet-version: 8.0.x
 
     - name: Restoring Packages
       run: dotnet restore

--- a/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
+++ b/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
@@ -1,7 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <!-- Both of the package's targets, so the net8.0 asset is proven by the same suite
+         rather than assumed from a green net10.0 run. -->
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Standard.Agents/Brokers/Audits/FileAuditBroker.cs
+++ b/Standard.Agents/Brokers/Audits/FileAuditBroker.cs
@@ -125,6 +125,13 @@ public sealed class FileAuditBroker : IAuditBroker
         this.previousHash = lastLine is null ? null : Hash(lastLine);
     }
 
+    // Convert.ToHexStringLower is .NET 9+. Both forms emit identical lowercase hex, which is
+    // load-bearing: the chain a net8.0 process wrote must verify on a net10.0 one.
+#if NET9_0_OR_GREATER
     private static string Hash(string line) =>
         Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(line)));
+#else
+    private static string Hash(string line) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(line))).ToLowerInvariant();
+#endif
 }

--- a/Standard.Agents/Brokers/Resiliences/FallbackResilienceBroker.cs
+++ b/Standard.Agents/Brokers/Resiliences/FallbackResilienceBroker.cs
@@ -3,6 +3,12 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+#if !NET9_0_OR_GREATER
+// System.Threading.Lock arrived in .NET 9. On the net8.0 target a plain object under the
+// same lock statements is the identical semantic; the alias keeps one body for both.
+using Lock = System.Object;
+#endif
+
 namespace Standard.Agents.Brokers.Resiliences;
 
 // Degradation before failure (SPEC.md §4.10). After enough consecutive failures the primary is

--- a/Standard.Agents/Brokers/Sessions/FileSessionBroker.cs
+++ b/Standard.Agents/Brokers/Sessions/FileSessionBroker.cs
@@ -75,9 +75,17 @@ public sealed class FileSessionBroker : ISessionBroker
     // trying to sanitize a name that could escape the folder.
     private string FileFor(string sessionId)
     {
+        // Convert.ToHexStringLower is .NET 9+. Both forms emit identical lowercase hex, which
+        // is load-bearing: a session written on one target must be found on the other.
+#if NET9_0_OR_GREATER
         string safeName = Convert.ToHexStringLower(
             System.Security.Cryptography.SHA256.HashData(
                 System.Text.Encoding.UTF8.GetBytes(sessionId)))[..32];
+#else
+        string safeName = Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(sessionId))).ToLowerInvariant()[..32];
+#endif
 
         return Path.Combine(this.sessionsPath, $"{safeName}.json");
     }

--- a/Standard.Agents/Models/Orchestrations/Effects/AgentEffect.cs
+++ b/Standard.Agents/Models/Orchestrations/Effects/AgentEffect.cs
@@ -97,7 +97,14 @@ public sealed record AgentEffect
             toolName.Trim().ToLowerInvariant(),
             canonicalArguments);
 
+        // Convert.ToHexStringLower is .NET 9+. Both forms emit identical lowercase hex, which
+        // is load-bearing: a key derived on one target must match the same key on the other.
+#if NET9_0_OR_GREATER
         return Convert.ToHexStringLower(
             SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+#else
+        return Convert.ToHexString(
+            SHA256.HashData(Encoding.UTF8.GetBytes(canonical))).ToLowerInvariant();
+#endif
     }
 }

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <!-- net8.0 is the LTS most enterprise estates actually run; net10.0 is current. One
+         compiler (global.json) builds both, and the unit suite runs against both, so the
+         net8.0 asset is proven, not assumed. -->
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -4,6 +4,11 @@
 // ---------------------------------------------------------------
 
 using System.Runtime.CompilerServices;
+#if !NET9_0_OR_GREATER
+// System.Threading.Lock arrived in .NET 9. On the net8.0 target a plain object under the
+// same lock statements is the identical semantic; the alias keeps one body for both.
+using Lock = System.Object;
+#endif
 using Microsoft.Extensions.Logging.Abstractions;
 using Standard.Agents.Brokers.Audits;
 using Standard.Agents.Brokers.Approvals;


### PR DESCRIPTION
### What does this PR do?
`Standard.Agents` multi-targets `net8.0;net10.0` — an estate on the LTS line could not reference the package at all, which is probably the cheapest adoption blocker on the list. One compiler builds both (pinned by `global.json`), and the unit test project now multi-targets too, so **the net8.0 asset is proven by the same 532 tests, not assumed from a green net10.0 run**.

Three .NET 9+ API uses gained net8.0 forms with identical observable output where identity is load-bearing:
- `System.Threading.Lock` → aliased to `object` under the same `lock` statements (`StandardAgent`, `FallbackResilienceBroker`);
- `Convert.ToHexStringLower` → `Convert.ToHexString(...).ToLowerInvariant()` — byte-identical lowercase hex, so an idempotency key, audit hash chain, or session file written on one target matches on the other (`AgentEffect`, `FileAuditBroker`, `FileSessionBroker`).

CI installs the 8.0 runtime (runtime only — the compiler stays the one `global.json` pins) to run the net8.0 half of the suite.

**Proof, run locally:** solution builds with 0 warnings; unit suite `Passed! 532` on **net8.0** and `Passed! 532` on **net10.0**; Critical profile CERTIFIED; `dotnet pack` produces `lib/net8.0/` and `lib/net10.0/` in the nupkg.

### Category
- [x] CONFIG

### Size
- [x] N/A (CONFIG — no tests added; the whole suite now runs twice)

### Branch name follows Standard convention
- [x] `users/hassanhabib/CONFIG-package-net8-multitarget`

### TDD compliance
- [x] N/A — configuration change proven by the existing suite on both targets

### No sensitive data
- [x] No secrets, API keys, or connection strings in the diff

### Quality gates
- [x] 0 warnings, both targets
- [x] 532/532 tests on net8.0 and on net10.0
- [x] Critical profile certifies