### PR TITLE
[CLIENTS]: StandardAgent - Integrations Accumulate, Never Replace

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Integrations.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Integrations.cs
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Brokers.Mcps;
+using Standard.Agents.Models.Foundations.Skills;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+// The integration rule: what the agent connects TO accumulates, never replaces. Tools always
+// did; these tests hold MCP servers and skill sources to the same rule — a second registration
+// must not silently unplug the first.
+public class StandardAgentIntegrationTests
+{
+    [Fact]
+    public async Task ShouldRouteAcrossMultipleMcpServersByToolNameAsync()
+    {
+        // given — two servers, each owning one tool; the FIRST registered owns 'alpha'.
+        var firstServer = new Mock<IMcpBroker>();
+
+        firstServer.Setup(broker => broker.ListToolsAsync())
+            .ReturnsAsync([new McpTool("alpha", "first server's tool")]);
+
+        firstServer.Setup(broker => broker.CallAsync("alpha", It.IsAny<string>()))
+            .ReturnsAsync("42 from the first server");
+
+        var secondServer = new Mock<IMcpBroker>();
+
+        secondServer.Setup(broker => broker.ListToolsAsync())
+            .ReturnsAsync([new McpTool("beta", "second server's tool")]);
+
+        int turn = 0;
+
+        StandardAgent agent = new StandardAgent()
+            .UseMemory(EmptyMemory())
+            .UseKnowledge(EmptyKnowledge())
+            .UseMcp(firstServer.Object)
+            .UseMcp(secondServer.Object)
+            .OnBrain(async (systemPrompt, userPrompt) =>
+                ++turn is 1 ? "ACTION: alpha: ping" : "FINAL: done");
+
+        // when
+        await agent.ProcessPromptAsync("use alpha");
+
+        // then — the call reached the server that owns the name, not merely the last one added.
+        firstServer.Verify(broker =>
+            broker.CallAsync("alpha", It.IsAny<string>()),
+                Times.Once);
+
+        secondServer.Verify(broker =>
+            broker.CallAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+    }
+
+    [Fact]
+    public async Task ShouldReadSkillsFromEveryRegisteredSourceAsync()
+    {
+        // given — a broker-backed source and a delegate source, registered in that order.
+        var registrySource = new Mock<ISkillBroker>();
+
+        registrySource.Setup(broker => broker.SelectSkillsAsync())
+            .ReturnsAsync([new Skill { Name = "alpha", Content = "ALPHA-RULE" }]);
+
+        string? capturedSystemPrompt = null;
+
+        StandardAgent agent = new StandardAgent()
+            .UseMemory(EmptyMemory())
+            .UseKnowledge(EmptyKnowledge())
+            .UseSkills(registrySource.Object)
+            .OnSkills(async () => [new Skill { Name = "beta", Content = "BETA-RULE" }])
+            .OnBrain(async (systemPrompt, userPrompt) =>
+            {
+                capturedSystemPrompt = systemPrompt;
+
+                return "FINAL: done";
+            });
+
+        // when
+        await agent.ProcessPromptAsync("hello");
+
+        // then — both sources reached the brain; the second registration added, not replaced.
+        capturedSystemPrompt.Should().Contain("ALPHA-RULE");
+        capturedSystemPrompt.Should().Contain("BETA-RULE");
+    }
+
+    private static IMemoryBroker EmptyMemory()
+    {
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        return memoryBroker.Object;
+    }
+
+    private static IKnowledgeBroker EmptyKnowledge()
+    {
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return knowledgeBroker.Object;
+    }
+}

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 *REMOVED*Standard.Agents.Brokers.Mcps.McpBroker.McpBroker(string! endpointUrl, string! relativeUrl, int timeoutSeconds) -> void
+*REMOVED*Standard.Agents.StandardAgent.Mcp(string! endpointUrl, string! relativeUrl = "", int timeoutSeconds = 30) -> Standard.Agents.StandardAgent!
 Standard.Agents.Brokers.Mcps.CompositeMcpBroker
 Standard.Agents.Brokers.Mcps.CompositeMcpBroker.CallAsync(string! name, string! input) -> System.Threading.Tasks.ValueTask<string!>
 Standard.Agents.Brokers.Mcps.CompositeMcpBroker.CompositeMcpBroker(System.Collections.Generic.IEnumerable<Standard.Agents.Brokers.Mcps.IMcpBroker!>! brokers) -> void
@@ -20,6 +21,7 @@ Standard.Agents.Models.Brokers.Mcps.McpTool.Equals(Standard.Agents.Models.Broker
 Standard.Agents.Models.Brokers.Mcps.McpTool.McpTool(string! Name, string! Description) -> void
 Standard.Agents.Models.Brokers.Mcps.McpTool.Name.get -> string!
 Standard.Agents.Models.Brokers.Mcps.McpTool.Name.init -> void
+Standard.Agents.StandardAgent.Mcp(string! endpointUrl, string! relativeUrl = "", int timeoutSeconds = 30, string? bearerToken = null, string? apiKey = null, string! apiKeyHeader = "X-Api-Key", System.Func<System.Threading.Tasks.ValueTask<string!>>? bearerTokenProvider = null) -> Standard.Agents.StandardAgent!
 override Standard.Agents.Models.Brokers.Mcps.McpTool.Equals(object? obj) -> bool
 override Standard.Agents.Models.Brokers.Mcps.McpTool.GetHashCode() -> int
 override Standard.Agents.Models.Brokers.Mcps.McpTool.ToString() -> string!

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -76,7 +76,11 @@ public sealed partial class StandardAgent : IAgent
     private readonly List<ITool> tools = [];
     private readonly Lock compositionLock = new();
 
-    private string skillsPath = "Skills";
+    // Integrations accumulate, never replace: a second skill source or MCP server adds to the
+    // agent the way a second .Tool() always has.
+    private readonly List<ISkillBroker> skillSources = [];
+    private readonly List<IMcpBroker> mcpSources = [];
+
     private string constitutionPath = string.Empty;
     private string consumptionPath = string.Empty;
     private string logPath = string.Empty;
@@ -96,11 +100,6 @@ public sealed partial class StandardAgent : IAgent
     private InferenceSettings? gateSettings;
     private InferenceSettings? judgeSettings;
 
-    private string mcpEndpointUrl = string.Empty;
-    private string mcpRelativeUrl = string.Empty;
-    private int mcpTimeoutSeconds = 30;
-
-    private ISkillBroker? skillBroker;
     private IGeneratorBroker? generatorBroker;
     private IMemoryBroker? memoryBroker;
     private IKnowledgeBroker? knowledgeBroker;
@@ -108,7 +107,6 @@ public sealed partial class StandardAgent : IAgent
     private IVerifierBroker? verifierBroker;
     private Func<string, string, ValueTask<string>>? localGateScreen;
     private Func<string, string, ValueTask<string>>? localJudgeEvaluate;
-    private IMcpBroker? mcpBroker;
     private ILoggingBroker? loggingBroker;
     private IAuditBroker? auditBroker;
     private ITelemetryBroker? telemetryBroker;
@@ -168,8 +166,11 @@ public sealed partial class StandardAgent : IAgent
     /// </summary>
     /// <param name="path">Folder holding the <c>.md</c> skill files.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
+    /// <remarks>Sources accumulate: a second call adds another folder rather than replacing the
+    /// first, and skills read in registration order across sources.</remarks>
     public StandardAgent Skills(string path) =>
-        Set(() => this.skillsPath = path);
+        Set(() => this.skillSources.Add(
+            new FileSkillBroker(Path.Combine(AppContext.BaseDirectory, path))));
 
     /// <summary>
     /// Points the agent at the ethical constitution: a markdown file whose text is prepended
@@ -404,14 +405,37 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="endpointUrl">Base URL of the MCP server.</param>
     /// <param name="relativeUrl">Relative path appended to the base URL. Defaults to empty.</param>
     /// <param name="timeoutSeconds">Per-call timeout in seconds. Defaults to 30.</param>
+    /// <param name="bearerToken">
+    /// Optional <c>Authorization: Bearer</c> credential — an OAuth access token or PAT, for a
+    /// server that wants one. A server with no auth needs none of these parameters.
+    /// </param>
+    /// <param name="apiKey">Optional API key, sent as <paramref name="apiKeyHeader"/>.</param>
+    /// <param name="apiKeyHeader">Header the API key travels in. Defaults to <c>X-Api-Key</c>.</param>
+    /// <param name="bearerTokenProvider">
+    /// Optional per-call token source for OAuth refresh flows: every request asks it, so the
+    /// token is always the current one. Your OAuth client runs the flow; the agent carries the
+    /// result. Wins over <paramref name="bearerToken"/> when both are given.
+    /// </param>
     /// <returns>The same agent, so calls can be chained.</returns>
-    public StandardAgent Mcp(string endpointUrl, string relativeUrl = "", int timeoutSeconds = 30) =>
-    Set(() =>
-    {
-        this.mcpEndpointUrl = endpointUrl;
-        this.mcpRelativeUrl = relativeUrl;
-        this.mcpTimeoutSeconds = timeoutSeconds;
-    });
+    /// <remarks>Servers accumulate: each call adds another server, a tool call routes to the
+    /// server whose catalog owns the name, and the first-registered server wins a name both
+    /// claim.</remarks>
+    public StandardAgent Mcp(
+        string endpointUrl,
+        string relativeUrl = "",
+        int timeoutSeconds = 30,
+        string? bearerToken = null,
+        string? apiKey = null,
+        string apiKeyHeader = "X-Api-Key",
+        Func<ValueTask<string>>? bearerTokenProvider = null) =>
+        Set(() => this.mcpSources.Add(new McpBroker(
+            endpointUrl,
+            relativeUrl,
+            timeoutSeconds,
+            bearerToken,
+            apiKey,
+            apiKeyHeader,
+            bearerTokenProvider)));
 
     /// <summary>
     /// Registers one tool the agent may call. It is only advertised to the brain when it carries a
@@ -746,7 +770,7 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="broker">The skill broker to use.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent UseSkills(ISkillBroker broker) =>
-        Set(() => this.skillBroker = broker);
+        Set(() => this.skillSources.Add(broker));
 
     /// <summary>
     /// Supplies skills from your own code — the <b>Custom</b> mode (SPEC.md §4.8), for when they
@@ -755,7 +779,7 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="select">A <c>() =&gt; skills</c> delegate, called each turn.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent OnSkills(Func<ValueTask<IReadOnlyList<Skill>>> select) =>
-        Set(() => this.skillBroker = new FunctionSkillBroker(select));
+        Set(() => this.skillSources.Add(new FunctionSkillBroker(select)));
 
     /// <summary>
     /// Swaps in a custom generator (brain) broker — the extension point for a runtime that streams
@@ -884,12 +908,13 @@ public sealed partial class StandardAgent : IAgent
         Set(() => this.verifierBroker = broker);
 
     /// <summary>
-    /// Swaps in a custom MCP broker, replacing the HTTP-backed one set up by <see cref="Mcp"/>.
+    /// Adds a custom MCP broker alongside any servers registered with <see cref="Mcp"/> — the
+    /// door for a transport or auth scheme the built-in HTTP broker does not speak.
     /// </summary>
-    /// <param name="broker">The MCP broker to use.</param>
+    /// <param name="broker">The MCP broker to add.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent UseMcp(IMcpBroker broker) =>
-        Set(() => this.mcpBroker = broker);
+        Set(() => this.mcpSources.Add(broker));
 
     /// <summary>
     /// Swaps in a custom logging broker for the agent's internal diagnostic logging.
@@ -1389,18 +1414,23 @@ public sealed partial class StandardAgent : IAgent
 
         IToolBroker toolBroker = new ToolBroker(allTools);
 
-        IMcpBroker mcp =
-            this.mcpBroker ?? (string.IsNullOrWhiteSpace(this.mcpEndpointUrl)
-                ? new NotConfiguredMcpBroker()
-                : new McpBroker(
-                    this.mcpEndpointUrl, this.mcpRelativeUrl, this.mcpTimeoutSeconds));
+        // One source composes as itself; several compose behind the same seam the service
+        // already speaks — the tier above never learns how many integrations answered.
+        IMcpBroker mcp = this.mcpSources.Count switch
+        {
+            0 => new NotConfiguredMcpBroker(),
+            1 => this.mcpSources[0],
+            _ => new CompositeMcpBroker(this.mcpSources)
+        };
 
+        ISkillBroker skills = this.skillSources.Count switch
+        {
+            0 => new FileSkillBroker(Path.Combine(AppContext.BaseDirectory, "Skills")),
+            1 => this.skillSources[0],
+            _ => new CompositeSkillBroker(this.skillSources)
+        };
 
-        ISkillService skillService = this.skillBroker is null
-            ? new SkillService(
-                new FileSkillBroker(Path.Combine(AppContext.BaseDirectory, this.skillsPath)),
-                logging)
-            : new SkillService(this.skillBroker, logging);
+        ISkillService skillService = new SkillService(skills, logging);
 
         IKnowledgeService knowledgeService = this.knowledgeBroker is null
             ? new KnowledgeService(


### PR DESCRIPTION
### What

The integration rule on the client: what the agent connects **to** accumulates, the way `.Tool(...)` always has.

- `.Mcp(...)` and `.UseMcp(...)` each **add** a server; `Compose()` builds one broker for one server and `CompositeMcpBroker` (#326) for several — a call routes to the server whose catalog owns the name, first-registered wins.
- `.Mcp(...)` gains the optional per-server auth from #326: none by default, `bearerToken` (OAuth access token / PAT), `apiKey` + configurable `apiKeyHeader`, and `bearerTokenProvider` for refresh flows.
- `.Skills(path)`, `.UseSkills(broker)` and `.OnSkills(fn)` each **add** a source; `Compose()` builds `CompositeSkillBroker` (#327) for several, and the bare-agent default (a `Skills` folder beside the executable) is unchanged when nothing was registered.
- The single-slot `mcpEndpointUrl`/`skillsPath`/`skillBroker`/`mcpBroker` fields are gone.

### Why

An agent can very much connect to multiple tools, multiple MCP servers, and multiple skill sources — a second registration silently unplugging the first was the only thing standing in the way, and nothing in the suite relied on it.

### Evidence

TDD, both committed FAIL (observed red) then PASS:
- `ShouldRouteAcrossMultipleMcpServersByToolNameAsync` — two servers, the tool lives on the **first** registered; red under replace semantics (the call went to the last server), green under routing, with the second server verified never called.
- `ShouldReadSkillsFromEveryRegisteredSourceAsync` — a broker source plus a delegate source; both contents reach the brain's system prompt.

Full suite 581/581 on net8.0 and net10.0, zero warnings, 44/44 conformance vectors, the widened `Mcp` signature baselined with its old form `*REMOVED*`.