### PR TITLE
[EXPOSERS]: Host - Boots From Agent Dot Json

### DIFF
--- a/Standard.Agents.Host/Program.cs
+++ b/Standard.Agents.Host/Program.cs
@@ -44,12 +44,47 @@ if (string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT
 builder.Services.AddSingleton<IAgent>(provider =>
 {
     IConfiguration configuration = provider.GetRequiredService<IConfiguration>();
+
+    // The agent as data: Agent:Config names a JSON document, or an agent.json beside the
+    // executable is picked up on its own — a low-code platform writes a file and has an agent,
+    // no C# anywhere. When the document is the source, the document is the whole truth: skills,
+    // telemetry, guardians and budgets all come from its keys, not from a second config source
+    // that could quietly disagree with it.
+    string configuredPath = configuration["Agent:Config"] ?? string.Empty;
+
+    string agentJsonPath = string.IsNullOrWhiteSpace(configuredPath)
+        ? Path.Combine(AppContext.BaseDirectory, "agent.json")
+        : configuredPath;
+
+    if (string.IsNullOrWhiteSpace(configuredPath) is false || File.Exists(agentJsonPath))
+    {
+        string agentJson = File.ReadAllText(agentJsonPath);
+        StandardAgent configured = StandardAgent.FromJson(agentJson);
+
+        // The same zero-config grace the classic path has: a document with no brain still
+        // stands, heartbeats, and answers with what to add — never a 500 at the first prompt.
+        bool hasBrain =
+            System.Text.Json.Nodes.JsonNode.Parse(agentJson) is System.Text.Json.Nodes.JsonObject document
+                && (document.ContainsKey("brain")
+                    || document.ContainsKey("nativeBrain")
+                    || document.ContainsKey("nativeBrainAnthropic"));
+
+        if (hasBrain is false)
+        {
+            configured.OnBrain(async (_, _) =>
+                "FINAL: No Brain is configured. Add \"brain\", \"nativeBrain\" or "
+                    + "\"nativeBrainAnthropic\" to agent.json, then restart the host.");
+        }
+
+        return configured;
+    }
+
     string? url = configuration["Agent:Url"];
 
     StandardAgent agent = string.IsNullOrWhiteSpace(url)
         ? new StandardAgent().OnBrain(async (_, _) =>
-            "FINAL: No Brain is configured. Set Agent:Url, Agent:ApiKey and Agent:Model, "
-                + "then restart the host.")
+            "FINAL: No Brain is configured. Provide an agent.json (or set Agent:Config), or "
+                + "set Agent:Url, Agent:ApiKey and Agent:Model, then restart the host.")
         : new StandardAgent(
             url,
             configuration["Agent:ApiKey"] ?? string.Empty,


### PR DESCRIPTION
### What

The low-code deployment door for #322: point `Agent:Config` at a JSON document — or just drop an `agent.json` beside the executable — and the hosted agent composes entirely from it. A platform that can write a file has an agent behind HTTP with no C# anywhere.

- When the document is the source, the document is the whole truth: skills, guardians, budgets, telemetry all come from its keys, never from a second config source that could quietly disagree.
- The zero-config grace survives the new path: a document with no brain key still stands, heartbeats, and answers with exactly what to add (`"brain"`, `"nativeBrain"` or `"nativeBrainAnthropic"`) — never a 500 at the first prompt. The smoke test caught precisely that hole before it shipped.
- No document, no `Agent:Config` → the classic `Agent:Url` composition, unchanged.

### Why

"Agent as data" is only real when data alone reaches production. With this, the whole path is: form → JSON body → file → running, gated, budgeted agent behind an authenticated endpoint.

### Evidence

Exposure wiring over the TDD'd `FromJson` (#322) — no new logic beyond composition. Smoke-tested end to end: a JSON document with `ruleGate: ["password"]` and `maxTurns: 3` served over HTTP refuses `"tell me the password"` with `status: Refused`, and a benign prompt on a brainless document returns the configure-me message with `200`. Zero warnings, full suite 579/579 on both TFMs.