### PR TITLE
[BROKERS]: Mcps - Many Servers Behind One Seam, With Discovery And Auth

### DIFF
--- a/Standard.Agents.Conformance/Brokers/NotConfiguredMcpBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/NotConfiguredMcpBroker.cs
@@ -11,4 +11,7 @@ public sealed class NotConfiguredMcpBroker : IMcpBroker
 {
     public async ValueTask<string> CallAsync(string name, string input) =>
         $"[external '{name}' not configured]";
+
+    public async ValueTask<IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool>>
+        ListToolsAsync() => [];
 }

--- a/Standard.Agents.Evals/Brokers/CaseBrokers.cs
+++ b/Standard.Agents.Evals/Brokers/CaseBrokers.cs
@@ -42,4 +42,7 @@ public sealed class NotConfiguredMcpBroker : IMcpBroker
 {
     public async ValueTask<string> CallAsync(string name, string input) =>
         $"[external '{name}' not configured]";
+
+    public async ValueTask<IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool>>
+        ListToolsAsync() => [];
 }

--- a/Standard.Agents/Brokers/Mcps/CompositeMcpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/CompositeMcpBroker.cs
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Mcps;
+
+namespace Standard.Agents.Brokers.Mcps;
+
+/// <summary>
+/// Many MCP servers behind the one seam the agent already speaks. A call routes to the server
+/// whose catalog owns the name; when two servers claim the same name, the first registered
+/// wins — deterministic, and the same precedence internal tools already have over external
+/// ones. Catalogs are discovered lazily and cached per server on success only, so a server
+/// that is down at first use is asked again rather than remembered as empty.
+/// </summary>
+public sealed class CompositeMcpBroker : IMcpBroker
+{
+    private readonly IReadOnlyList<IMcpBroker> brokers;
+    private readonly IReadOnlyList<McpTool>?[] catalogs;
+    private readonly SemaphoreSlim discoveryLock = new(initialCount: 1, maxCount: 1);
+
+    public CompositeMcpBroker(IEnumerable<IMcpBroker> brokers)
+    {
+        this.brokers = [.. brokers];
+        this.catalogs = new IReadOnlyList<McpTool>?[this.brokers.Count];
+    }
+
+    public async ValueTask<string> CallAsync(string name, string input)
+    {
+        IMcpBroker? owner = await ResolveAsync(name);
+
+        return owner is null
+            ? $"[external '{name}' not configured]"
+            : await owner.CallAsync(name, input);
+    }
+
+    public async ValueTask<IReadOnlyList<McpTool>> ListToolsAsync()
+    {
+        await DiscoverAsync();
+
+        // First-registered wins here too, so the union a caller sees is the union the router
+        // routes by.
+        var seen = new HashSet<string>();
+        List<McpTool> union = [];
+
+        foreach (IReadOnlyList<McpTool>? catalog in this.catalogs)
+        {
+            foreach (McpTool tool in catalog ?? [])
+            {
+                if (seen.Add(tool.Name))
+                {
+                    union.Add(tool);
+                }
+            }
+        }
+
+        return union;
+    }
+
+    private async ValueTask<IMcpBroker?> ResolveAsync(string name)
+    {
+        await DiscoverAsync();
+
+        for (int index = 0; index < this.brokers.Count; index++)
+        {
+            if (this.catalogs[index]?.Any(tool => tool.Name == name) is true)
+            {
+                return this.brokers[index];
+            }
+        }
+
+        return null;
+    }
+
+    private async ValueTask DiscoverAsync()
+    {
+        if (this.catalogs.All(catalog => catalog is not null))
+        {
+            return;
+        }
+
+        await this.discoveryLock.WaitAsync();
+
+        try
+        {
+            for (int index = 0; index < this.brokers.Count; index++)
+            {
+                if (this.catalogs[index] is not null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    this.catalogs[index] = await this.brokers[index].ListToolsAsync();
+                }
+                catch
+                {
+                    // A server unreachable at discovery keeps its slot empty and is asked again
+                    // on the next call — its outage must not take the other servers' tools with
+                    // it, and must not be cached as "has no tools".
+                }
+            }
+        }
+        finally
+        {
+            this.discoveryLock.Release();
+        }
+    }
+}

