### PR TITLE
[ORCHESTRATIONS]: Retrieval - Remote Tools Advertise Themselves

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.McpAdvertisement.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.McpAdvertisement.cs
@@ -1,0 +1,100 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Models.Brokers.Mcps;
+using Standard.Agents.Models.Foundations.Skills;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+// Discovery (tools/list) already routes calls; these tests make it advertise too. A remote tool
+// with a description belongs in the {{tools}} catalog beside the local ones — the same opt-in
+// rule (a description is the advertisement), the same catalog line, and best-effort: a server
+// down at advertisement time hides only its own tools and never fails the turn.
+public class StandardAgentMcpAdvertisementTests
+{
+    [Fact]
+    public async Task ShouldAdvertiseDescribedMcpToolsInTheCatalogAsync()
+    {
+        // given — a server offering one described and one undescribed tool.
+        var server = new Mock<IMcpBroker>();
+
+        server.Setup(broker => broker.ListToolsAsync())
+            .ReturnsAsync(
+            [
+                new McpTool("weather", "answers weather questions"),
+                new McpTool("undocumented", "")
+            ]);
+
+        string? capturedSystemPrompt = null;
+
+        StandardAgent agent = new StandardAgent()
+            .UseMemory(EmptyMemory())
+            .UseKnowledge(EmptyKnowledge())
+            .OnSkills(async () =>
+                [new Skill { Name = "persona", Content = "Your tools:\n{{tools}}" }])
+            .UseMcp(server.Object)
+            .OnBrain(async (systemPrompt, userPrompt) =>
+            {
+                capturedSystemPrompt = systemPrompt;
+
+                return "FINAL: done";
+            });
+
+        // when
+        await agent.ProcessPromptAsync("hello");
+
+        // then — described remote tools advertise; the description opt-in holds for them too.
+        capturedSystemPrompt.Should().Contain("weather — answers weather questions");
+        capturedSystemPrompt.Should().NotContain("undocumented");
+    }
+
+    [Fact]
+    public async Task ShouldStillAnswerWhenAdvertisementDiscoveryFailsAsync()
+    {
+        // given — a server that cannot even list its tools.
+        var server = new Mock<IMcpBroker>();
+
+        server.Setup(broker => broker.ListToolsAsync())
+            .ThrowsAsync(new HttpRequestException("server is down"));
+
+        StandardAgent agent = new StandardAgent()
+            .UseMemory(EmptyMemory())
+            .UseKnowledge(EmptyKnowledge())
+            .OnSkills(async () =>
+                [new Skill { Name = "persona", Content = "Your tools:\n{{tools}}" }])
+            .UseMcp(server.Object)
+            .OnBrain(async (systemPrompt, userPrompt) => "FINAL: 42");
+
+        // when
+        string answer = await agent.ProcessPromptAsync("hello");
+
+        // then — advertisement is best-effort; a down server never fails the turn.
+        answer.Should().Be("42");
+    }
+
+    private static IMemoryBroker EmptyMemory()
+    {
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        return memoryBroker.Object;
+    }
+
+    private static IKnowledgeBroker EmptyKnowledge()
+    {
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return knowledgeBroker.Object;
+    }
+}

--- a/Standard.Agents/Models/Orchestrations/Retrievals/ExternalToolCatalog.cs
+++ b/Standard.Agents/Models/Orchestrations/Retrievals/ExternalToolCatalog.cs
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Orchestrations.Retrievals;
+
+/// <summary>
+/// How Retrieval learns what remote tools exist, carried as a model because a delegate that
+/// shapes what the Brain may reach for is policy, and policy is Data — named here, where its
+/// arrival is a reviewed diff, rather than constructor sprawl. Remote tools are Direction's
+/// resource; this crosses natures as configuration, which a dependency may not.
+/// </summary>
+public sealed record ExternalToolCatalog(Func<ValueTask<string>> DiscoverAsync);

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,1 +1,15 @@
 #nullable enable
