### PR TITLE
EXPOSERS: Host - The Same Agent Definition As A Service

### DIFF
--- a/Standard.Agents.Host/Controllers/AgentsController.cs
+++ b/Standard.Agents.Host/Controllers/AgentsController.cs
@@ -23,6 +23,11 @@ public class AgentsController : ControllerBase
     [HttpPost("runs")]
     public async ValueTask<ActionResult<AgentRunResponse>> PostRunAsync(AgentRunRequest request)
     {
+        if (string.IsNullOrWhiteSpace(request.Prompt))
+        {
+            return BadRequest("prompt is required");
+        }
+
         // The caller closing the connection cancels the run at its next turn boundary - and,
         // through the nesting seam, any sub-agents the run started.
         AgentOutcome outcome =

--- a/Standard.Agents.Host/Controllers/AgentsController.cs
+++ b/Standard.Agents.Host/Controllers/AgentsController.cs
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Standard.Agents.Host.Models;
+
+namespace Standard.Agents.Host.Controllers;
+
+// The agent, exposed. Pure duplex mapping over ONE service dependency (IAgent) - no business
+// logic lives here, because an exposer is disposable and the loop is not.
+[ApiController]
+[Route("api/[controller]")]
+public class AgentsController : ControllerBase
+{
+    private readonly IAgent agent;
+
+    public AgentsController(IAgent agent) =>
+        this.agent = agent;
+
+    [HttpPost("runs")]
+    public async ValueTask<ActionResult<AgentRunResponse>> PostRunAsync(AgentRunRequest request)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Standard.Agents.Host/Controllers/AgentsController.cs
+++ b/Standard.Agents.Host/Controllers/AgentsController.cs
@@ -38,9 +38,28 @@ public class AgentsController : ControllerBase
             Status: outcome.Status.ToString()));
     }
 
+    // The streamed door, as server-sent events: the kind as the event name so a consumer can
+    // switch on it, the content as data. Filtering the stream to Response events equals what
+    // the batched door returns - the parity the loop guarantees, carried out to the protocol.
     [HttpPost("streams")]
     public async ValueTask PostStreamAsync(AgentRunRequest request)
     {
-        throw new NotImplementedException();
+        if (string.IsNullOrWhiteSpace(request.Prompt))
+        {
+            Response.StatusCode = StatusCodes.Status400BadRequest;
+
+            return;
+        }
+
+        Response.ContentType = "text/event-stream";
+
+        await foreach (AgentStreamEvent streamEvent in
+            this.agent.StreamPromptAsync(request.Prompt, HttpContext.RequestAborted))
+        {
+            string message = $"event: {streamEvent.Type}\ndata: {streamEvent.Content}\n\n";
+
+            await Response.WriteAsync(message, HttpContext.RequestAborted);
+            await Response.Body.FlushAsync(HttpContext.RequestAborted);
+        }
     }
 }

--- a/Standard.Agents.Host/Controllers/AgentsController.cs
+++ b/Standard.Agents.Host/Controllers/AgentsController.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.AspNetCore.Mvc;
 using Standard.Agents.Host.Models;
+using Standard.Agents.Models.Clients.Agents;
 
 namespace Standard.Agents.Host.Controllers;
 
@@ -22,6 +23,13 @@ public class AgentsController : ControllerBase
     [HttpPost("runs")]
     public async ValueTask<ActionResult<AgentRunResponse>> PostRunAsync(AgentRunRequest request)
     {
-        throw new NotImplementedException();
+        // The caller closing the connection cancels the run at its next turn boundary - and,
+        // through the nesting seam, any sub-agents the run started.
+        AgentOutcome outcome =
+            await this.agent.RunAsync(request.Prompt, HttpContext.RequestAborted);
+
+        return Ok(new AgentRunResponse(
+            Result: outcome.Result,
+            Status: outcome.Status.ToString()));
     }
 }

--- a/Standard.Agents.Host/Controllers/AgentsController.cs
+++ b/Standard.Agents.Host/Controllers/AgentsController.cs
@@ -37,4 +37,10 @@ public class AgentsController : ControllerBase
             Result: outcome.Result,
             Status: outcome.Status.ToString()));
     }
