### PR TITLE
[ACCEPTANCE]: Three Vectors Pin The Plural And Data Contracts

### DIFF
--- a/Standard.Agents.Conformance/Brokers/ScriptedMcpServer.cs
+++ b/Standard.Agents.Conformance/Brokers/ScriptedMcpServer.cs
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Mcps;
+using Standard.Agents.Models.Brokers.Mcps;
+
+namespace Standard.Agents.Conformance;
+
+// A remote tool server, scripted: its catalog is the tools the vector gave it, every one
+// described, and every call is counted — routing across servers is certified by the owner
+// being called and the bystander not (SPEC.md §4.8 v1.5).
+public sealed class ScriptedMcpServer : IMcpBroker
+{
+    private readonly Dictionary<string, string> tools;
+    private int callCount;
+
+    public ScriptedMcpServer(Dictionary<string, string> tools) =>
+        this.tools = tools;
+
+    public int CallCount => Volatile.Read(ref this.callCount);
+
+    public async ValueTask<string> CallAsync(string name, string input)
+    {
+        Interlocked.Increment(ref this.callCount);
+
+        return this.tools.TryGetValue(name, out string? reply)
+            ? reply
+            : $"[external '{name}' not configured]";
+    }
+
+    public async ValueTask<IReadOnlyList<McpTool>> ListToolsAsync() =>
+        [.. this.tools.Keys.Select(name => new McpTool(name, $"scripted tool {name}"))];
+}

--- a/Standard.Agents.Conformance/Models/Expectation.cs
+++ b/Standard.Agents.Conformance/Models/Expectation.cs
@@ -84,4 +84,17 @@ public sealed record Expectation(
     //   PolicySawPrincipal — the identity the policy broker was actually handed when it decided.
     //                        An audit record naming the caller afterwards is not authorization,
     //                        so this reads the decision's input rather than the log (SPEC.md §4.9).
-    string? PolicySawPrincipal = null);
+    string? PolicySawPrincipal = null,
+
+    //   McpServerCalls — exactly how many calls each scripted server received, in registration
+    //                    order. Routing across servers is certified by the owner being called
+    //                    and the bystander not (SPEC.md §4.8 v1.5).
+    //   BrainSeesEvery — every entry must have reached the Brain, which is how accumulation is
+    //                    certified: a source silently replaced is a source whose text is absent.
+    List<int>? McpServerCalls = null,
+    List<string>? BrainSeesEvery = null,
+
+    //   ConfigurationRefusalNames — the composition refusal must carry this text: a refusal
+    //                               that does not name the offending entry leaves the host
+    //                               searching the document by hand (SPEC.md §4.8 v1.4).
+    string? ConfigurationRefusalNames = null);

--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -115,4 +115,17 @@ public sealed record Vector(
     // Memories the run recalls (SPEC.md §4.2) — which is also how a POISONED memory is
     // certified: an injected instruction rides the same seam a remembered preference would,
     // and the perimeter must hold whether or not the Brain is fooled by it.
-    List<string>? Memories = null);
+    List<string>? Memories = null,
+
+    // Plural integrations (SPEC.md §4.8 v1.5). McpServers scripts remote tool servers in
+    // REGISTRATION ORDER — each entry is that server's catalog, {toolName: reply} — because
+    // order is the contract: routing is by declared ownership, first registered wins a
+    // contested name. ExtraSkills adds skill sources after the harness's stub, in order,
+    // because accumulation is only observable with more than one source.
+    List<Dictionary<string, string>>? McpServers = null,
+    List<string>? ExtraSkills = null,
+
+    // Composition from data (SPEC.md §4.8 v1.4). When set, the vector certifies composition
+    // alone — the document must refuse with the named text and no run ever happens, so
+    // GeneratorReplies and Prompt are carried empty.
+    string? ConfigurationJson = null);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -9,6 +9,7 @@ using Standard.Agents.Brokers.Approvals;
 using Standard.Agents.Conformance;
 using Standard.Agents.Models.Brokers.Audits;
 using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Foundations.Skills;
 using Standard.Agents.Models.Orchestrations.Effects;
 
 string? profileName = ReadProfileArgument(args);
