### PR TITLE
[BROKERS]: Skills - Many Sources As The One Stream The Agent Reads

### DIFF
--- a/Standard.Agents/Brokers/Skills/CompositeSkillBroker.cs
+++ b/Standard.Agents/Brokers/Skills/CompositeSkillBroker.cs
@@ -1,0 +1,34 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Foundations.Skills;
+
+namespace Standard.Agents.Brokers.Skills;
+
+/// <summary>
+/// Many skill sources — folders, registries, delegates — as the one stream the agent reads. The
+/// sources are read in registration order and their skills concatenate, so what a skill file
+/// relies on (earlier files establish context for later ones) holds across sources exactly as
+/// it holds across files within one folder.
+/// </summary>
+public sealed class CompositeSkillBroker : ISkillBroker
+{
+    private readonly IReadOnlyList<ISkillBroker> brokers;
+
+    public CompositeSkillBroker(IEnumerable<ISkillBroker> brokers) =>
+        this.brokers = [.. brokers];
+
+    public async ValueTask<IReadOnlyList<Skill>> SelectSkillsAsync()
+    {
+        List<Skill> skills = [];
+
+        foreach (ISkillBroker broker in this.brokers)
+        {
+            skills.AddRange(await broker.SelectSkillsAsync());
+        }
+
+        return skills;
+    }
+}

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -8,6 +8,9 @@ Standard.Agents.Brokers.Mcps.IMcpBroker.ListToolsAsync() -> System.Threading.Tas
 Standard.Agents.Brokers.Mcps.McpBroker.ListToolsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!>
 Standard.Agents.Brokers.Mcps.McpBroker.McpBroker(string! endpointUrl, string! relativeUrl, int timeoutSeconds, string? bearerToken = null, string? apiKey = null, string! apiKeyHeader = "X-Api-Key", System.Func<System.Threading.Tasks.ValueTask<string!>>? bearerTokenProvider = null) -> void
 Standard.Agents.Brokers.Mcps.NotConfiguredMcpBroker.ListToolsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!>
+Standard.Agents.Brokers.Skills.CompositeSkillBroker
+Standard.Agents.Brokers.Skills.CompositeSkillBroker.CompositeSkillBroker(System.Collections.Generic.IEnumerable<Standard.Agents.Brokers.Skills.ISkillBroker!>! brokers) -> void
+Standard.Agents.Brokers.Skills.CompositeSkillBroker.SelectSkillsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Foundations.Skills.Skill!>!>
 Standard.Agents.Models.Brokers.Mcps.McpTool
 Standard.Agents.Models.Brokers.Mcps.McpTool.<Clone>$() -> Standard.Agents.Models.Brokers.Mcps.McpTool!
 Standard.Agents.Models.Brokers.Mcps.McpTool.Deconstruct(out string! Name, out string! Description) -> void


### PR DESCRIPTION
### What

`CompositeSkillBroker` — many skill sources (folders, registries, delegates) behind the one `ISkillBroker` seam. Sources are read in registration order and their skills concatenate, so the context earlier files establish for later ones holds across sources exactly as it holds across files within one folder.

### Why

Second of the five-PR multiple-integrations program (after #326): the broker the client verbs compose over in the CLIENTS PR that follows.

### Evidence

Brokers carry no unit tests, per The Standard; the accumulation behavior is proven test-first in the CLIENTS PR where it is observable. Zero warnings on both TFMs, symbols in `PublicAPI.Unshipped.txt`.