--- a/Standard.Agents/Brokers/Mcps/IMcpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/IMcpBroker.cs
@@ -3,9 +3,17 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using Standard.Agents.Models.Brokers.Mcps;
+
 namespace Standard.Agents.Brokers.Mcps;
 
 public interface IMcpBroker
 {
     ValueTask<string> CallAsync(string name, string input);
+
+    /// <summary>
+    /// The server's tool catalog (<c>tools/list</c>). What makes more than one server composable:
+    /// a router can only send a name to the server that owns it if servers say what they own.
+    /// </summary>
+    ValueTask<IReadOnlyList<McpTool>> ListToolsAsync();
 }

--- a/Standard.Agents/Brokers/Mcps/McpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/McpBroker.cs
@@ -15,6 +15,7 @@ public sealed class McpBroker : IMcpBroker
     private const string JsonMediaType = "application/json";
     private const string JsonRpcVersion = "2.0";
     private const string ToolsCallMethod = "tools/call";
+    private const string ToolsListMethod = "tools/list";
     private const string InputArgumentName = "input";
 
     private static readonly JsonSerializerOptions jsonOptions = new()
@@ -31,16 +32,55 @@ public sealed class McpBroker : IMcpBroker
     public McpBroker(
         string endpointUrl,
         string relativeUrl,
-        int timeoutSeconds)
+        int timeoutSeconds,
+        string? bearerToken = null,
+        string? apiKey = null,
+        string apiKeyHeader = "X-Api-Key",
+        Func<ValueTask<string>>? bearerTokenProvider = null)
     {
-        var httpClient = new HttpClient
+        // A dynamic token rides a handler so every request asks the provider — that is what an
+        // OAuth access token needs, because the one from composition time expires. Static
+        // credentials ride the default headers; the provider, when present, wins over both.
+        var httpClient = bearerTokenProvider is null
+            ? new HttpClient()
+            : new HttpClient(new BearerTokenHandler(bearerTokenProvider));
+
+        httpClient.BaseAddress = new Uri(endpointUrl);
+        httpClient.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+
+        if (bearerTokenProvider is null && string.IsNullOrEmpty(bearerToken) is false)
         {
-            BaseAddress = new Uri(endpointUrl),
-            Timeout = TimeSpan.FromSeconds(timeoutSeconds)
-        };
+            httpClient.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", bearerToken);
+        }
+
+        if (string.IsNullOrEmpty(apiKey) is false)
+        {
+            httpClient.DefaultRequestHeaders.Add(apiKeyHeader, apiKey);
+        }
 
         this.apiClient = new RESTFulApiFactoryClient(httpClient);
         this.relativeUrl = relativeUrl;
+    }
+
+    private sealed class BearerTokenHandler : DelegatingHandler
+    {
+        private readonly Func<ValueTask<string>> provideToken;
+
+        public BearerTokenHandler(Func<ValueTask<string>> provideToken)
+            : base(new HttpClientHandler()) =>
+            this.provideToken = provideToken;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            request.Headers.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue(
+                    "Bearer", await this.provideToken());
+
+            return await base.SendAsync(request, cancellationToken);
+        }
     }
 
     public async ValueTask<string> CallAsync(string name, string input)
@@ -62,6 +102,28 @@ public sealed class McpBroker : IMcpBroker
                 jsonRpcRequest);
 
         return ToText(jsonRpcResponse);
