### PR TITLE
[BROKERS]: Telemetry - Emit Through An ActivitySource And A Meter

### DIFF
--- a/Standard.Agents/Brokers/Telemetries/ActivityTelemetryBroker.cs
+++ b/Standard.Agents/Brokers/Telemetries/ActivityTelemetryBroker.cs
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Standard.Agents.Brokers.Telemetries;
+
+/// <summary>
+/// The in-box telemetry broker: OpenTelemetry-compatible spans and metrics through the BCL's
+/// <see cref="ActivitySource"/> and <see cref="Meter"/> — no packages, no exporter, no
+/// dependency. A process that wires an OpenTelemetry SDK (or any ActivityListener) against the
+/// <c>Standard.Agents</c> source picks everything up; a process that wires nothing pays nothing,
+/// because an unobserved source hands back <c>null</c> instead of a span. Attribute and metric
+/// names follow the OpenTelemetry GenAI semantic conventions, so a collector that already
+/// understands agents understands this one.
+/// </summary>
+public sealed class ActivityTelemetryBroker : ITelemetryBroker
+{
+    public const string SourceName = "Standard.Agents";
+
+    private static readonly ActivitySource activitySource = new(SourceName);
+    private static readonly Meter meter = new(SourceName);
+
+    private static readonly Histogram<long> tokenUsage =
+        meter.CreateHistogram<long>("gen_ai.client.token.usage", unit: "{token}");
+
+    private static readonly Histogram<double> operationDuration =
+        meter.CreateHistogram<double>("gen_ai.client.operation.duration", unit: "s");
+
+    private readonly string agentName;
+
+    public ActivityTelemetryBroker(string agentName = "standard-agent") =>
+        this.agentName = agentName;
+
+    public IDisposable? StartRun(string sessionId)
+    {
+        Activity? run = activitySource.StartActivity($"invoke_agent {this.agentName}");
+        run?.SetTag("gen_ai.operation.name", "invoke_agent");
+        run?.SetTag("gen_ai.agent.name", this.agentName);
+
+        if (string.IsNullOrEmpty(sessionId) is false)
+        {
+            run?.SetTag("gen_ai.conversation.id", sessionId);
+        }
+
+        return run;
+    }
+
+    public IDisposable? StartTurn(int turn)
+    {
+        Activity? turnActivity = activitySource.StartActivity($"turn {turn}");
+        turnActivity?.SetTag("standard.agents.turn.index", turn);
+
+        return turnActivity;
+    }
+
+    public void RecordTurnUsage(int promptTokens, int completionTokens, bool estimated)
+    {
+        // Only a span this source opened is annotated — the ambient current activity may belong
+        // to the host when nothing is listening here, and another library's span is not ours to
+        // write on.
+        Activity? current = Activity.Current;
+
+        if (current?.Source == activitySource)
+        {
+            current.SetTag("gen_ai.usage.input_tokens", promptTokens);
+            current.SetTag("gen_ai.usage.output_tokens", completionTokens);
+            current.SetTag("standard.agents.usage.estimated", estimated);
+        }
+
+        tokenUsage.Record(
+            promptTokens,
+            new KeyValuePair<string, object?>("gen_ai.token.type", "input"));
+
+        tokenUsage.Record(
+            completionTokens,
+            new KeyValuePair<string, object?>("gen_ai.token.type", "output"));
+    }
+
+    public void RecordRunOutcome(string status, int promptTokens, int completionTokens)
+    {
+        Activity? current = Activity.Current;
+
+        if (current?.Source == activitySource)
+        {
+            current.SetTag("standard.agents.run.status", status);
+            current.SetTag("gen_ai.usage.input_tokens", promptTokens);
+            current.SetTag("gen_ai.usage.output_tokens", completionTokens);
+
+            operationDuration.Record(
+                (DateTime.UtcNow - current.StartTimeUtc).TotalSeconds,
+                new KeyValuePair<string, object?>("gen_ai.operation.name", "invoke_agent"),
+                new KeyValuePair<string, object?>("standard.agents.run.status", status));
+        }
+    }
+}