+*REMOVED*Standard.Agents.Services.Orchestrations.Data.Retrievals.RetrievalOrchestrationService.RetrievalOrchestrationService(Standard.Agents.Services.Foundations.Skills.ISkillService! skillService, Standard.Agents.Services.Foundations.Knowledges.IKnowledgeService! knowledgeService, string! toolCatalog, Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker) -> void
+Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog
+Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.<Clone>$() -> Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog!
+Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.Deconstruct(out System.Func<System.Threading.Tasks.ValueTask<string!>>! DiscoverAsync) -> void
+Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.DiscoverAsync.get -> System.Func<System.Threading.Tasks.ValueTask<string!>>!
+Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.DiscoverAsync.init -> void
+Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.Equals(Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? other) -> bool
+Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.ExternalToolCatalog(System.Func<System.Threading.Tasks.ValueTask<string!>>! DiscoverAsync) -> void
+Standard.Agents.Services.Orchestrations.Data.Retrievals.RetrievalOrchestrationService.RetrievalOrchestrationService(Standard.Agents.Services.Foundations.Skills.ISkillService! skillService, Standard.Agents.Services.Foundations.Knowledges.IKnowledgeService! knowledgeService, string! toolCatalog, Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker, Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? externalToolCatalog = null) -> void
+override Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.Equals(object? obj) -> bool
+override Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.GetHashCode() -> int
+override Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.ToString() -> string!
+static Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.operator !=(Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? left, Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? right) -> bool
+static Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.operator ==(Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? left, Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? right) -> bool

--- a/Standard.Agents/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationService.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Models.Orchestrations.Retrievals;
 using Standard.Agents.Services.Foundations.Knowledges;
 using Standard.Agents.Services.Foundations.Skills;
 
@@ -19,16 +20,23 @@ public partial class RetrievalOrchestrationService : IRetrievalOrchestrationServ
     private readonly string toolCatalog;
     private readonly ILoggingBroker loggingBroker;
 
+    // A model carrying a delegate rather than a broker, because remote tools are Direction's
+    // resource and this is Data's tier — configuration crosses natures where a dependency may
+    // not. Null when there is nothing remote to advertise.
+    private readonly ExternalToolCatalog? externalToolCatalog;
+
     public RetrievalOrchestrationService(
         ISkillService skillService,
         IKnowledgeService knowledgeService,
         string toolCatalog,
-        ILoggingBroker loggingBroker)
+        ILoggingBroker loggingBroker,
+        ExternalToolCatalog? externalToolCatalog = null)
     {
         this.skillService = skillService;
         this.knowledgeService = knowledgeService;
         this.toolCatalog = toolCatalog;
         this.loggingBroker = loggingBroker;
+        this.externalToolCatalog = externalToolCatalog;
     }
 
     // The catalogs are expanded here rather than in a skill file, because which tools a Brain may
