### PR TITLE
[EXPOSERS]: Host - OpenTelemetry Export And An Api Key Front Door

### DIFF
--- a/Standard.Agents.Host/Program.cs
+++ b/Standard.Agents.Host/Program.cs
@@ -7,11 +7,35 @@
 // behind HTTP: composition here is configuration, never new concepts - the appliance
 // guarantee holds at the exposure layer too.
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Standard.Agents;
+using Standard.Agents.Brokers.Telemetries;
+using Standard.Agents.Host.Security;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+
+// Exporting is opt-in by the standard OTel switch: set OTEL_EXPORTER_OTLP_ENDPOINT and the
+// agent's spans and metrics (plus the HTTP server's) leave for your collector; leave it unset
+// and nothing is wired, so the default host stays exactly what it was. The library side needs
+// no flag at all - an unobserved ActivitySource already costs nothing.
+if (string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]) is false)
+{
+    builder.Services.AddOpenTelemetry()
+        .ConfigureResource(resource => resource.AddService(
+            builder.Configuration["Agent:Name"] ?? "standard-agents-host"))
+        .WithTracing(tracing => tracing
+            .AddAspNetCoreInstrumentation()
+            .AddSource(ActivityTelemetryBroker.SourceName)
+            .AddOtlpExporter())
+        .WithMetrics(metrics => metrics
+            .AddAspNetCoreInstrumentation()
+            .AddMeter(ActivityTelemetryBroker.SourceName)
+            .AddOtlpExporter());
+}
 
 // One agent, one singleton - one instance serving prompts concurrently is the intended
 // shape (docs/support.md), and run state is per invocation by SPEC.md 4.4. Zero config
@@ -38,10 +62,35 @@ builder.Services.AddSingleton<IAgent>(provider =>
         agent.Skills(skillsPath);
     }
 
+    // Always on: the spans exist only when something listens, so this line is free on a
+    // laptop and load-bearing behind a collector.
+    agent.Telemetry(configuration["Agent:Name"] ?? "standard-agent");
+
     return agent;
 });
 
 var app = builder.Build();
+
+// The front door, before the routes: no configured Host:ApiKey means open (a laptop), one
+// configuration line means every agent route wants X-Api-Key (a deployment). The heartbeat
+// stays open either way - a probe cannot present a key and learns nothing.
+app.Use(async (context, next) =>
+{
+    bool allowed = ApiKeyGate.Allows(
+        configuredKey: app.Configuration["Host:ApiKey"],
+        presentedKey: context.Request.Headers["X-Api-Key"],
+        path: context.Request.Path);
+
+    if (allowed)
+    {
+        await next();
+
+        return;
+    }
+
+    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+    await context.Response.WriteAsync("missing or invalid X-Api-Key");
+});
 
 app.MapControllers();
 

--- a/Standard.Agents.Host/Security/ApiKeyGate.cs
+++ b/Standard.Agents.Host/Security/ApiKeyGate.cs
@@ -3,6 +3,9 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Security.Cryptography;
+using System.Text;
+
 namespace Standard.Agents.Host.Security;
 
 /// <summary>
@@ -14,5 +17,15 @@ namespace Standard.Agents.Host.Security;
 public static class ApiKeyGate
 {
     public static bool Allows(string? configuredKey, string? presentedKey, string path) =>
-        throw new NotImplementedException();
+        string.IsNullOrEmpty(configuredKey)
+            || path is "/"
+            || KeysMatch(configuredKey, presentedKey);
+
+    // Fixed-time on the bytes, because a comparison that returns at the first wrong character
+    // hands an attacker the key one character at a time.
+    private static bool KeysMatch(string configuredKey, string? presentedKey) =>
+        presentedKey is not null
+            && CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(configuredKey),
+                Encoding.UTF8.GetBytes(presentedKey));
 }