--- a/Standard.Agents/Brokers/Telemetries/FunctionTelemetryBroker.cs
+++ b/Standard.Agents/Brokers/Telemetries/FunctionTelemetryBroker.cs
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Telemetries;
+
+/// <summary>
+/// The Custom mode of the telemetry seam: every boundary the loop crosses arrives at one
+/// delegate as a named event with its attributes, for a pipeline no ActivityListener reaches —
+/// StatsD, a log shipper, a metrics API of your own.
+/// </summary>
+public sealed class FunctionTelemetryBroker : ITelemetryBroker
+{
+    private readonly Action<string, IReadOnlyDictionary<string, object?>> record;
+
+    public FunctionTelemetryBroker(
+        Action<string, IReadOnlyDictionary<string, object?>> record) =>
+        this.record = record;
+
+    public IDisposable? StartRun(string sessionId)
+    {
+        this.record(
+            "run.start",
+            new Dictionary<string, object?> { ["session.id"] = sessionId });
+
+        return new Scope(() => this.record("run.end", EmptyAttributes));
+    }
+
+    public IDisposable? StartTurn(int turn)
+    {
+        this.record(
+            "turn.start",
+            new Dictionary<string, object?> { ["turn.index"] = turn });
+
+        return new Scope(() => this.record("turn.end", EmptyAttributes));
+    }
+
+    public void RecordTurnUsage(int promptTokens, int completionTokens, bool estimated) =>
+        this.record(
+            "turn.usage",
+            new Dictionary<string, object?>
+            {
+                ["input_tokens"] = promptTokens,
+                ["output_tokens"] = completionTokens,
+                ["estimated"] = estimated
+            });
+
+    public void RecordRunOutcome(string status, int promptTokens, int completionTokens) =>
+        this.record(
+            "run.outcome",
+            new Dictionary<string, object?>
+            {
+                ["status"] = status,
+                ["input_tokens"] = promptTokens,
+                ["output_tokens"] = completionTokens
+            });
+
+    private static readonly IReadOnlyDictionary<string, object?> EmptyAttributes =
+        new Dictionary<string, object?>();
+
+    private sealed class Scope(Action end) : IDisposable
+    {
+        public void Dispose() => end();
+    }
+}

--- a/Standard.Agents/Brokers/Telemetries/ITelemetryBroker.cs
+++ b/Standard.Agents/Brokers/Telemetries/ITelemetryBroker.cs
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Telemetries;
+
+/// <summary>
+/// The telemetry seam — spans and metrics for the run the way <c>ILoggingBroker</c> is prose and
+/// <c>IAuditBroker</c> is records. A utility broker: held by the loop, exempt from the dependency
+/// count, and structurally unable to change what the agent decides or does.
+/// </summary>
+public interface ITelemetryBroker
+{
+    /// <summary>
+    /// Opens the run scope. Dispose it to close the scope; a <c>null</c> return means nothing is
+    /// listening and there is no scope to close.
+    /// </summary>
+    IDisposable? StartRun(string sessionId);
+
+    /// <summary>Opens one turn's scope inside the run scope.</summary>
+    IDisposable? StartTurn(int turn);
+
+    /// <summary>Records what one turn's model calls consumed, and whether it was counted or reported.</summary>
+    void RecordTurnUsage(int promptTokens, int completionTokens, bool estimated);
+
+    /// <summary>Records how the run ended and what it consumed in total.</summary>
+    void RecordRunOutcome(string status, int promptTokens, int completionTokens);
+}

--- a/Standard.Agents/Brokers/Telemetries/NotConfiguredTelemetryBroker.cs
+++ b/Standard.Agents/Brokers/Telemetries/NotConfiguredTelemetryBroker.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Telemetries;
+
+/// <summary>
+/// The default when no telemetry was asked for: every scope is nothing and every record goes
+/// nowhere, so an agent that never called <c>.Telemetry()</c> spends nothing on it.
+/// </summary>
+public sealed class NotConfiguredTelemetryBroker : ITelemetryBroker
+{
+    public IDisposable? StartRun(string sessionId) => null;
+
+    public IDisposable? StartTurn(int turn) => null;
+
+    public void RecordTurnUsage(int promptTokens, int completionTokens, bool estimated)
+    { }
+
+    public void RecordRunOutcome(string status, int promptTokens, int completionTokens)
+    { }
+}

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,1 +1,25 @@
 #nullable enable