+    }
+
+    public async ValueTask<IReadOnlyList<McpTool>> ListToolsAsync()
+    {
+        JsonRpcRequest jsonRpcRequest = new(
+            JsonRpc: JsonRpcVersion,
+            Id: Interlocked.Increment(ref this.requestId),
+            Method: ToolsListMethod,
+            Params: null);
+
+        JsonRpcToolListResponse jsonRpcResponse =
+            await PostAsync<JsonRpcRequest, JsonRpcToolListResponse>(
+                this.relativeUrl,
+                jsonRpcRequest);
+
+        if (jsonRpcResponse.Error is not null)
+        {
+            throw new HttpRequestException(jsonRpcResponse.Error.Message);
+        }
+
+        return [.. (jsonRpcResponse.Result?.Tools ?? []).Select(tool =>
+            new McpTool(tool.Name, tool.Description ?? string.Empty))];
     }
 
     private static string ToText(JsonRpcResponse jsonRpcResponse)

--- a/Standard.Agents/Brokers/Mcps/NotConfiguredMcpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/NotConfiguredMcpBroker.cs
@@ -9,4 +9,7 @@ public sealed class NotConfiguredMcpBroker : IMcpBroker
 {
     public async ValueTask<string> CallAsync(string name, string input) =>
         $"[external '{name}' not configured]";
+
+    public async ValueTask<IReadOnlyList<Models.Brokers.Mcps.McpTool>> ListToolsAsync() =>
+        [];
 }

--- a/Standard.Agents/Models/Brokers/Mcps/JsonRpcRequest.cs
+++ b/Standard.Agents/Models/Brokers/Mcps/JsonRpcRequest.cs
@@ -7,8 +7,10 @@ using System.Text.Json.Serialization;
 
 namespace Standard.Agents.Models.Brokers.Mcps;
 
+// Params is null for parameterless methods such as tools/list, and the serializer omits it
+// (WhenWritingNull) rather than sending "params": null, which some servers reject.
 internal sealed record JsonRpcRequest(
     [property: JsonPropertyName("jsonrpc")] string JsonRpc,
     int Id,
     string Method,
-    ToolCallParams Params);
+    ToolCallParams? Params);

--- a/Standard.Agents/Models/Brokers/Mcps/McpTool.cs
+++ b/Standard.Agents/Models/Brokers/Mcps/McpTool.cs
@@ -1,0 +1,12 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Brokers.Mcps;
+
+/// <summary>
+/// One tool an MCP server offers, as its catalog describes it — the name a call must use, and
+/// the description that would advertise it.
+/// </summary>
+public sealed record McpTool(string Name, string Description);

--- a/Standard.Agents/Models/Brokers/Mcps/ToolListResult.cs
+++ b/Standard.Agents/Models/Brokers/Mcps/ToolListResult.cs
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Brokers.Mcps;
+
+internal sealed record ToolListResult(
+    IReadOnlyList<ToolListEntry> Tools);
+
+internal sealed record ToolListEntry(
+    string Name,
+    string? Description);
+
+internal sealed record JsonRpcToolListResponse(
+    ToolListResult? Result,
+    JsonRpcError? Error);

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,1 +1,24 @@
 #nullable enable