+
+    [HttpPost("streams")]
+    public async ValueTask PostStreamAsync(AgentRunRequest request)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/Standard.Agents.Host/Controllers/HomeController.cs
+++ b/Standard.Agents.Host/Controllers/HomeController.cs
@@ -15,5 +15,5 @@ public class HomeController : ControllerBase
 {
     [HttpGet]
     public ActionResult<string> Get() =>
-        throw new NotImplementedException();
+        Ok("The Standard Agent is alive.");
 }

--- a/Standard.Agents.Host/Controllers/HomeController.cs
+++ b/Standard.Agents.Host/Controllers/HomeController.cs
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Standard.Agents.Host.Controllers;
+
+// The heartbeat: no security, no dependencies, aliveness and nothing else - the endpoint a
+// load balancer or a first-day deployment checks before anything harder.
+[ApiController]
+[Route("api/[controller]")]
+public class HomeController : ControllerBase
+{
+    [HttpGet]
+    public ActionResult<string> Get() =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents.Host/Models/AgentRunRequest.cs
+++ b/Standard.Agents.Host/Models/AgentRunRequest.cs
@@ -1,0 +1,9 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Host.Models;
+
+/// <summary>What to run: the prompt, and nothing else the protocol needs yet.</summary>
+public sealed record AgentRunRequest(string Prompt);

--- a/Standard.Agents.Host/Models/AgentRunResponse.cs
+++ b/Standard.Agents.Host/Models/AgentRunResponse.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Host.Models;
+
+/// <summary>
+/// How the run ended, in protocol form. Status travels beside the result because only
+/// <c>Responded</c> makes the result an answer — a consumer that cannot tell a held run
+/// from an answered one will eventually report unfinished work as done.
+/// </summary>
+public sealed record AgentRunResponse(string Result, string Status);

--- a/Standard.Agents.Host/Program.cs
+++ b/Standard.Agents.Host/Program.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+// The same agent definition as a service. Five lines on a laptop, the same five lines
+// behind HTTP: composition here is configuration, never new concepts - the appliance
+// guarantee holds at the exposure layer too.
+
+using Standard.Agents;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+// One agent, one singleton - one instance serving prompts concurrently is the intended
+// shape (docs/support.md), and run state is per invocation by SPEC.md 4.4. Zero config
+// must still run: without a Brain the host stands, heartbeats, and answers with what to
+// configure rather than crashing at startup.
+builder.Services.AddSingleton<IAgent>(provider =>
+{
+    IConfiguration configuration = provider.GetRequiredService<IConfiguration>();
+    string? url = configuration["Agent:Url"];
+
+    StandardAgent agent = string.IsNullOrWhiteSpace(url)
+        ? new StandardAgent().OnBrain(async (_, _) =>
+            "FINAL: No Brain is configured. Set Agent:Url, Agent:ApiKey and Agent:Model, "
+                + "then restart the host.")
+        : new StandardAgent(
+            url,
+            configuration["Agent:ApiKey"] ?? string.Empty,
+            configuration["Agent:Model"] ?? string.Empty);
+
+    string? skillsPath = configuration["Agent:Skills"];
+
+    if (string.IsNullOrWhiteSpace(skillsPath) is false)
+    {
+        agent.Skills(skillsPath);
+    }
+
+    return agent;
+});
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();

--- a/Standard.Agents.Host/Standard.Agents.Host.csproj
+++ b/Standard.Agents.Host/Standard.Agents.Host.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <!-- Same two targets as the package, for the same reason: the estates that need a host
+         most are the ones on the LTS line. -->
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Standard.Agents\Standard.Agents.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Standard.Agents.Tests.Unit/Controllers/AgentsControllerTests.Streams.cs
+++ b/Standard.Agents.Tests.Unit/Controllers/AgentsControllerTests.Streams.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Standard.Agents.Host.Controllers;
+using Standard.Agents.Host.Models;
+using Standard.Agents.Models.Clients.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Controllers;
+
+public partial class AgentsControllerTests
+{
+    private static async IAsyncEnumerable<AgentStreamEvent> TwoEvents()
+    {
+        await Task.CompletedTask;
+
+        yield return new AgentStreamEvent(AgentStreamEventType.Thinking, "considering");
+        yield return new AgentStreamEvent(AgentStreamEventType.Response, "the answer");
+    }
+
+    [Fact]
+    public async Task ShouldPostStreamAsServerSentEventsAsync()
+    {
+        // given — a response body that can be read back
+        using var responseBody = new MemoryStream();
+
+        var streamingController = new AgentsController(this.agentMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    Response = { Body = responseBody }
+                }
+            }
+        };
+
+        this.agentMock.Setup(agent =>
+            agent.StreamPromptAsync("what is owed", It.IsAny<CancellationToken>()))
+                .Returns(TwoEvents());
+
+        // when
+        await streamingController.PostStreamAsync(new AgentRunRequest(Prompt: "what is owed"));
+
+        // then — each event arrives as SSE: its kind as the event name, its content as data
+        streamingController.Response.ContentType.Should().Be("text/event-stream");
+
+        string streamed = System.Text.Encoding.UTF8.GetString(responseBody.ToArray());
+
+        streamed.Should().Contain("event: Thinking");
+        streamed.Should().Contain("data: considering");
+        streamed.Should().Contain("event: Response");
+        streamed.Should().Contain("data: the answer");
+    }
+}