+Standard.Agents.Brokers.Telemetries.ActivityTelemetryBroker
+Standard.Agents.Brokers.Telemetries.ActivityTelemetryBroker.ActivityTelemetryBroker(string! agentName = "standard-agent") -> void
+Standard.Agents.Brokers.Telemetries.ActivityTelemetryBroker.RecordRunOutcome(string! status, int promptTokens, int completionTokens) -> void
+Standard.Agents.Brokers.Telemetries.ActivityTelemetryBroker.RecordTurnUsage(int promptTokens, int completionTokens, bool estimated) -> void
+Standard.Agents.Brokers.Telemetries.ActivityTelemetryBroker.StartRun(string! sessionId) -> System.IDisposable?
+Standard.Agents.Brokers.Telemetries.ActivityTelemetryBroker.StartTurn(int turn) -> System.IDisposable?
+Standard.Agents.Brokers.Telemetries.FunctionTelemetryBroker
+Standard.Agents.Brokers.Telemetries.FunctionTelemetryBroker.FunctionTelemetryBroker(System.Action<string!, System.Collections.Generic.IReadOnlyDictionary<string!, object?>!>! record) -> void
+Standard.Agents.Brokers.Telemetries.FunctionTelemetryBroker.RecordRunOutcome(string! status, int promptTokens, int completionTokens) -> void
+Standard.Agents.Brokers.Telemetries.FunctionTelemetryBroker.RecordTurnUsage(int promptTokens, int completionTokens, bool estimated) -> void
+Standard.Agents.Brokers.Telemetries.FunctionTelemetryBroker.StartRun(string! sessionId) -> System.IDisposable?
+Standard.Agents.Brokers.Telemetries.FunctionTelemetryBroker.StartTurn(int turn) -> System.IDisposable?
+Standard.Agents.Brokers.Telemetries.ITelemetryBroker
+Standard.Agents.Brokers.Telemetries.ITelemetryBroker.RecordRunOutcome(string! status, int promptTokens, int completionTokens) -> void
+Standard.Agents.Brokers.Telemetries.ITelemetryBroker.RecordTurnUsage(int promptTokens, int completionTokens, bool estimated) -> void
+Standard.Agents.Brokers.Telemetries.ITelemetryBroker.StartRun(string! sessionId) -> System.IDisposable?
+Standard.Agents.Brokers.Telemetries.ITelemetryBroker.StartTurn(int turn) -> System.IDisposable?
+Standard.Agents.Brokers.Telemetries.NotConfiguredTelemetryBroker
+Standard.Agents.Brokers.Telemetries.NotConfiguredTelemetryBroker.NotConfiguredTelemetryBroker() -> void
+Standard.Agents.Brokers.Telemetries.NotConfiguredTelemetryBroker.RecordRunOutcome(string! status, int promptTokens, int completionTokens) -> void
+Standard.Agents.Brokers.Telemetries.NotConfiguredTelemetryBroker.RecordTurnUsage(int promptTokens, int completionTokens, bool estimated) -> void
+Standard.Agents.Brokers.Telemetries.NotConfiguredTelemetryBroker.StartRun(string! sessionId) -> System.IDisposable?
+Standard.Agents.Brokers.Telemetries.NotConfiguredTelemetryBroker.StartTurn(int turn) -> System.IDisposable?
+const Standard.Agents.Brokers.Telemetries.ActivityTelemetryBroker.SourceName = "Standard.Agents" -> string!


### PR DESCRIPTION
### What

The telemetry seam — a new utility broker beside Logging, Time and Audit, with **zero new dependencies**:

- `ITelemetryBroker` — run scope, turn scope, per-turn usage, run outcome. The seam is domain-shaped (the loop's boundaries), not OTel-shaped, so a host can back it with anything.
- `ActivityTelemetryBroker` — the in-box implementation on the BCL's `ActivitySource` and `Meter` (`System.Diagnostics`, in the box since .NET 5/6): a span per run (`invoke_agent {agent}`), a span per turn, and `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics. Attribute and metric names follow the **OpenTelemetry GenAI semantic conventions** (`gen_ai.operation.name`, `gen_ai.agent.name`, `gen_ai.conversation.id`, `gen_ai.usage.input_tokens`/`output_tokens`), so any collector that understands agents understands this one. An unobserved source hands back `null` instead of a span — a process that wires no listener pays nothing. It only annotates spans it opened itself: the ambient current activity may belong to the host, and another library's span is not ours to write on.
- `FunctionTelemetryBroker` — the Custom mode: every boundary as a named event with attributes, for pipelines no ActivityListener reaches.
- `NotConfiguredTelemetryBroker` — the default when telemetry was never asked for; every scope is nothing.

### Why

The one enterprise gap that was buildable without a dependency: real OTel-compatible spans and metrics from the dependency-free core. This PR is the seam and its implementations only; the loop learns to call it in the next PR (MANAGEMENTS), and the client verbs (`.Telemetry()` / `.UseTelemetry` / `.OnTelemetry`) follow in a third (CLIENTS), each under its own review.

### Evidence

Brokers are thin and hold no logic, so they carry no unit tests, per The Standard. Build is clean at zero warnings on both TFMs (the new symbols are declared in `PublicAPI.Unshipped.txt`), and the full suite still passes: 563/563 on net8.0 and net10.0.