--- a/Standard.Agents.Host/Security/ApiKeyGate.cs
+++ b/Standard.Agents.Host/Security/ApiKeyGate.cs
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Host.Security;
+
+/// <summary>
+/// The host's front door. An agent endpoint carries approval and budget semantics, so the door
+/// is not optional to think about — but it is optional to lock: no configured key means open,
+/// which is what a laptop wants, and one configuration line locks every agent route for what a
+/// deployment wants.
+/// </summary>
+public static class ApiKeyGate
+{
+    public static bool Allows(string? configuredKey, string? presentedKey, string path) =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents.Host/Security/ApiKeyGate.cs
+++ b/Standard.Agents.Host/Security/ApiKeyGate.cs
@@ -18,7 +18,7 @@ public static class ApiKeyGate
 {
     public static bool Allows(string? configuredKey, string? presentedKey, string path) =>
         string.IsNullOrEmpty(configuredKey)
-            || path is "/"
+            || string.Equals(path, "/api/home", StringComparison.OrdinalIgnoreCase)
             || KeysMatch(configuredKey, presentedKey);
 
     // Fixed-time on the bytes, because a comparison that returns at the first wrong character

--- a/Standard.Agents.Host/Standard.Agents.Host.csproj
+++ b/Standard.Agents.Host/Standard.Agents.Host.csproj
@@ -13,4 +13,13 @@
     <ProjectReference Include="..\Standard.Agents\Standard.Agents.csproj" />
   </ItemGroup>
 
+  <!-- The exporter lives here, not in the core: the library emits through the BCL's
+       ActivitySource with zero dependencies, and shipping those spans somewhere is a
+       deployment concern - exactly what a host is for. -->
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+  </ItemGroup>
+
 </Project>

--- a/Standard.Agents.Tests.Unit/Controllers/ApiKeyGateTests.cs
+++ b/Standard.Agents.Tests.Unit/Controllers/ApiKeyGateTests.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Standard.Agents.Host.Security;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Controllers;
+
+public class ApiKeyGateTests
+{
+    [Fact]
+    public void ShouldAllowEverythingWhenNoKeyIsConfigured()
+    {
+        // given . when
+        bool actualDecision = ApiKeyGate.Allows(
+            configuredKey: null,
+            presentedKey: null,
+            path: "/api/agents/runs");
+
+        // then — an unset key is a deliberate open door, not a locked one with no key cut.
+        actualDecision.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldAllowTheAgentRoutesOnlyWithTheConfiguredKey()
+    {
+        // given . when
+        bool matchingDecision = ApiKeyGate.Allows(
+            configuredKey: "psk-live-7",
+            presentedKey: "psk-live-7",
+            path: "/api/agents/runs");
+
+        bool mismatchedDecision = ApiKeyGate.Allows(
+            configuredKey: "psk-live-7",
+            presentedKey: "psk-live-8",
+            path: "/api/agents/runs");
+
+        bool absentDecision = ApiKeyGate.Allows(
+            configuredKey: "psk-live-7",
+            presentedKey: null,
+            path: "/api/agents/streams");
+
+        // then
+        matchingDecision.Should().BeTrue();
+        mismatchedDecision.Should().BeFalse();
+        absentDecision.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldKeepTheHeartbeatOpenForProbes()
+    {
+        // given . when — a load balancer cannot present a key, and the heartbeat tells it
+        // nothing an attacker could use.
+        bool actualDecision = ApiKeyGate.Allows(
+            configuredKey: "psk-live-7",
+            presentedKey: null,
+            path: "/");
+
+        // then
+        actualDecision.Should().BeTrue();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Controllers/ApiKeyGateTests.cs
+++ b/Standard.Agents.Tests.Unit/Controllers/ApiKeyGateTests.cs
@@ -57,7 +57,7 @@ public class ApiKeyGateTests
         bool actualDecision = ApiKeyGate.Allows(
             configuredKey: "psk-live-7",
             presentedKey: null,
-            path: "/");
+            path: "/api/home");
 
         // then
         actualDecision.Should().BeTrue();


### PR DESCRIPTION
### What

The two deployment halves of the telemetry capability, plus the lock a security review asks about first:

- **OTel export**: the Host wires the OpenTelemetry SDK (1.18.0 — 1.12.0 was rejected by our own vulnerability gate for two known advisories) with tracing and metrics against the `Standard.Agents` ActivitySource/Meter plus ASP.NET Core instrumentation, exporting over OTLP. Gated on the standard `OTEL_EXPORTER_OTLP_ENDPOINT` switch: set it and spans leave for your collector; leave it unset and nothing is wired. The exporter lives in the Host, not the core — the library emits with zero dependencies, and shipping spans somewhere is a deployment concern.
- **The hosted agent composes `.Telemetry(Agent:Name)`** — free on a laptop (no listener, no spans), load-bearing behind a collector.
- **`ApiKeyGate`**: no configured `Host:ApiKey` means open (a laptop); one configuration line means every agent route requires `X-Api-Key`, compared fixed-time on the bytes so a mismatch cannot leak the key one character at a time. The `/api/home` heartbeat stays open either way — a probe cannot present a key and learns nothing.

### Why

Feature 2 of the three: the core emits (#315–#317), the Host exports and locks the door. Together they close the "can I see it in my APM / is the door locked" enterprise checkboxes.

### Evidence

TDD on the gate, two FAIL→PASS cycles observed red first — including one the smoke test forced: the first heartbeat exemption guarded `/`, the smoke run answered 404, and the corrected test (`/api/home`) went red before the fix. Smoke-tested end to end with curl: heartbeat 200 without a key, agent route 401 without and with a wrong key, 200 with the right one. Full suite 573/573 on net8.0 and net10.0, zero warnings, dependency audit clean at 1.18.0.