### PR TITLE
DOCUMENTATION: README And How-To - Accuracy Corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,7 @@ before any code is written. Build to it.
 
 ```
 Standard.Agents/                  the library
-  |-- Brokers/{Data,Decision,Direction,Loggings}
-  |-- Brokers/{Audits,Policies,Approvals,Effects,Sessions,Resiliences,Redactions}
+  |-- Brokers/{Skills,Generators,Tools,...}   one flat folder per seam — twenty in all
   |-- Models/Foundations/{Entity}/Exceptions
   |-- Models/Orchestrations/Agents          AgentContext, AgentStatus, ToolExchange
   |-- Models/Orchestrations/Effects         AgentEffect, AgentPrincipal, CompensationOutcome

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ var agent = new StandardAgent(url, key, "LLooMA2.0")
 Pick each nature's home independently; the code above doesn't change when you do — that's the whole
 promise of the broker seam.
 
-## The 1·3·9
+## From the 1·3·9 to the 1·3·6·15
 
 ![The Standard for Agents — architecture: StandardAgent → RunManagement → the three nature Coordinations (Data, Decision, Direction) → six Orchestration regions → fifteen Foundation services → their fourteen nature Brokers, with three utility and two decorating brokers beneath](https://raw.githubusercontent.com/hassanhabib/The-Standard-Agent/main/assets/the-standard-agent-architecture.png)
 
@@ -196,8 +196,8 @@ promise of the broker seam.
 [`assets/the-standard-agent-architecture.svg`](https://github.com/hassanhabib/The-Standard-Agent/blob/main/assets/the-standard-agent-architecture.svg)
 — edit the SVG, re-render the PNG.*
 
-**The 1·3·9 is the shape of an agent.** One loop, three natures, and beneath them the foundations —
-the nine that have been there since the beginning:
+**The 1·3·9 is the core shape of an agent.** One loop, three natures, and beneath them the
+foundations — the nine that have been there since the beginning:
 
 | | |
 |---|---|

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -2,8 +2,8 @@
 
 This guide starts with the smallest possible agent and adds one capability at a time — each section
 **building on the agent from the one before**, so the `// ← new this section` line is exactly what
-that step adds. Every snippet is real and runs against `Standard.Agents` (1.0.0+). Copy a section,
-run it, then move to the next.
+that step adds. Every snippet is real and runs against the current `Standard.Agents` release. Copy
+a section, run it, then move to the next.
 
 Sections **0–10** build a working agent and swap the simple file/HTTP defaults for real backends —
 a local GGUF model, Redis, PostgreSQL, SQL Server — one line at a time. Sections **11–15** are what
@@ -52,7 +52,8 @@ agent is already talking.
 
 `Brain(...)` also accepts optional `temperature` (default `0.7`), `maxTokens` (`1024`) and
 `timeoutSeconds` (`120`) when you need to tune sampling or limits; `Gate(...)` and `Judge(...)`
-take the same three (defaulting to `0.0` temperature and `16` tokens, since a verdict is short).
+take the same three, defaulting to `0.0` temperature, `16` tokens and a `30`-second timeout,
+since a verdict is short and quick.
 
 Want the answer as it's generated? Stream it:
 


### PR DESCRIPTION
### What

Corrections from a full claim-by-claim review of README.md and docs/how-to.md against the code:

- **README structure tree**: it showed `Brokers/{Data,Decision,Direction,Loggings}` and a second nature-grouped line — subfolders that do not exist. The Brokers folder is flat, one folder per seam, twenty in all; the tree now says so.
- **docs/how-to.md intro**: it claimed every snippet runs against `Standard.Agents` (1.0.0+), but several documented capabilities shipped later — `.Contract` and `.Permissions`/`.Risk` in 1.5.0, `.Usage` in 1.6, `ResumeAsync` and more. It now says "the current release".
- **docs/how-to.md §0**: the Gate/Judge tuning note read as though they share the Brain's defaults; their `timeoutSeconds` defaults to 30, not the Brain's 120. The note now states all three defaults.
- **README architecture heading**: the section was titled "The 1·3·9" while the diagram directly under it draws the full 1·3·6·15 — the core-then-full teaching stays, but the heading now reads "From the 1·3·9 to the 1·3·6·15", and the opening line says the 1·3·9 is the **core** shape, matching the spec's "Core is 1·3·9, Full is 1·3·6·15".

### Why

These docs are the contract a reader builds against. Everything else in the review checked out — all 63 documented fluent methods exist in `PublicAPI.Shipped.txt` with the signatures shown, every stated default matches the source, the 18-capability matrix matches the enforcing test, and every enum, message string, and quoted behavior is real — so the drifts above were the only fixes needed.

### Evidence

Documentation only, no code changes. Verified against `StandardAgent.cs` defaults, `PublicAPI.Shipped.txt`, `StandardAgentTests.Capabilities.cs`, and the broker/foundation folder layout on disk.

*(The first commit was originally pushed to the PR #313 branch minutes after it merged; this PR carries it onto main properly.)*