### PR TITLE
[CLIENTS]: FromJson - Integrations Are Plural In The Document Too

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
@@ -86,10 +86,14 @@ public class StandardAgentFromJsonTests
                      "temperature": 0.2, "maxTokens": 512, "timeoutSeconds": 60 },
           "nativeBrain": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "m" },
           "nativeBrainAnthropic": { "apiKey": "k", "model": "claude-sonnet-4-5" },
-          "skills": "Skills",
+          "skills": ["Skills", "MoreSkills"],
           "knowledge": { "path": "Knowledge", "pattern": "*.md", "maxResults": 3, "minScore": 0.1 },
           "memory": "memory.txt",
-          "mcp": { "endpointUrl": "https://mcp.example/", "timeoutSeconds": 20 },
+          "mcp": [
+            "https://mcp.example/",
+            { "endpointUrl": "https://locked.example/", "timeoutSeconds": 20,
+              "bearerToken": "token", "apiKey": "key", "apiKeyHeader": "X-Api-Key" }
+          ],
           "gate": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "m" },
           "ruleGate": ["password", "ssn"],
           "judge": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "m" },
@@ -119,6 +123,28 @@ public class StandardAgentFromJsonTests
 
         // when
         StandardAgent agent = StandardAgent.FromJson(everything);
+
+        // then
+        agent.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ShouldComposeMultipleIntegrationsFromJson()
+    {
+        // given — integrations are plural in the document the same way they are in code: a
+        // form adds a row, the agent gains a source.
+        const string integrations = """
+        {
+          "skills": ["Skills", "Compliance/Skills"],
+          "mcp": [
+            "https://tools.example/",
+            { "endpointUrl": "https://internal.example/", "apiKey": "psk-1" }
+          ]
+        }
+        """;
+
+        // when
+        StandardAgent agent = StandardAgent.FromJson(integrations);
 
         // then
         agent.Should().NotBeNull();

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -98,6 +98,14 @@ public partial class StandardAgent
 
                 break;
 
+            case "skills" when value is JsonArray sources:
+                foreach (JsonNode? source in sources)
+                {
+                    agent.Skills(Text(source, key));
+                }
+
+                break;
+
             case "skills":
                 agent.Skills(Text(value, key));
 
@@ -122,16 +130,16 @@ public partial class StandardAgent
 
                 break;
 
-            case "mcp" when value is JsonObject:
-                agent.Mcp(
-                    Text(value, key, "endpointUrl"),
-                    Text(value, key, "relativeUrl", fallback: string.Empty),
-                    Whole(value, "timeoutSeconds", fallback: 30));
+            case "mcp" when value is JsonArray servers:
+                foreach (JsonNode? server in servers)
+                {
+                    ApplyMcpServer(agent, server, key);
+                }
 
                 break;
 
             case "mcp":
-                agent.Mcp(Text(value, key));
+                ApplyMcpServer(agent, value, key);
 
                 break;
 
@@ -325,6 +333,31 @@ public partial class StandardAgent
                         + "The keys are the builder verbs, camelCased — see docs/how-to.md.");
         }
     }
+
+    // A server is a URL when it needs nothing else, an object when it carries auth — an API key
+    // in a named header, or a bearer token (an OAuth access token or PAT). A server with no
+    // auth carries none of those keys; a refresh-flow token is code (a delegate) and arrives
+    // through UseMcp, never through the document.
+    private static void ApplyMcpServer(StandardAgent agent, JsonNode? server, string key)
+    {
+        if (server is JsonObject)
+        {
+            agent.Mcp(
+                Text(server, key, "endpointUrl"),
+                Text(server, key, "relativeUrl", fallback: string.Empty),
+                Whole(server, "timeoutSeconds", fallback: 30),
+                OptionalText(server, "bearerToken"),
+                OptionalText(server, "apiKey"),
+                Text(server, key, "apiKeyHeader", fallback: "X-Api-Key"));
+
+            return;
+        }
+
+        agent.Mcp(Text(server, key));
+    }
+
+    private static string? OptionalText(JsonNode? node, string property) =>
+        (node as JsonObject)?[property]?.GetValue<string>();
 
     private static string Text(JsonNode? node, string key) =>
         node?.GetValueKind() is JsonValueKind.String


### PR DESCRIPTION
### What

The JSON surface catches up with #328: `"skills"` and `"mcp"` accept a single value **or an array** — a form adds a row, the agent gains a source. Each MCP entry may be a bare URL (a server with no auth needs nothing else) or an object carrying its own static credentials: `endpointUrl`, `relativeUrl`, `timeoutSeconds`, `bearerToken` (OAuth access token / PAT), `apiKey`, `apiKeyHeader`. A refresh-flow token is code, not data — it arrives as a delegate through `.Mcp(bearerTokenProvider: …)` or `.UseMcp(...)`, never through the document.

The parity-gate document now carries the array forms and an authenticated server entry, so this shape is held by the build like every other key.

### Why

Completes the multiple-integrations program's data door: a low-code platform can now attach several skill folders and several MCP servers — each with or without auth — from one JSON body.

### Evidence

TDD: `ShouldComposeMultipleIntegrationsFromJson` plus the upgraded parity document, both observed red (`'skills' must be a string`) before the FAIL commit, green after. Full suite 582/582 on net8.0 and net10.0, zero warnings, 44/44 conformance vectors.