@@ -37,7 +45,7 @@ public partial class RetrievalOrchestrationService : IRetrievalOrchestrationServ
     TryCatch(async () =>
     {
         string skills = await this.skillService.RetrieveSkillsAsync(route);
-        string instructions = skills.Replace(ToolsMarker, this.toolCatalog);
+        string instructions = skills.Replace(ToolsMarker, await RenderToolCatalogAsync(skills));
 
         if (instructions.Contains(SkillsMarker))
         {
@@ -47,6 +55,27 @@ public partial class RetrievalOrchestrationService : IRetrievalOrchestrationServ
 
         return instructions;
     });
+
+    // Remote tools join the catalog under the same opt-in as local ones — and only when the
+    // marker is present, so an agent that never advertises never pays a discovery call.
+    private async ValueTask<string> RenderToolCatalogAsync(string skills)
+    {
+        if (this.externalToolCatalog is null || skills.Contains(ToolsMarker) is false)
+        {
+            return this.toolCatalog;
+        }
+
+        string externalCatalog = await this.externalToolCatalog.DiscoverAsync();
+
+        if (string.IsNullOrEmpty(externalCatalog))
+        {
+            return this.toolCatalog;
+        }
+
+        return string.IsNullOrEmpty(this.toolCatalog)
+            ? externalCatalog
+            : $"{this.toolCatalog}\n{externalCatalog}";
+    }
 
     public ValueTask<IReadOnlyList<string>> RetrieveGroundingAsync(string query) =>
     TryCatch(async () =>

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -1442,11 +1442,45 @@ public sealed partial class StandardAgent : IAgent
                 this.knowledgeMinScore)
             : new KnowledgeService(this.knowledgeBroker, logging);
 
+        // Remote tools advertise beside local ones, under the same opt-in: only tools whose
+        // catalog carries a description are listed. Best-effort and cached on success — a server
+        // down at discovery hides only its own tools this turn, is asked again on the next, and
+        // never fails the run.
+        string? discoveredCatalog = null;
+
+        Models.Orchestrations.Retrievals.ExternalToolCatalog? externalToolCatalog =
+            this.mcpSources.Count is 0
+            ? null
+            : new(async () =>
+            {
+                if (discoveredCatalog is not null)
+                {
+                    return discoveredCatalog;
+                }
+
+                try
+                {
+                    IReadOnlyList<Models.Brokers.Mcps.McpTool> remoteTools =
+                        await mcp.ListToolsAsync();
+
+                    discoveredCatalog = string.Join("\n", remoteTools
+                        .Where(tool => string.IsNullOrWhiteSpace(tool.Description) is false)
+                        .Select(tool => $"- {tool.Name} — {tool.Description} parameters: {{}}"));
+
+                    return discoveredCatalog;
+                }
+                catch
+                {
+                    return string.Empty;
+                }
+            });
+
         // The Data nature, as two regions and the coordination that composes them. Retrieval is
         // authored material selected by relevance; Recollection is what the agent accumulated.
         DataCoordinationService data = new(
             new RetrievalOrchestrationService(
-                skillService, knowledgeService, RenderToolCatalog(allTools), logging),
+                skillService, knowledgeService, RenderToolCatalog(allTools), logging,
+                externalToolCatalog),
             new RecollectionOrchestrationService(
                 memoryService,
                 new SessionService(


### PR DESCRIPTION
### What

Discovery (`tools/list`, #326) already routes calls; now it advertises. Described MCP tools join the `{{tools}}` catalog beside local ones, so the Brain learns remote tools' names and descriptions from the servers themselves rather than from a skill file.

- **The description opt-in holds for remote tools too**: a tool whose catalog entry carries no description stays callable but unlisted — declaring a server does not quietly widen what the Brain may reach for.
- **Best-effort and cached on success**: a server down at discovery hides only its own tools that turn, is asked again the next, and never fails the run. No `{{tools}}` marker, no discovery call at all.
- **Tier discipline, the hard way**: the first cut passed Retrieval a bare delegate and `ShouldHoldNoNakedDelegateInAnyServiceConstructor` rejected it — the same gate the Direction sweep installed. The delegate now rides in a named model, `ExternalToolCatalog` under `Models/Orchestrations/Retrievals`, where its arrival is a reviewed diff: remote tools are Direction's resource, Retrieval is Data's tier, and configuration crosses natures where a dependency may not.

### Why

The one seam left half-open by 1.9.0: multiple servers routed correctly, but the model had to be taught their tool names by hand. Now a low-code `agent.json` that lists MCP servers gets a fully self-describing toolbox.

### Evidence

TDD — `ShouldAdvertiseDescribedMcpToolsInTheCatalogAsync` observed red (catalog was local-only) then green, with the undescribed tool asserted absent; `ShouldStillAnswerWhenAdvertisementDiscoveryFailsAsync` pins the best-effort rule. Full suite 584/584 on net8.0 and net10.0, zero warnings, 44/44 conformance vectors, the widened Retrieval constructor baselined with its old form `*REMOVED*`.