### PR TITLE
[DOCUMENTATION]: Docs - The Agent As Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,34 @@ Nineteen capabilities, the same three verbs each. A capability offered fewer way
 build — it is a test, not a convention, because the erosion is otherwise invisible until there are
 six of them.
 
+### Agent as data — the whole thing as JSON
+
+There is a fourth door, and no mainstream framework has it: the **entire configurable surface as
+one JSON document**, one key per capability, the same names as the builder verbs. Any platform
+that can push a form into a JSON body can define an agent — guardians, budgets, perimeter,
+approvals, redaction, telemetry and all:
+
+```csharp
+var agent = StandardAgent.FromJson(formBody);   // data
+    // .Tool(new CalculatorTool())              // code still chains — tools ARE code
+```
+
+```json
+{
+  "brain": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "LLooMA2.0" },
+  "ruleGate": ["password"], "redact": true, "maxTurns": 5,
+  "requireApproval": ["wire_transfer"], "budget": { "maxCostUsd": 0.25 },
+  "telemetry": "form-built-agent"
+}
+```
+
+A key the agent does not know **refuses to compose, with the key named** — a typo'd `"buget"`
+must never produce an unbounded agent that looks configured. Tools stay code because they are
+code — except MCP, where a tool is a URL, which is data. And the deployment half is one file:
+drop an `agent.json` beside `Standard.Agents.Host` and the hosted agent composes entirely from
+it — no C# anywhere
+([docs/how-to.md §16](https://github.com/hassanhabib/The-Standard-Agent/blob/main/docs/how-to.md)).
+
 ## Streaming, and no DI
 
 Stream the agent thinking and answering — each event is tagged, and the answer arrives live:

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -44,6 +44,28 @@ invocation by SPEC.md §4.4. Enterprise controls — perimeter, budgets, session
 approval — are composition like everything else; add the builder calls where the singleton is
 built.
 
+## The agent as a document
+
+The host also composes its agent from a single JSON document — the whole configurable surface
+as data ([how-to.md §16](how-to.md)). Point `Agent:Config` at the file, or just drop an
+`agent.json` beside the executable:
+
+```json
+{
+  "brain": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "LLooMA2.0" },
+  "skills": "Skills",
+  "ruleGate": ["password"],
+  "budget": { "maxCostUsd": 0.25 },
+  "telemetry": "form-built-agent"
+}
+```
+
+When the document is present it is the whole truth — skills, guardians, budgets and telemetry
+come from its keys, never from a second config source that could quietly disagree. A document
+with no brain key still stands and heartbeats, and answers every run with exactly what to add,
+rather than failing at startup or at the first prompt. No document means the classic
+`Agent:Url` configuration above, unchanged.
+
 ## Locking the door
 
 An agent endpoint carries approval and budget semantics, so the front door is worth a thought.

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -8,7 +8,8 @@ a section, run it, then move to the next.
 Sections **0–10** build a working agent and swap the simple file/HTTP defaults for real backends —
 a local GGUF model, Redis, PostgreSQL, SQL Server — one line at a time. Sections **11–15** are what
 a regulated deployment adds on top: conversation, the perimeter, resilience, compensation and
-native tool calls. Nothing in the second half changes anything in the first.
+native tool calls. Nothing in the second half changes anything in the first. Section **16** is
+the whole surface again, as a single JSON document — the agent as data.
 
 ```bash
 dotnet add package Standard.Agents
@@ -1119,6 +1120,74 @@ is *read*, not what the agent is.
 often does better with the text one.
 
 ---
+
+## 16 · The whole agent as JSON
+
+Everything above composes through code. It also composes through **data**: one JSON document,
+one key per capability, the same names as the builder verbs, camelCased. Any platform that can
+push a form into a JSON body can define an agent — low code, no code, a database row, a config
+service.
+
+```csharp
+var agent = StandardAgent.FromJson(json);        // or StandardAgent.FromJsonFile("agent.json")
+```
+
+```json
+{
+  "brain": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "LLooMA2.0" },
+  "skills": "Skills",
+  "knowledge": "Knowledge",
+  "memory": "memory.txt",
+  "mcp": "https://my-mcp-server/",
+  "ruleGate": ["password", "ssn"],
+  "ruleJudge": ["Sources:"],
+  "contract": { "type": "object", "required": ["amount", "currency"] },
+  "redact": true,
+  "maxTurns": 5,
+  "allowTools": ["calculator", "write_file:/project/"],
+  "permissions": "Ask",
+  "risk": { "irreversible": ["wire_transfer"] },
+  "requireApproval": ["wire_transfer"],
+  "logTo": "log.txt",
+  "audit": "audit.jsonl",
+  "telemetry": "form-built-agent",
+  "sessions": "sessions",
+  "effectLedger": "ledger",
+  "screenToolOutput": true,
+  "budget": { "maxTokens": 50000, "maxCostUsd": 0.25 },
+  "resilience": 3,
+  "compensateOnFailure": true
+}
+```
+
+The rules, and each is deliberate:
+
+- **An unknown key refuses to compose**, with the key named. A form that typos `"buget"` must
+  not get an unbounded agent that looks configured — a control you believe is on and is not is
+  worse than an error at composition. Wrong-shaped values refuse the same way, and enum-valued
+  keys name what they accept (`permissions` accepts Open, Ask, Deny).
+- **Tools stay code, because they are code** — except `mcp`, where a tool is a URL, which is
+  data. Delegates (`On*`) and broker instances (`Use*`) stay code for the same reason.
+- **Data and code compose.** `FromJson` returns the same `StandardAgent`, so keep chaining:
+
+```csharp
+var agent = StandardAgent.FromJson(formBody)     // everything that is data
+    .Tool(new CalculatorTool())                  // everything that is code
+    .OnApproval(effect => AskTheDutyOfficerAsync(effect));
+```
+
+- **Short forms for form-builders**: where the long form is an object, a bare value works —
+  `"knowledge": "Knowledge"`, `"mcp": "url"`, `"redact": true`, `"telemetry": true`,
+  `"sessions": "path"`, `"logTo": "path"`, `"resilience": 3`. The long forms carry the same
+  optional fields as the builder verbs (`"knowledge": { "path", "pattern", "maxResults",
+  "minScore" }`, `"sessions": { "path", "maxHistoryTurns" }`, and so on).
+- **The `contract` schema rides embedded** — real JSON inside the JSON, never an escaped string
+  a form author would have to hand-quote.
+
+And the deployment half: drop an `agent.json` beside `Standard.Agents.Host` (or point
+`Agent:Config` at one) and the hosted agent composes entirely from it — form → JSON → file →
+a running, gated, budgeted agent behind an authenticated endpoint, no C# anywhere
+([docs/hosting.md](hosting.md)).
 
 ## Putting it together
 


### PR DESCRIPTION
### What

The documentation for #322 and #323:

- **docs/how-to.md** — new **§16 · The whole agent as JSON**: the full example document, the four rules (unknown keys refuse with the key named; tools stay code except MCP where a tool is a URL; data and code compose by chaining after `FromJson`; short forms for form-builders), and the `agent.json` deployment path. The intro now points at it.
- **README.md** — a headline section under the three-verbs story: "**Agent as data — the whole thing as JSON**", with the one-liner, a compact document, and the claim stated carefully: a fourth door no mainstream framework has.
- **docs/hosting.md** — "The agent as a document": `Agent:Config` / `agent.json`, the document-is-the-whole-truth rule, and the brainless-document grace.

### Why

The low-code story only lands if a form author can find the key list and the rules without reading C#. The §16 key list is the same document the parity test composes, so the docs and the build gate the same surface.

### Evidence

Documentation only. Every key, short form, and behavior stated matches the shipped `FromJson` mapping and the smoke-tested Host path.