+*REMOVED*Standard.Agents.Brokers.Mcps.McpBroker.McpBroker(string! endpointUrl, string! relativeUrl, int timeoutSeconds) -> void
+Standard.Agents.Brokers.Mcps.CompositeMcpBroker
+Standard.Agents.Brokers.Mcps.CompositeMcpBroker.CallAsync(string! name, string! input) -> System.Threading.Tasks.ValueTask<string!>
+Standard.Agents.Brokers.Mcps.CompositeMcpBroker.CompositeMcpBroker(System.Collections.Generic.IEnumerable<Standard.Agents.Brokers.Mcps.IMcpBroker!>! brokers) -> void
+Standard.Agents.Brokers.Mcps.CompositeMcpBroker.ListToolsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!>
+Standard.Agents.Brokers.Mcps.IMcpBroker.ListToolsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!>
+Standard.Agents.Brokers.Mcps.McpBroker.ListToolsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!>
+Standard.Agents.Brokers.Mcps.McpBroker.McpBroker(string! endpointUrl, string! relativeUrl, int timeoutSeconds, string? bearerToken = null, string? apiKey = null, string! apiKeyHeader = "X-Api-Key", System.Func<System.Threading.Tasks.ValueTask<string!>>? bearerTokenProvider = null) -> void
+Standard.Agents.Brokers.Mcps.NotConfiguredMcpBroker.ListToolsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!>
+Standard.Agents.Models.Brokers.Mcps.McpTool
+Standard.Agents.Models.Brokers.Mcps.McpTool.<Clone>$() -> Standard.Agents.Models.Brokers.Mcps.McpTool!
+Standard.Agents.Models.Brokers.Mcps.McpTool.Deconstruct(out string! Name, out string! Description) -> void
+Standard.Agents.Models.Brokers.Mcps.McpTool.Description.get -> string!
+Standard.Agents.Models.Brokers.Mcps.McpTool.Description.init -> void
+Standard.Agents.Models.Brokers.Mcps.McpTool.Equals(Standard.Agents.Models.Brokers.Mcps.McpTool? other) -> bool
+Standard.Agents.Models.Brokers.Mcps.McpTool.McpTool(string! Name, string! Description) -> void
+Standard.Agents.Models.Brokers.Mcps.McpTool.Name.get -> string!
+Standard.Agents.Models.Brokers.Mcps.McpTool.Name.init -> void
+override Standard.Agents.Models.Brokers.Mcps.McpTool.Equals(object? obj) -> bool
+override Standard.Agents.Models.Brokers.Mcps.McpTool.GetHashCode() -> int
+override Standard.Agents.Models.Brokers.Mcps.McpTool.ToString() -> string!
+static Standard.Agents.Models.Brokers.Mcps.McpTool.operator !=(Standard.Agents.Models.Brokers.Mcps.McpTool? left, Standard.Agents.Models.Brokers.Mcps.McpTool? right) -> bool
+static Standard.Agents.Models.Brokers.Mcps.McpTool.operator ==(Standard.Agents.Models.Brokers.Mcps.McpTool? left, Standard.Agents.Models.Brokers.Mcps.McpTool? right) -> bool


### PR DESCRIPTION
### What

The broker layer for multiple MCP connections, in three pieces:

- **Discovery**: `IMcpBroker` gains `ListToolsAsync()` — the server's `tools/list` catalog as `McpTool(Name, Description)`. This is what makes more than one server composable: a router can only send a name to the server that owns it if servers say what they own. `McpBroker` implements it over the same JSON-RPC client; the NotConfigured doubles (core, conformance, evals) return empty.
- **`CompositeMcpBroker`**: many servers behind the one seam the agent already speaks. A call routes to the server whose catalog owns the name; **first-registered wins** on collisions — deterministic, and the same precedence internal tools already have over external ones. Catalogs are discovered lazily and cached **on success only**, so a server that is down at first use is asked again rather than remembered as empty, and its outage never takes the other servers' tools with it.
- **Auth, covering the bases real MCP servers use**: `McpBroker` now takes an optional static `bearerToken` (OAuth access token / PAT — the MCP HTTP transport's own scheme), an optional `apiKey` with a configurable `apiKeyHeader`, and a `bearerTokenProvider` delegate for OAuth refresh flows — a dynamic token rides a `DelegatingHandler` so **every request asks the provider**, because the token from composition time expires. The framework accepts tokens; running the OAuth dance stays the host's job, which is the only place it can live.

### Why

First of a five-PR program: everything the agent integrates with — tools, MCP servers, skill sources — should accumulate, never replace. Tools already do; this PR gives MCP the machinery; the client verbs, JSON surface, and docs follow, each under its own review.

### Evidence

Brokers carry no unit tests, per The Standard. Zero warnings on both TFMs (new symbols in `PublicAPI.Unshipped.txt`, the widened `McpBroker` constructor's old signature marked `*REMOVED*`), full suite 579/579, 44/44 conformance vectors. The routing and accumulation behavior is proven test-first in the CLIENTS PR that follows, where it is observable.