@@ -45,6 +46,46 @@ foreach (string vectorFile in
 {
     Vector vector =
         JsonSerializer.Deserialize<Vector>(await File.ReadAllTextAsync(vectorFile), jsonOptions)!;
+
+    // Composition-from-data vectors certify the refusal itself: the document must not compose,
+    // and the refusal must name the offending entry (SPEC.md §4.8 v1.4). No run happens.
+    if (vector.ConfigurationJson is string configurationJson)
+    {
+        string? refusal = null;
+
+        try
+        {
+            StandardAgent.FromJson(configurationJson);
+        }
+        catch (Exception exception)
+        {
+            refusal = exception.Message;
+        }
+
+        string requiredNaming = vector.Expect.ConfigurationRefusalNames ?? string.Empty;
+
+        bool refusalConformant = refusal is not null
+            && refusal.Contains(requiredNaming, StringComparison.Ordinal);
+
+        if (refusalConformant)
+        {
+            Console.WriteLine($"PASS  {vector.Name}");
+            passed++;
+            passedVectors.Add(vector.Name);
+        }
+        else
+        {
+            Console.WriteLine($"FAIL  {vector.Name}");
+
+            Console.WriteLine(refusal is null
+                ? "        the document composed; it should have refused"
+                : $"        the refusal does not name {Show(requiredNaming)}: {Show(refusal)}");
+
+            failed++;
+        }
+
+        continue;
+    }
 
     VectorRun run = await RunVectorAsync(vector);
     string actualResult = run.Result;
@@ -203,6 +244,11 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         (vector.ApprovalDecisions ?? []).Select(decision =>
             Enum.Parse<ApprovalDecision>(decision, ignoreCase: true)));
 
+    // Created once per vector so call counts survive instance rebuilds, the way a real
+    // server's would.
+    List<ScriptedMcpServer> scriptedMcpServers =
+        [.. (vector.McpServers ?? []).Select(catalog => new ScriptedMcpServer(catalog))];
+
     Dictionary<string, StubTool> stubTools =
         (vector.Tools ?? []).ToDictionary(
             pair => pair.Key,
@@ -272,7 +318,25 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
             .UseGenerator(recordingGenerator)
             .UseMemory(new StubMemoryBroker(vector.Memories))
             .UseMcp(new NotConfiguredMcpBroker())
-            .Tools(stubTools.Values)
+            .Tools(stubTools.Values);
+
+        // Plural integrations (SPEC.md §4.8 v1.5): scripted servers join in registration order —
+        // the order IS the contract under contention — and each extra skill source accumulates
+        // after the harness's stub through the same client verb a host would use.
+        foreach (ScriptedMcpServer scriptedServer in scriptedMcpServers)
+        {
+            agent.UseMcp(scriptedServer);
+        }
+
+        foreach (string extraSkill in vector.ExtraSkills ?? [])
+        {
+            string content = extraSkill;
+
+            agent.OnSkills(() => new ValueTask<IReadOnlyList<Skill>>(
+                [new Skill { Name = $"extra-{content.GetHashCode():x}", Content = content }]));
+        }
+
+        agent
             .OnGate((rubric, prompt) =>
             {
                 gateRubric ??= rubric;
@@ -534,7 +598,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         }
     }
 
-    return new VectorRun(result, promptResults, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, promptScreenings, auditRecords, compensationOrder, nativeGenerator, policyPrincipals);
+    return new VectorRun(result, promptResults, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, promptScreenings, auditRecords, compensationOrder, nativeGenerator, policyPrincipals, [.. scriptedMcpServers.Select(server => server.CallCount)]);
 }
 
 // The decision log's guarantees, certified from the records themselves: one run per prompt,
@@ -798,6 +862,30 @@ static bool GuardianInputConformant(
         return false;
     }
 
+    // Accumulation is certified by every source's text arriving: a source silently replaced is
+    // a source whose text is absent (SPEC.md §4.8 v1.5).
+    foreach (string requiredFromEverySource in vector.Expect.BrainSeesEvery ?? [])
+    {
+        if (run.BrainInputs.Any(input =>
+            input.Contains(requiredFromEverySource, StringComparison.Ordinal)) is false)
+        {
+            failure = $"the Brain never saw {Show(requiredFromEverySource)} — a source was lost";
+
+            return false;
+        }
+    }
+
+    // Routing is certified by the owner being called and the bystander not (SPEC.md §4.8 v1.5).
+    if (vector.Expect.McpServerCalls is List<int> expectedServerCalls
+        && run.McpServerCalls.SequenceEqual(expectedServerCalls) is false)
+    {
+        failure =
+            $"server calls were [{string.Join(", ", run.McpServerCalls)}], "
+                + $"expected [{string.Join(", ", expectedServerCalls)}]";
+
+        return false;
+    }
+
     if (vector.Expect.GateScreenedPromptTimes is int expectedScreenings
         && run.PromptScreenings != expectedScreenings)
     {
@@ -922,4 +1010,5 @@ internal sealed record VectorRun(
     List<AuditRecord> AuditRecords,
     List<string> CompensationOrder,
     ScriptedNativeGeneratorBroker? NativeGenerator,
-    List<string?> PolicyPrincipals);
+    List<string?> PolicyPrincipals,
+    List<int> McpServerCalls);

--- a/conformance/vectors/45-many-servers-one-owner.json
+++ b/conformance/vectors/45-many-servers-one-owner.json
@@ -1,0 +1,19 @@
+{
+  "name": "many-servers-one-owner",
+  "description": "Two remote tool servers both claim 'alpha'. Routing is by declared ownership with first-registered precedence (SPEC.md 4.8 v1.5): the call lands on the first server, the second is never consulted, and the Brain sees the first server's answer - a second registration must never silently unplug or shadow the first.",
+  "mcpServers": [
+    { "alpha": "42, says the first server" },
+    { "alpha": "42, says the SECOND server", "beta": "unused" }
+  ],
+  "generatorReplies": [
+    "ACTION: alpha: ping",
+    "FINAL: alpha answered."
+  ],
+  "prompt": "use alpha",
+  "expect": {
+    "resultContains": "alpha answered",
+    "brainSees": "42, says the first server",
+    "brainNeverSees": "SECOND",
+    "mcpServerCalls": [1, 0]
+  }
+}

--- a/conformance/vectors/46-many-skill-sources-one-stream.json
+++ b/conformance/vectors/46-many-skill-sources-one-stream.json
@@ -1,0 +1,16 @@
+{
+  "name": "many-skill-sources-one-stream",
+  "description": "Skills arrive from more than one source and concatenate in registration order (SPEC.md 4.8 v1.5). Accumulation is certified by every source's text reaching the Brain: under replace semantics the first source's text is simply absent, which is exactly how a host would have discovered the loss.",
+  "extraSkills": [
+    "ALPHA-RULE: answer tersely.",
+    "BETA-RULE: cite your sources."
+  ],
+  "generatorReplies": [
+    "FINAL: done."
+  ],
+  "prompt": "hello",
+  "expect": {
+    "resultContains": "done",
+    "brainSeesEvery": ["ALPHA-RULE", "BETA-RULE"]
+  }
+}

--- a/conformance/vectors/47-a-typoed-key-refuses-to-compose.json
+++ b/conformance/vectors/47-a-typoed-key-refuses-to-compose.json
@@ -1,0 +1,10 @@
+{
+  "name": "a-typoed-key-refuses-to-compose",
+  "description": "Composition from data (SPEC.md 4.8 v1.4): a document carrying a key the surface does not know MUST refuse to compose, and the refusal MUST name the key - a misspelled budget silently ignored is a bound the host believes is holding and is not. No run happens; the refusal is the certification.",
+  "configurationJson": "{ \"buget\": { \"maxTokens\": 50000 } }",
+  "generatorReplies": [],
+  "prompt": "",
+  "expect": {
+    "configurationRefusalNames": "buget"
+  }
+}


### PR DESCRIPTION
### What

SPEC v1.4/v1.5's newest contracts become language-neutral conformance vectors — what forces the next implementation, in any language, to match:

- **45 `many-servers-one-owner`** — two scripted remote tool servers both claim `alpha`; the call MUST land on the first registered (`mcpServerCalls: [1, 0]`), the Brain MUST see the first server's answer and never the second's.
- **46 `many-skill-sources-one-stream`** — two extra skill sources; every source's text MUST reach the Brain (`brainSeesEvery`), because a source silently replaced is a source whose text is absent.
- **47 `a-typoed-key-refuses-to-compose`** — a configuration document with `"buget"` MUST refuse to compose and the refusal MUST name the key; no run happens — the refusal is the certification.

Runner extensions to carry them: `ScriptedMcpServer` (catalog + call counting), `mcpServers` / `extraSkills` / `configurationJson` vector fields, `mcpServerCalls` / `brainSeesEvery` / `configurationRefusalNames` expectations — all under the existing typo'd-field-fails-loudly deserialization rule.

### Why

A green suite that no longer conforms is worth catching on the PR that breaks it — and a contract only the C# unit tests know is a contract a second-language implementation will miss.

### Evidence

47/47 vectors green, Enterprise profile CERTIFIED, 584/584 unit tests on both TFMs, zero warnings. **Every new vector was proven able to fail** before being trusted to pass: registering the servers in reverse order failed 45; registering only the last skill source (replace semantics) failed 46; swallowing the composition exception (silent-ignore semantics) failed 47 — each sabotage reverted after observation.