### PR TITLE
MEDIUM INFRA: Dependencies - The Watched Supply Chain's First Harvest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+    ignore:
+      # FluentAssertions moved to a commercial license from v8; 7.x is the last
+      # freely-licensed line and this repository stays on it deliberately.
+      - dependency-name: FluentAssertions
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,17 +21,17 @@ jobs:
 
     steps:
     - name: Pulling Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Same rule as dotnet.yml: global.json pins the SDK, so analysis compiles with the
     # same compiler as the build it analyzes.
     - name: Installing .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
 
     - name: Initializing CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: csharp
         build-mode: manual
@@ -43,6 +43,6 @@ jobs:
       run: dotnet build --no-restore --configuration Release
 
     - name: Analyzing
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:csharp"

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Pulling Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Creating The Tag And The Release
       env:

--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -14,7 +14,7 @@ jobs:
   sweep:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,14 +12,14 @@ jobs:
 
     steps:
     - name: Pulling Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # global.json pins the SDK, so CI and a developer's machine compile with the same one.
     # A version named in two places drifts in one of them. The 8.0 line below is a runtime,
     # not a second compiler: the package multi-targets net8.0, and the unit suite runs on
     # both targets, so the runner needs somewhere to run the net8.0 half.
     - name: Installing .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
         dotnet-version: 8.0.x
@@ -62,12 +62,12 @@ jobs:
     # clone has no parent to diff against — it fails to scan rather than finding nothing, which
     # is the failure mode a security check must never have.
     - name: Pulling Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
     - name: Installing .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
 
@@ -90,6 +90,6 @@ jobs:
     # Secrets that reach a public repository are already leaked; the value of this check is
     # catching the commit that would have done it.
     - name: Scanning For Secrets
-      uses: gitleaks/gitleaks-action@v2
+      uses: gitleaks/gitleaks-action@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
     - name: Pulling Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # The SDK comes from global.json, so the package is built with the same compiler a
     # developer used. Reproducibility starts with agreeing on the toolchain.
     - name: Installing .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
 
@@ -66,7 +66,7 @@ jobs:
     # these bytes. It is not a code-signing certificate — see docs/support.md — but it is the
     # part a consumer can check without trusting us.
     - name: Attesting Build Provenance
-      uses: actions/attest-build-provenance@v1
+      uses: actions/attest-build-provenance@v4
       with:
         subject-path: ${{ github.workspace }}/artifacts/*.nupkg
 

--- a/Standard.Agents.Demo/Standard.Agents.Demo.csproj
+++ b/Standard.Agents.Demo/Standard.Agents.Demo.csproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageReference Include="NCalc" Version="6.4.0" />
   </ItemGroup>
 

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -447,7 +447,7 @@
          while still declared, fails the zero-warning build. Segment 1 and 2 changes become
          visible in the diff of this file instead of resting on discipline. Analyzer only -
          nothing ships to consumers. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
### What does this PR do?
Every upgrade Dependabot proposed (#290–#299), taken in one verified pass instead of nine serial merges: `actions/checkout` v7, `actions/setup-dotnet` v6, `github/codeql-action` v4, `gitleaks/gitleaks-action` v3, `actions/attest-build-provenance` v4, `Microsoft.CodeAnalysis.PublicApiAnalyzers` 5.6.0, and the three `Microsoft.Extensions.Configuration.*` packages to 10.0.11. Dependabot closes its own PRs once main carries the versions.

**FluentAssertions 8 is declined** (#295, closed with reasoning): it moved to a commercial license from v8 — 7.x is the last freely-licensed line, and `dependabot.yml` now ignores its majors so the proposal does not return weekly.

Verified locally under the bumps: 0 warnings, 563/563 tests on both targets, Critical certified, 6/6 eval cases. The workflow-action bumps are proven by this PR's own CI runs (build, supply-chain with gitleaks v3, CodeQL v4).

### Category
- [x] MEDIUM INFRA

### Size
- [x] N/A (INFRA — no tests changed)

### Branch name follows Standard convention
- [x] `users/hassanhabib/MEDIUM-INFRA-dependencies-update`

### TDD compliance
- [x] N/A — dependency bumps proven by the existing gates

### No sensitive data
- [x] No secrets in the diff

### Quality gates
- [x] 0 warnings; 563×2 tests; Critical certified; 6/6 evals under the new analyzer and packages
- [x] This PR's CI exercises the bumped actions themselves