--- a/Standard.Agents.Tests.Unit/Controllers/AgentsControllerTests.cs
+++ b/Standard.Agents.Tests.Unit/Controllers/AgentsControllerTests.cs
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Standard.Agents.Host.Controllers;
+using Standard.Agents.Host.Models;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Controllers;
+
+// An exposer is pure mapping over one service dependency, so its tests are mapping tests:
+// success in, protocol out; invalid in, 400 out; nothing else in between.
+public partial class AgentsControllerTests
+{
+    private readonly Mock<IAgent> agentMock;
+    private readonly AgentsController agentsController;
+
+    public AgentsControllerTests()
+    {
+        this.agentMock = new Mock<IAgent>();
+
+        this.agentsController = new AgentsController(this.agentMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    [Fact]
+    public async Task ShouldPostRunAsync()
+    {
+        // given
+        var request = new AgentRunRequest(Prompt: "what is owed");
+
+        this.agentMock.Setup(agent =>
+            agent.RunAsync("what is owed", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new AgentOutcome("the answer", AgentStatus.Responded));
+
+        // when
+        ActionResult<AgentRunResponse> actualResult =
+            await this.agentsController.PostRunAsync(request);
+
+        // then
+        OkObjectResult okResult = actualResult.Result.Should().BeOfType<OkObjectResult>().Subject;
+
+        okResult.Value.Should().BeEquivalentTo(
+            new AgentRunResponse(Result: "the answer", Status: "Responded"));
+    }
+}

--- a/Standard.Agents.Tests.Unit/Controllers/AgentsControllerTests.cs
+++ b/Standard.Agents.Tests.Unit/Controllers/AgentsControllerTests.cs
@@ -55,4 +55,24 @@ public partial class AgentsControllerTests
         okResult.Value.Should().BeEquivalentTo(
             new AgentRunResponse(Result: "the answer", Status: "Responded"));
     }
+
+    [Fact]
+    public async Task ShouldReturnBadRequestOnPostRunIfPromptIsEmptyAsync()
+    {
+        // given
+        var request = new AgentRunRequest(Prompt: "   ");
+
+        // when
+        ActionResult<AgentRunResponse> actualResult =
+            await this.agentsController.PostRunAsync(request);
+
+        // then — a prompt of nothing is the caller's mistake, told as 400 before any run starts
+        actualResult.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        this.agentMock.Verify(agent =>
+            agent.RunAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+
+        this.agentMock.VerifyNoOtherCalls();
+    }
 }

--- a/Standard.Agents.Tests.Unit/Controllers/HomeControllerTests.cs
+++ b/Standard.Agents.Tests.Unit/Controllers/HomeControllerTests.cs
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Standard.Agents.Host.Controllers;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Controllers;
+
+public class HomeControllerTests
+{
+    [Fact]
+    public void ShouldGetAlive()
+    {
+        // given
+        var homeController = new HomeController();
+
+        // when
+        ActionResult<string> actualResult = homeController.Get();
+
+        // then — aliveness and nothing else: no security, no dependencies, no claims
+        OkObjectResult okResult = actualResult.Result.Should().BeOfType<OkObjectResult>().Subject;
+
+        okResult.Value.Should().Be("The Standard Agent is alive.");
+    }
+}

--- a/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
+++ b/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Standard.Agents\Standard.Agents.csproj" />
+    <ProjectReference Include="..\Standard.Agents.Host\Standard.Agents.Host.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Standard.Agents.slnx
+++ b/Standard.Agents.slnx
@@ -3,5 +3,6 @@
   <Project Path="Standard.Agents.Conformance/Standard.Agents.Conformance.csproj" />
   <Project Path="Standard.Agents.Demo/Standard.Agents.Demo.csproj" />
   <Project Path="Standard.Agents.Evals/Standard.Agents.Evals.csproj" />
+  <Project Path="Standard.Agents.Host/Standard.Agents.Host.csproj" />
   <Project Path="Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj" />
 </Solution>

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,0 +1,45 @@
+# Hosting
+
+The same agent definition as a service. `Standard.Agents.Host` is the exposure layer as The
+Standard defines one — controllers that are pure mapping over one dependency (`IAgent`), a
+heartbeat, and composition that is configuration rather than code. Nothing was added to the
+builder to make this possible: the appliance stays five lines, and the host is a consumer of
+them like any other.
+
+```bash
+dotnet run --project Standard.Agents.Host
+```
+
+## Endpoints
+
+| Endpoint | What it does |
+|---|---|
+| `GET api/home` | Aliveness, nothing else — no security, no dependencies. What a load balancer checks. |
+| `POST api/agents/runs` | `{ "prompt": "..." }` → `{ "result": "...", "status": "Responded" }`. Status travels beside result because only `Responded` makes the result an answer. An empty prompt is `400` before any run starts. |
+| `POST api/agents/streams` | The same run as server-sent events — each event's kind as the SSE event name, its content as data. Filtering to `Response` events equals what `runs` returns. |
+
+Closing the connection cancels the run at its next turn boundary — and, through the nesting
+seam, any sub-agents the run started.
+
+## Configuration
+
+```json
+{
+  "Agent": {
+    "Url": "http://localhost:11434/v1/chat/completions",
+    "ApiKey": "",
+    "Model": "LLooMA2.0",
+    "Skills": "Skills"
+  }
+}
+```
+
+Zero config still runs: without a Brain the host stands, heartbeats, and answers every run
+with what to configure — a first deployment fails loudly at the first prompt, never silently
+at startup.
+
+The agent is registered as a **singleton**, which is the intended shape
+([support.md](support.md)): one instance serves prompts concurrently, and run state is per
+invocation by SPEC.md §4.4. Enterprise controls — perimeter, budgets, sessions, redaction,
+approval — are composition like everything else; add the builder calls where the singleton is
+built.


### PR DESCRIPTION
### What does this PR do?
The Hosting half of Evals & Hosting. `Standard.Agents.Host` is the exposure layer as The Standard defines one — controllers that are **pure mapping over one dependency** (`IAgent`), a `HomeController` heartbeat (no security, no dependencies, aliveness only), and composition that is configuration. **Nothing was added to the builder**: the appliance stays five lines and the host consumes them like any caller.

- `GET api/home` — aliveness.
- `POST api/agents/runs` — the outcome in protocol form, status beside result (only `Responded` makes the result an answer); whitespace prompt → 400 before any run starts, agent never consulted.
- `POST api/agents/streams` — the same run as server-sent events; filtering to `Response` equals what `runs` returns — the loop's parity carried to the protocol.
- Closing the connection cancels the run at its next turn boundary and, through the nesting seam (#302), any sub-agents it started.
- Zero config still runs: without a Brain the host stands, heartbeats, and answers with what to configure.

Four FAIL/PASS pairs, each FAIL observed red by the runner. Smoke-verified against the actually-running host: all three endpoints answered as documented. Multi-targets `net8.0;net10.0` like the package. `docs/hosting.md` documents it.

### Category
- [x] EXPOSERS

### Size
- [x] N/A (EXPOSERS — 4 mapping tests added via FAIL/PASS)

### Branch name follows Standard convention
- [x] `users/hassanhabib/EXPOSERS-agent-host-create`

### TDD compliance
- [x] Four FAIL commits verified red by the runner
- [x] Each PASS verified with the full suite green on both targets

### No sensitive data
- [x] No secrets; configuration is placeholders in docs only, no appsettings committed with values

### Quality gates
- [x] 563/563 tests on net8.0 and net10.0
- [x] 0 warnings
- [x] Live smoke test of all three endpoints