### PR TITLE
[CLIENTS]: StandardAgent - The Whole Agent As A JSON Document

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Standard.Agents.Models.Clients.Agents.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+// The whole configurable surface as data (SPEC.md §4.8's three verbs, reached a fourth way):
+// one JSON key per capability, the same names as the builder verbs, composing the same agent
+// the fluent code composes. Tools and delegates stay code; JSON reaches everything that is data.
+public class StandardAgentFromJsonTests
+{
+    [Fact]
+    public async Task ShouldComposeAnAgentFromJsonAsync()
+    {
+        // given — a rule gate from data, a brain from code: the two compose.
+        bool brainWasCalled = false;
+
+        StandardAgent agent = StandardAgent
+            .FromJson("""{ "ruleGate": ["password"], "maxTurns": 3 }""")
+            .OnBrain(async (systemPrompt, userPrompt) =>
+            {
+                brainWasCalled = true;
+
+                return "FINAL: 42";
+            });
+
+        // when
+        await agent.ProcessPromptAsync("print the admin password");
+
+        // then — the gate the JSON configured refused before the brain ever ran.
+        brainWasCalled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldCapTurnsFromJsonAsync()
+    {
+        // given
+        StandardAgent agent = StandardAgent
+            .FromJson("""{ "maxTurns": 1 }""")
+            .OnBrain(async (systemPrompt, userPrompt) => "ACTION: missing_tool: anything");
+
+        // when
+        string answer = await agent.ProcessPromptAsync("loop forever");
+
+        // then — one turn, then the honest stop the fluent .MaxTurns(1) produces.
+        answer.Should().Contain("ran out of turns");
+    }
+
+    [Fact]
+    public void ShouldRejectAnUnknownConfigurationKey()
+    {
+        // given . when
+        Action composing = () =>
+            StandardAgent.FromJson("""{ "buget": { "maxTokens": 50000 } }""");
+
+        // then — a typo'd key must not produce an unbounded agent that looks configured.
+        composing.Should().Throw<InvalidAgentConfigurationException>()
+            .WithMessage("*buget*");
+    }
+
+    [Fact]
+    public void ShouldRejectMalformedConfigurationJson()
+    {
+        // given . when
+        Action composing = () => StandardAgent.FromJson("{ not json at all");
+
+        // then
+        composing.Should().Throw<InvalidAgentConfigurationException>();
+    }
+
+    // The parity gate: every data-expressible capability, all in one document, must compose.
+    // A capability added to the builder without a JSON binding turns red here the moment its
+    // key is added below — and the key list below is part of the docs' contract.
+    [Fact]
+    public void ShouldComposeEveryDataExpressibleCapabilityFromJson()
+    {
+        // given
+        const string everything = """
+        {
+          "brain": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "LLooMA2.0",
+                     "temperature": 0.2, "maxTokens": 512, "timeoutSeconds": 60 },
+          "nativeBrain": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "m" },
+          "nativeBrainAnthropic": { "apiKey": "k", "model": "claude-sonnet-4-5" },
+          "skills": "Skills",
+          "knowledge": { "path": "Knowledge", "pattern": "*.md", "maxResults": 3, "minScore": 0.1 },
+          "memory": "memory.txt",
+          "mcp": { "endpointUrl": "https://mcp.example/", "timeoutSeconds": 20 },
+          "gate": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "m" },
+          "ruleGate": ["password", "ssn"],
+          "judge": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "m" },
+          "ruleJudge": ["Sources:"],
+          "contract": { "type": "object", "required": ["amount"] },
+          "constitution": "Constitution/ethics.md",
+          "consumption": "Constitution/consuming-skills.md",
+          "redact": { "rules": [ { "label": "TICKET", "pattern": "INC-\\d{6}" } ] },
+          "maxTurns": 5,
+          "allowTools": ["calculator", "write_file:/project/"],
+          "permissions": "Ask",
+          "risk": { "irreversible": ["wire_transfer"], "sensitive": ["write_file"] },
+          "requireApproval": ["wire_transfer"],
+          "logTo": { "path": "log.txt", "verbosity": "Natures" },
+          "audit": "audit.jsonl",
+          "telemetry": "form-built-agent",
+          "sessions": { "path": "sessions", "maxHistoryTurns": 10 },
+          "effectLedger": "ledger",
+          "screenToolOutput": true,
+          "budget": { "maxTokens": 50000, "maxCostUsd": 0.25,
+                      "maxWallClockSeconds": 30, "costPerThousandTokens": 0.002 },
+          "usage": { "charactersPerToken": 3.5 },
+          "resilience": { "retries": 3 },
+          "compensateOnFailure": true
+        }
+        """;
+
+        // when
+        StandardAgent agent = StandardAgent.FromJson(everything);
+
+        // then
+        agent.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ShouldAcceptTheSimpleFormsOfPolymorphicKeys()
+    {
+        // given — the low-code-friendly short forms: a bare string or a bare true where the
+        // long form would be an object.
+        const string shortForms = """
+        {
+          "knowledge": "Knowledge",
+          "mcp": "https://mcp.example/",
+          "redact": true,
+          "telemetry": true,
+          "sessions": "sessions",
+          "logTo": "log.txt",
+          "resilience": 3
+        }
+        """;
+
+        // when
+        StandardAgent agent = StandardAgent.FromJson(shortForms);
+
+        // then
+        agent.Should().NotBeNull();
+    }
+}

--- a/Standard.Agents/Models/Clients/Agents/Exceptions/InvalidAgentConfigurationException.cs
+++ b/Standard.Agents/Models/Clients/Agents/Exceptions/InvalidAgentConfigurationException.cs
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Clients.Agents.Exceptions;
+
+/// <summary>
+/// A configuration document the agent cannot honestly compose from — malformed JSON, a key it
+/// does not know, or a value of the wrong shape. Always loud and always named: a typo'd key
+/// silently ignored is a control the caller believes is on and is not.
+/// </summary>
+public class InvalidAgentConfigurationException : Xeption
+{
+    public InvalidAgentConfigurationException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -26,9 +26,13 @@ Standard.Agents.Brokers.Telemetries.NotConfiguredTelemetryBroker.RecordRunOutcom
 Standard.Agents.Brokers.Telemetries.NotConfiguredTelemetryBroker.RecordTurnUsage(int promptTokens, int completionTokens, bool estimated) -> void
 Standard.Agents.Brokers.Telemetries.NotConfiguredTelemetryBroker.StartRun(string! sessionId) -> System.IDisposable?
 Standard.Agents.Brokers.Telemetries.NotConfiguredTelemetryBroker.StartTurn(int turn) -> System.IDisposable?
+Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentConfigurationException
+Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentConfigurationException.InvalidAgentConfigurationException(string! message) -> void
 Standard.Agents.Services.Managements.RunManagementService.RunManagementService(Standard.Agents.Services.Coordinations.Data.IDataCoordinationService! dataCoordinationService, Standard.Agents.Services.Coordinations.Decision.IDecisionCoordinationService! decisionCoordinationService, Standard.Agents.Services.Coordinations.Direction.IDirectionCoordinationService! directionCoordinationService, Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker, int maxTurns = 7, Standard.Agents.Brokers.Times.ITimeBroker? timeBroker = null, Standard.Agents.Models.Coordinations.Agents.AgentBudget? budget = null, int maxHistoryTurns = 20, bool compensateOnFailure = false, bool screenToolOutput = false, Standard.Agents.Brokers.Telemetries.ITelemetryBroker? telemetryBroker = null) -> void
 Standard.Agents.StandardAgent.NativeBrainAnthropic(string! apiKey, string! model, double temperature = 0.7, int maxTokens = 1024) -> Standard.Agents.StandardAgent!
 Standard.Agents.StandardAgent.OnTelemetry(System.Action<string!, System.Collections.Generic.IReadOnlyDictionary<string!, object?>!>! record) -> Standard.Agents.StandardAgent!
 Standard.Agents.StandardAgent.Telemetry(string! agentName = "standard-agent") -> Standard.Agents.StandardAgent!
 Standard.Agents.StandardAgent.UseTelemetry(Standard.Agents.Brokers.Telemetries.ITelemetryBroker! broker) -> Standard.Agents.StandardAgent!
 const Standard.Agents.Brokers.Telemetries.ActivityTelemetryBroker.SourceName = "Standard.Agents" -> string!
+static Standard.Agents.StandardAgent.FromJson(string! json) -> Standard.Agents.StandardAgent!
+static Standard.Agents.StandardAgent.FromJsonFile(string! path) -> Standard.Agents.StandardAgent!

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents;
+
+public partial class StandardAgent
+{
+    /// <summary>
+    /// Composes an agent from a JSON document — the whole configurable surface as data, one key
+    /// per capability, the same names as the builder verbs. Anything about an agent that is data
+    /// can arrive as data: a low-code form, a database row, a request body some platform stored.
+    /// Tools stay code because they are code — except MCP, where a tool is a URL, which is data.
+    /// An unknown key throws with the key named rather than composing an agent that silently
+    /// lacks a control the caller believes is on.
+    /// </summary>
+    /// <param name="json">The configuration document.</param>
+    /// <returns>The composed agent — keep chaining code (tools, delegates) after it.</returns>
+    public static StandardAgent FromJson(string json) =>
+        throw new NotImplementedException();
+
+    /// <summary>Reads <paramref name="path"/> and composes the agent from its JSON.</summary>
+    /// <param name="path">Path to the configuration document (e.g. <c>agent.json</c>).</param>
+    /// <returns>The composed agent — keep chaining code (tools, delegates) after it.</returns>
+    public static StandardAgent FromJsonFile(string path) =>
+        FromJson(File.ReadAllText(path));
+}

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -3,6 +3,13 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Standard.Agents.Models.Clients.Agents.Exceptions;
+using Standard.Agents.Models.Foundations.Brains;
+using Standard.Agents.Models.Loggings;
+using Standard.Agents.Models.Orchestrations.Effects;
+
 namespace Standard.Agents;
 
 public partial class StandardAgent
@@ -17,12 +24,384 @@ public partial class StandardAgent
     /// </summary>
     /// <param name="json">The configuration document.</param>
     /// <returns>The composed agent — keep chaining code (tools, delegates) after it.</returns>
-    public static StandardAgent FromJson(string json) =>
-        throw new NotImplementedException();
+    public static StandardAgent FromJson(string json)
+    {
+        JsonObject document = ParseDocument(json);
+        var agent = new StandardAgent();
+
+        foreach ((string key, JsonNode? value) in document)
+        {
+            Apply(agent, key, value);
+        }
+
+        return agent;
+    }
 
     /// <summary>Reads <paramref name="path"/> and composes the agent from its JSON.</summary>
     /// <param name="path">Path to the configuration document (e.g. <c>agent.json</c>).</param>
     /// <returns>The composed agent — keep chaining code (tools, delegates) after it.</returns>
     public static StandardAgent FromJsonFile(string path) =>
         FromJson(File.ReadAllText(path));
+
+    private static JsonObject ParseDocument(string json)
+    {
+        JsonNode? parsed;
+
+        try
+        {
+            parsed = JsonNode.Parse(json);
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidAgentConfigurationException(
+                $"The configuration is not valid JSON: {exception.Message}");
+        }
+
+        return parsed as JsonObject
+            ?? throw new InvalidAgentConfigurationException(
+                "The configuration must be a JSON object with one key per capability.");
+    }
+
+    // One case per capability, named exactly as the builder verb it drives — the parity test
+    // feeds a document containing every key, so a verb added without a binding turns red there.
+    private static void Apply(StandardAgent agent, string key, JsonNode? value)
+    {
+        switch (key)
+        {
+            case "brain":
+                agent.Brain(
+                    Text(value, key, "apiUrl"),
+                    Text(value, key, "apiKey", fallback: string.Empty),
+                    Text(value, key, "model"),
+                    Number(value, "temperature", fallback: 0.7),
+                    Whole(value, "maxTokens", fallback: 1024),
+                    Whole(value, "timeoutSeconds", fallback: 120));
+
+                break;
+
+            case "nativeBrain":
+                agent.NativeBrain(
+                    Text(value, key, "apiUrl"),
+                    Text(value, key, "apiKey", fallback: string.Empty),
+                    Text(value, key, "model"),
+                    Number(value, "temperature", fallback: 0.7),
+                    Whole(value, "maxTokens", fallback: 1024));
+
+                break;
+
+            case "nativeBrainAnthropic":
+                agent.NativeBrainAnthropic(
+                    Text(value, key, "apiKey"),
+                    Text(value, key, "model"),
+                    Number(value, "temperature", fallback: 0.7),
+                    Whole(value, "maxTokens", fallback: 1024));
+
+                break;
+
+            case "skills":
+                agent.Skills(Text(value, key));
+
+                break;
+
+            case "knowledge" when value is JsonObject:
+                agent.Knowledge(
+                    Text(value, key, "path"),
+                    Text(value, key, "pattern", fallback: "*.md"),
+                    Whole(value, "maxResults", fallback: 3),
+                    Number(value, "minScore", fallback: 0.0));
+
+                break;
+
+            case "knowledge":
+                agent.Knowledge(Text(value, key));
+
+                break;
+
+            case "memory":
+                agent.Memory(Text(value, key));
+
+                break;
+
+            case "mcp" when value is JsonObject:
+                agent.Mcp(
+                    Text(value, key, "endpointUrl"),
+                    Text(value, key, "relativeUrl", fallback: string.Empty),
+                    Whole(value, "timeoutSeconds", fallback: 30));
+
+                break;
+
+            case "mcp":
+                agent.Mcp(Text(value, key));
+
+                break;
+
+            case "gate":
+                agent.Gate(
+                    Text(value, key, "apiUrl"),
+                    Text(value, key, "apiKey", fallback: string.Empty),
+                    Text(value, key, "model"),
+                    Number(value, "temperature", fallback: 0.0),
+                    Whole(value, "maxTokens", fallback: 16),
+                    Whole(value, "timeoutSeconds", fallback: 30));
+
+                break;
+
+            case "ruleGate":
+                agent.RuleGate(Texts(value, key));
+
+                break;
+
+            case "judge":
+                agent.Judge(
+                    Text(value, key, "apiUrl"),
+                    Text(value, key, "apiKey", fallback: string.Empty),
+                    Text(value, key, "model"),
+                    Number(value, "temperature", fallback: 0.0),
+                    Whole(value, "maxTokens", fallback: 16),
+                    Whole(value, "timeoutSeconds", fallback: 30));
+
+                break;
+
+            case "ruleJudge":
+                agent.RuleJudge(Texts(value, key));
+
+                break;
+
+            // The contract is itself a JSON schema, so it rides embedded rather than as an
+            // escaped string a form author would have to hand-quote.
+            case "contract":
+                agent.Contract(value?.ToJsonString() ?? "{}");
+
+                break;
+
+            case "constitution":
+                agent.Constitution(Text(value, key));
+
+                break;
+
+            case "consumption":
+                agent.Consumption(Text(value, key));
+
+                break;
+
+            case "redact" when value is JsonObject rules:
+                agent.Redact([.. Items(rules["rules"], "redact.rules").Select(rule =>
+                    new RedactionRule
+                    {
+                        Label = Text(rule, "redact.rules", "label"),
+                        Pattern = Text(rule, "redact.rules", "pattern")
+                    })]);
+
+                break;
+
+            case "redact" when Truth(value, key):
+                agent.Redact();
+
+                break;
+
+            case "redact":
+                break;
+
+            case "maxTurns":
+                agent.MaxTurns(Whole(value, key));
+
+                break;
+
+            case "allowTools":
+                agent.AllowTools(Texts(value, key));
+
+                break;
+
+            case "permissions":
+                agent.Permissions(Named<PermissionMode>(value, key));
+
+                break;
+
+            case "risk":
+                foreach ((string levelName, JsonNode? toolNames) in Entries(value, key))
+                {
+                    agent.Risk(NamedText<RiskLevel>(levelName, key), Texts(toolNames, key));
+                }
+
+                break;
+
+            case "requireApproval":
+                agent.RequireApproval(Texts(value, key));
+
+                break;
+
+            case "logTo" when value is JsonObject:
+                agent.LogTo(
+                    Text(value, key, "path"),
+                    NamedText<TraceVerbosity>(
+                        Text(value, key, "verbosity", fallback: "Full"), key));
+
+                break;
+
+            case "logTo":
+                agent.LogTo(Text(value, key));
+
+                break;
+
+            case "audit":
+                agent.Audit(Text(value, key));
+
+                break;
+
+            case "telemetry" when value?.GetValueKind() is JsonValueKind.String:
+                agent.Telemetry(Text(value, key));
+
+                break;
+
+            case "telemetry" when Truth(value, key):
+                agent.Telemetry();
+
+                break;
+
+            case "telemetry":
+                break;
+
+            case "sessions" when value is JsonObject:
+                agent.Sessions(
+                    Text(value, key, "path"),
+                    Whole(value, "maxHistoryTurns", fallback: 20));
+
+                break;
+
+            case "sessions":
+                agent.Sessions(Text(value, key));
+
+                break;
+
+            case "effectLedger":
+                agent.EffectLedger(Text(value, key));
+
+                break;
+
+            case "screenToolOutput" when Truth(value, key):
+                agent.ScreenToolOutput();
+
+                break;
+
+            case "screenToolOutput":
+                break;
+
+            case "budget":
+                agent.Budget(
+                    OptionalWhole(value, "maxTokens"),
+                    OptionalMoney(value, "maxCostUsd"),
+                    OptionalSeconds(value, "maxWallClockSeconds"),
+                    OptionalMoney(value, "costPerThousandTokens") ?? 0m);
+
+                break;
+
+            case "usage":
+                agent.Usage(Number(value, "charactersPerToken", fallback: 4.0));
+
+                break;
+
+            case "resilience" when value is JsonObject:
+                agent.Resilience(Whole(value, "retries", fallback: 3));
+
+                break;
+
+            case "resilience":
+                agent.Resilience(Whole(value, key));
+
+                break;
+
+            case "compensateOnFailure" when Truth(value, key):
+                agent.CompensateOnFailure();
+
+                break;
+
+            case "compensateOnFailure":
+                break;
+
+            default:
+                throw new InvalidAgentConfigurationException(
+                    $"Unknown configuration key '{key}'. A key this agent does not know is a "
+                        + "control you believe is on and is not, so it refuses to compose. "
+                        + "The keys are the builder verbs, camelCased — see docs/how-to.md.");
+        }
+    }
+
+    private static string Text(JsonNode? node, string key) =>
+        node?.GetValueKind() is JsonValueKind.String
+            ? node.GetValue<string>()
+            : throw new InvalidAgentConfigurationException(
+                $"'{key}' must be a string.");
+
+    private static string Text(JsonNode? node, string key, string property, string? fallback = null)
+    {
+        JsonNode? value = (node as JsonObject)?[property];
+
+        if (value is null)
+        {
+            return fallback
+                ?? throw new InvalidAgentConfigurationException(
+                    $"'{key}' needs a '{property}'.");
+        }
+
+        return value.GetValueKind() is JsonValueKind.String
+            ? value.GetValue<string>()
+            : throw new InvalidAgentConfigurationException(
+                $"'{key}.{property}' must be a string.");
+    }
+
+    private static string[] Texts(JsonNode? node, string key) =>
+        [.. Items(node, key).Select(item => Text(item, key))];
+
+    private static IEnumerable<JsonNode?> Items(JsonNode? node, string key) =>
+        node as JsonArray
+            ?? throw new InvalidAgentConfigurationException(
+                $"'{key}' must be an array.");
+
+    private static IEnumerable<KeyValuePair<string, JsonNode?>> Entries(JsonNode? node, string key) =>
+        node as JsonObject
+            ?? throw new InvalidAgentConfigurationException(
+                $"'{key}' must be an object.");
+
+    private static bool Truth(JsonNode? node, string key) =>
+        node?.GetValueKind() switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+
+            _ => throw new InvalidAgentConfigurationException(
+                $"'{key}' must be true or false.")
+        };
+
+    private static double Number(JsonNode? node, string property, double fallback) =>
+        (node as JsonObject)?[property]?.GetValue<double>() ?? fallback;
+
+    private static int Whole(JsonNode? node, string key) =>
+        node?.GetValueKind() is JsonValueKind.Number
+            ? node.GetValue<int>()
+            : throw new InvalidAgentConfigurationException(
+                $"'{key}' must be a number.");
+
+    private static int Whole(JsonNode? node, string property, int fallback) =>
+        (node as JsonObject)?[property]?.GetValue<int>() ?? fallback;
+
+    private static int? OptionalWhole(JsonNode? node, string property) =>
+        (node as JsonObject)?[property]?.GetValue<int>();
+
+    private static decimal? OptionalMoney(JsonNode? node, string property) =>
+        (node as JsonObject)?[property]?.GetValue<decimal>();
+
+    private static TimeSpan? OptionalSeconds(JsonNode? node, string property) =>
+        (node as JsonObject)?[property] is JsonNode value
+            ? TimeSpan.FromSeconds(value.GetValue<double>())
+            : null;
+
+    private static TEnum Named<TEnum>(JsonNode? node, string key) where TEnum : struct =>
+        NamedText<TEnum>(Text(node, key), key);
+
+    private static TEnum NamedText<TEnum>(string name, string key) where TEnum : struct =>
+        Enum.TryParse(name, ignoreCase: true, out TEnum parsed)
+            ? parsed
+            : throw new InvalidAgentConfigurationException(
+                $"'{key}' does not accept '{name}'. It accepts: "
+                    + string.Join(", ", Enum.GetNames(typeof(TEnum))) + ".");
 }


### PR DESCRIPTION
### What

`StandardAgent.FromJson(json)` and `FromJsonFile(path)` — the entire configurable surface as one JSON document, one key per capability, named exactly as the builder verbs, camelCased. Any platform that can push a form into a JSON body can now define an agent: brain (all three native/text doors), skills, knowledge, memory, MCP, gate and judge (model-backed or rule-backed), contract (the schema rides embedded, never escaped), constitution, consumption, redaction, turn caps, allow-lists with scopes, permission mode, risk classification, approval names, trace, audit, telemetry, sessions, effect ledger, screening, budgets, usage, resilience, compensation.

The boundary is principled, not partial: **tools stay code because they are code — except MCP, where a tool is a URL, which is data.** Delegates (`On*`) and broker instances (`Use*`) stay code too; `FromJson(...)` returns the same `StandardAgent`, so data and code compose: `StandardAgent.FromJson(formBody).Tool(new CalculatorTool())`.

Two design decisions carry the framework's honesty rules into config:
- **Unknown keys refuse to compose**, with the key named. A form that typos `"buget"` must not get an unbounded agent that looks configured — the same reason an eval threshold that binds nothing is an error.
- **Wrong-shaped values refuse too**, and enum-valued keys name what they accept (`permissions` lists Open, Ask, Deny).

### Why

No mainstream framework does this today: visual builders serialize their own flow graphs, crewAI takes YAML for prompts while everything hard stays Python, and cloud agent APIs are vendor-locked. Here the hardened surface itself — perimeter, budgets, approvals, redaction — is data, with the same guarantees as the fluent code, under the same build.

### Evidence

TDD — six tests committed FAIL (observed red) then PASS:
- Composition proven behaviorally: a JSON `ruleGate` refuses before a code brain ever runs; a JSON `maxTurns: 1` produces the same honest turns-exhausted stop the fluent call does.
- `ShouldRejectAnUnknownConfigurationKey` and `ShouldRejectMalformedConfigurationJson` — loud, named failures as `InvalidAgentConfigurationException`.
- **The parity gate**: one document carrying every data-expressible capability must compose — a builder verb added without a JSON binding turns this red the moment its key is listed.
- Short forms for low-code ergonomics: `"redact": true`, `"telemetry": true`, `"mcp": "url"`, `"sessions": "path"`, `"resilience": 3`.

Full suite 579/579 on net8.0 and net10.0, zero warnings, 44/44 conformance vectors, symbols declared in `PublicAPI.Unshipped.txt`.