### PR TITLE
[CLIENTS]: StandardAgent - Agent Registry Local External And Custom

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Agents.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Agents.cs
@@ -96,6 +96,47 @@ public class StandardAgentAgentsTests
         outerSaw.Should().Contain("Handles refunds and invoices.");
     }
 
+    // The fleet is data like everything else: an "agents" entry is either a folder of agent
+    // documents (a path) or an agent document riding inline — identity included, because the
+    // document IS the agent. A form that can post JSON can post a fleet.
+    [Fact]
+    public async Task ShouldComposeAFleetFromJsonAsync()
+    {
+        // given
+        const string fleet = """
+        {
+          "agents": [
+            { "name": "billing", "description": "Handles refunds and invoices.", "maxTurns": 2 }
+          ]
+        }
+        """;
+
+        string? outerSaw = null;
+
+        StandardAgent outerAgent = StandardAgent.FromJson(fleet)
+            .UseMemory(EmptyMemory())
+            .UseKnowledge(EmptyKnowledge())
+            .OnSkills(() => new ValueTask<IReadOnlyList<Models.Foundations.Skills.Skill>>(
+                [new Models.Foundations.Skills.Skill
+                {
+                    Name = "concierge",
+                    Content = "Hand work to whoever does it best.\n\n{{tools}}"
+                }]))
+            .OnBrain(async (systemPrompt, userPrompt) =>
+            {
+                outerSaw = systemPrompt;
+
+                return "FINAL: nothing to do";
+            });
+
+        // when
+        await outerAgent.ProcessPromptAsync("hello");
+
+        // then — the document's fleet member is advertised exactly as a registered agent is.
+        outerSaw.Should().Contain("billing");
+        outerSaw.Should().Contain("Handles refunds and invoices.");
+    }
+
     private static IMemoryBroker EmptyMemory()
     {
         var memoryBroker = new Mock<IMemoryBroker>();

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Agents.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Agents.cs
@@ -61,7 +61,8 @@ public class StandardAgentAgentsTests
     public async Task ShouldAdvertiseRegisteredAgentsToTheBrainAsync()
     {
         // given — a registry whose agent carries a description, which is the advertisement
-        // opt-in a tool's description already is.
+        // opt-in a tool's description already is, surfaced where every advertisement is
+        // surfaced: a skill's {{tools}} marker.
         StandardAgent specialist = new StandardAgent()
             .UseMemory(EmptyMemory())
             .UseKnowledge(EmptyKnowledge())
@@ -72,6 +73,12 @@ public class StandardAgentAgentsTests
         StandardAgent outerAgent = new StandardAgent()
             .UseMemory(EmptyMemory())
             .UseKnowledge(EmptyKnowledge())
+            .OnSkills(() => new ValueTask<IReadOnlyList<Models.Foundations.Skills.Skill>>(
+                [new Models.Foundations.Skills.Skill
+                {
+                    Name = "concierge",
+                    Content = "Hand work to whoever does it best.\n\n{{tools}}"
+                }]))
             .OnAgents(() => new ValueTask<IReadOnlyList<RegisteredAgent>>(
                 [new RegisteredAgent("billing", "Handles refunds and invoices.", specialist)]))
             .OnBrain(async (systemPrompt, userPrompt) =>

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Agents.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Agents.cs
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Models.Brokers.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+// The fleet: registered agents materialize as tools at composition. That one decision buys
+// everything the framework already knows how to do — the advertisement opt-in, the perimeter,
+// the audit, cancellation across the seam — without a second code path for "agent" beside
+// "tool". A handoff is an act, and the same door governs every act.
+public class StandardAgentAgentsTests
+{
+    [Fact]
+    public async Task ShouldHandOffToARegisteredAgentAsync()
+    {
+        // given — a registered specialist that captures what it was actually handed.
+        string? innerReceived = null;
+
+        StandardAgent billingAgent = new StandardAgent()
+            .UseMemory(EmptyMemory())
+            .UseKnowledge(EmptyKnowledge())
+            .OnBrain(async (systemPrompt, userPrompt) =>
+            {
+                innerReceived = userPrompt;
+
+                return "FINAL: the refund is booked";
+            });
+
+        int turn = 0;
+
+        StandardAgent outerAgent = new StandardAgent()
+            .UseMemory(EmptyMemory())
+            .UseKnowledge(EmptyKnowledge())
+            .OnAgents(() => new ValueTask<IReadOnlyList<RegisteredAgent>>(
+                [new RegisteredAgent("billing", "Handles refunds and invoices.", billingAgent)]))
+            .OnBrain(async (systemPrompt, userPrompt) =>
+                ++turn is 1
+                    ? "ACTION: billing: refund order 7741"
+                    : "FINAL: done — billing booked the refund.");
+
+        // when
+        string answer = await outerAgent.ProcessPromptAsync(
+            "please refund my last order, number 7741");
+
+        // then — the handoff was grounded: the task the outer brain wrote AND the user's
+        // original ask, which is the default sharing ruling (task + just enough context).
+        innerReceived.Should().Contain("refund order 7741");
+        innerReceived.Should().Contain("please refund my last order, number 7741");
+        answer.Should().Contain("billing booked the refund");
+    }
+
+    [Fact]
+    public async Task ShouldAdvertiseRegisteredAgentsToTheBrainAsync()
+    {
+        // given — a registry whose agent carries a description, which is the advertisement
+        // opt-in a tool's description already is.
+        StandardAgent specialist = new StandardAgent()
+            .UseMemory(EmptyMemory())
+            .UseKnowledge(EmptyKnowledge())
+            .OnBrain(async (systemPrompt, userPrompt) => "FINAL: ok");
+
+        string? outerSaw = null;
+
+        StandardAgent outerAgent = new StandardAgent()
+            .UseMemory(EmptyMemory())
+            .UseKnowledge(EmptyKnowledge())
+            .OnAgents(() => new ValueTask<IReadOnlyList<RegisteredAgent>>(
+                [new RegisteredAgent("billing", "Handles refunds and invoices.", specialist)]))
+            .OnBrain(async (systemPrompt, userPrompt) =>
+            {
+                outerSaw = systemPrompt;
+
+                return "FINAL: nothing to do";
+            });
+
+        // when
+        await outerAgent.ProcessPromptAsync("hello");
+
+        // then — the brain can only hand off to an agent it was told exists.
+        outerSaw.Should().Contain("billing");
+        outerSaw.Should().Contain("Handles refunds and invoices.");
+    }
+
+    private static IMemoryBroker EmptyMemory()
+    {
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        return memoryBroker.Object;
+    }
+
+    private static IKnowledgeBroker EmptyKnowledge()
+    {
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return knowledgeBroker.Object;
+    }
+}

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Capabilities.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Capabilities.cs
@@ -77,6 +77,11 @@ public class StandardAgentCapabilityTests
 
         new("Contract", Local: "Contract", External: "UseContract", Custom: "OnContract"),
 
+        // The fleet: other agents, reachable as a registry the way every resource is — a local
+        // folder of agent documents, a provider's registry, or a delegate. A registered agent
+        // materializes as a tool, so the perimeter that governs acts governs handoffs.
+        new("Agents", Local: "Agents", External: "UseAgents", Custom: "OnAgents"),
+
         // Found missing in the 2026-08-23 sweep: a full capability nature — its own broker
         // seam, four decorators, a rule-backed default — absent from this matrix entirely, with
         // one mode on the client (.Redact(), hardcoded to the default rules), no waiver, and no

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
@@ -97,6 +97,8 @@ public class StandardAgentFromJsonTests
         // given
         const string everything = """
         {
+          "name": "concierge",
+          "description": "Answers anything, hands off what it should not answer.",
           "brain": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "LLooMA2.0",
                      "temperature": 0.2, "maxTokens": 512, "timeoutSeconds": 60 },
           "nativeBrain": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "m" },

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
@@ -51,6 +51,21 @@ public class StandardAgentFromJsonTests
         answer.Should().Contain("ran out of turns");
     }
 
+    // Identity is what makes an agent document registrable: the name a handoff calls, the
+    // description that advertises it. They ride in the document itself, so the file IS the
+    // agent — a registry needs nothing beside it.
+    [Fact]
+    public void ShouldComposeAgentIdentityFromJson()
+    {
+        // given . when
+        StandardAgent agent = StandardAgent.FromJson(
+            """{ "name": "billing", "description": "Handles refunds and invoices." }""");
+
+        // then
+        agent.Name.Should().Be("billing");
+        agent.Description.Should().Be("Handles refunds and invoices.");
+    }
+
     [Fact]
     public void ShouldRejectAnUnknownConfigurationKey()
     {

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
@@ -79,6 +79,19 @@ public class StandardAgentFromJsonTests
     }
 
     [Fact]
+    public void ShouldRejectANamelessInlineFleetMember()
+    {
+        // given . when — an inline fleet member with no name is an agent no handoff could
+        // ever call, so it refuses to compose rather than registering an unreachable agent.
+        Action composing = () =>
+            StandardAgent.FromJson("""{ "agents": [ { "maxTurns": 2 } ] }""");
+
+        // then
+        composing.Should().Throw<InvalidAgentConfigurationException>()
+            .WithMessage("*agents*name*");
+    }
+
+    [Fact]
     public void ShouldRejectMalformedConfigurationJson()
     {
         // given . when

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
@@ -124,6 +124,10 @@ public class StandardAgentFromJsonTests
             { "endpointUrl": "https://locked.example/", "timeoutSeconds": 20,
               "bearerToken": "token", "apiKey": "key", "apiKeyHeader": "X-Api-Key" }
           ],
+          "agents": [
+            "Fleet",
+            { "name": "billing", "description": "Handles refunds and invoices.", "maxTurns": 2 }
+          ],
           "gate": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "m" },
           "ruleGate": ["password", "ssn"],
           "judge": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "m" },

--- a/Standard.Agents/Brokers/Agents/FileAgentRegistryBroker.cs
+++ b/Standard.Agents/Brokers/Agents/FileAgentRegistryBroker.cs
@@ -3,7 +3,6 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
-using System.Text.Json.Nodes;
 using Standard.Agents.Models.Brokers.Agents;
 
 namespace Standard.Agents.Brokers.Agents;
@@ -34,14 +33,15 @@ public sealed class FileAgentRegistryBroker : IAgentRegistryBroker
             .EnumerateFiles(this.agentsPath, "*.json")
             .OrderBy(path => path, StringComparer.Ordinal))
         {
-            string document = await File.ReadAllTextAsync(documentPath);
-            JsonNode? identity = JsonNode.Parse(document);
+            StandardAgent composed =
+                StandardAgent.FromJson(await File.ReadAllTextAsync(documentPath));
 
             agents.Add(new RegisteredAgent(
-                Name: identity?["name"]?.GetValue<string>()
-                    ?? Path.GetFileNameWithoutExtension(documentPath),
-                Description: identity?["description"]?.GetValue<string>() ?? string.Empty,
-                Agent: StandardAgent.FromJson(document)));
+                Name: string.IsNullOrWhiteSpace(composed.Name)
+                    ? Path.GetFileNameWithoutExtension(documentPath)
+                    : composed.Name,
+                Description: composed.Description,
+                Agent: composed));
         }
 
         return agents;

--- a/Standard.Agents/Brokers/Agents/FileAgentRegistryBroker.cs
+++ b/Standard.Agents/Brokers/Agents/FileAgentRegistryBroker.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.Json.Nodes;
+using Standard.Agents.Models.Brokers.Agents;
+
+namespace Standard.Agents.Brokers.Agents;
+
+/// <summary>
+/// The Local mode of the fleet seam: a folder where every <c>.json</c> document is an agent
+/// (the same documents <c>StandardAgent.FromJson</c> composes), read in path order. A document's
+/// <c>name</c> names the agent (the file's own name when absent) and its <c>description</c>
+/// advertises it — no description, no advertisement, exactly like a tool.
+/// </summary>
+public sealed class FileAgentRegistryBroker : IAgentRegistryBroker
+{
+    private readonly string agentsPath;
+
+    public FileAgentRegistryBroker(string agentsPath) =>
+        this.agentsPath = agentsPath;
+
+    public async ValueTask<IReadOnlyList<RegisteredAgent>> SelectAgentsAsync()
+    {
+        if (Directory.Exists(this.agentsPath) is false)
+        {
+            return [];
+        }
+
+        List<RegisteredAgent> agents = [];
+
+        foreach (string documentPath in Directory
+            .EnumerateFiles(this.agentsPath, "*.json")
+            .OrderBy(path => path, StringComparer.Ordinal))
+        {
+            string document = await File.ReadAllTextAsync(documentPath);
+            JsonNode? identity = JsonNode.Parse(document);
+
+            agents.Add(new RegisteredAgent(
+                Name: identity?["name"]?.GetValue<string>()
+                    ?? Path.GetFileNameWithoutExtension(documentPath),
+                Description: identity?["description"]?.GetValue<string>() ?? string.Empty,
+                Agent: StandardAgent.FromJson(document)));
+        }
+
+        return agents;
+    }
+}

--- a/Standard.Agents/Brokers/Agents/FunctionAgentRegistryBroker.cs
+++ b/Standard.Agents/Brokers/Agents/FunctionAgentRegistryBroker.cs
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Agents;
+
+namespace Standard.Agents.Brokers.Agents;
+
+/// <summary>
+/// The Custom mode of the fleet seam: your own code decides which agents exist, per selection —
+/// a database of tenants' agents, a feature flag, a directory service.
+/// </summary>
+public sealed class FunctionAgentRegistryBroker : IAgentRegistryBroker
+{
+    private readonly Func<ValueTask<IReadOnlyList<RegisteredAgent>>> select;
+
+    public FunctionAgentRegistryBroker(
+        Func<ValueTask<IReadOnlyList<RegisteredAgent>>> select) =>
+        this.select = select;
+
+    public ValueTask<IReadOnlyList<RegisteredAgent>> SelectAgentsAsync() =>
+        this.select();
+}

--- a/Standard.Agents/Brokers/Agents/IAgentRegistryBroker.cs
+++ b/Standard.Agents/Brokers/Agents/IAgentRegistryBroker.cs
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Brokers.Agents;
+
+namespace Standard.Agents.Brokers.Agents;
+
+/// <summary>
+/// The fleet seam: where other agents come from — a folder of agent documents, a provider's
+/// registry, a delegate. Registered agents materialize as tools, so a handoff is an act and
+/// the perimeter that governs acts governs handoffs.
+/// </summary>
+public interface IAgentRegistryBroker
+{
+    ValueTask<IReadOnlyList<RegisteredAgent>> SelectAgentsAsync();
+}

--- a/Standard.Agents/Models/Brokers/Agents/RegisteredAgent.cs
+++ b/Standard.Agents/Models/Brokers/Agents/RegisteredAgent.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Brokers.Agents;
+
+/// <summary>
+/// One agent a registry offers: the name a handoff must use, the description that advertises it
+/// (the same opt-in a tool's description is — no description, no advertisement), and the agent
+/// itself, already composed by whoever registered it.
+/// </summary>
+public sealed record RegisteredAgent(string Name, string Description, IAgent Agent);

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,5 +1,24 @@
 #nullable enable
 *REMOVED*Standard.Agents.Services.Orchestrations.Data.Retrievals.RetrievalOrchestrationService.RetrievalOrchestrationService(Standard.Agents.Services.Foundations.Skills.ISkillService! skillService, Standard.Agents.Services.Foundations.Knowledges.IKnowledgeService! knowledgeService, string! toolCatalog, Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker) -> void
+Standard.Agents.Brokers.Agents.FileAgentRegistryBroker
+Standard.Agents.Brokers.Agents.FileAgentRegistryBroker.FileAgentRegistryBroker(string! agentsPath) -> void
+Standard.Agents.Brokers.Agents.FileAgentRegistryBroker.SelectAgentsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Agents.RegisteredAgent!>!>
+Standard.Agents.Brokers.Agents.FunctionAgentRegistryBroker
+Standard.Agents.Brokers.Agents.FunctionAgentRegistryBroker.FunctionAgentRegistryBroker(System.Func<System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Agents.RegisteredAgent!>!>>! select) -> void
+Standard.Agents.Brokers.Agents.FunctionAgentRegistryBroker.SelectAgentsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Agents.RegisteredAgent!>!>
+Standard.Agents.Brokers.Agents.IAgentRegistryBroker
+Standard.Agents.Brokers.Agents.IAgentRegistryBroker.SelectAgentsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Agents.RegisteredAgent!>!>
+Standard.Agents.Models.Brokers.Agents.RegisteredAgent
+Standard.Agents.Models.Brokers.Agents.RegisteredAgent.<Clone>$() -> Standard.Agents.Models.Brokers.Agents.RegisteredAgent!
+Standard.Agents.Models.Brokers.Agents.RegisteredAgent.Agent.get -> Standard.Agents.IAgent!
+Standard.Agents.Models.Brokers.Agents.RegisteredAgent.Agent.init -> void
+Standard.Agents.Models.Brokers.Agents.RegisteredAgent.Deconstruct(out string! Name, out string! Description, out Standard.Agents.IAgent! Agent) -> void
+Standard.Agents.Models.Brokers.Agents.RegisteredAgent.Description.get -> string!
+Standard.Agents.Models.Brokers.Agents.RegisteredAgent.Description.init -> void
+Standard.Agents.Models.Brokers.Agents.RegisteredAgent.Equals(Standard.Agents.Models.Brokers.Agents.RegisteredAgent? other) -> bool
+Standard.Agents.Models.Brokers.Agents.RegisteredAgent.Name.get -> string!
+Standard.Agents.Models.Brokers.Agents.RegisteredAgent.Name.init -> void
+Standard.Agents.Models.Brokers.Agents.RegisteredAgent.RegisteredAgent(string! Name, string! Description, Standard.Agents.IAgent! Agent) -> void
 Standard.Agents.Models.Loggings.AgentRun.Prompt.get -> string!
 Standard.Agents.Models.Loggings.AgentRun.Prompt.set -> void
 Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog
@@ -10,8 +29,16 @@ Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.DiscoverAsy
 Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.Equals(Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? other) -> bool
 Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.ExternalToolCatalog(System.Func<System.Threading.Tasks.ValueTask<string!>>! DiscoverAsync) -> void
 Standard.Agents.Services.Orchestrations.Data.Retrievals.RetrievalOrchestrationService.RetrievalOrchestrationService(Standard.Agents.Services.Foundations.Skills.ISkillService! skillService, Standard.Agents.Services.Foundations.Knowledges.IKnowledgeService! knowledgeService, string! toolCatalog, Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker, Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? externalToolCatalog = null) -> void
+Standard.Agents.StandardAgent.Agents(string! path) -> Standard.Agents.StandardAgent!
+Standard.Agents.StandardAgent.OnAgents(System.Func<System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Agents.RegisteredAgent!>!>>! select) -> Standard.Agents.StandardAgent!
+Standard.Agents.StandardAgent.UseAgents(Standard.Agents.Brokers.Agents.IAgentRegistryBroker! broker) -> Standard.Agents.StandardAgent!
+override Standard.Agents.Models.Brokers.Agents.RegisteredAgent.Equals(object? obj) -> bool
+override Standard.Agents.Models.Brokers.Agents.RegisteredAgent.GetHashCode() -> int
+override Standard.Agents.Models.Brokers.Agents.RegisteredAgent.ToString() -> string!
 override Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.Equals(object? obj) -> bool
 override Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.GetHashCode() -> int
 override Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.ToString() -> string!
+static Standard.Agents.Models.Brokers.Agents.RegisteredAgent.operator !=(Standard.Agents.Models.Brokers.Agents.RegisteredAgent? left, Standard.Agents.Models.Brokers.Agents.RegisteredAgent? right) -> bool
+static Standard.Agents.Models.Brokers.Agents.RegisteredAgent.operator ==(Standard.Agents.Models.Brokers.Agents.RegisteredAgent? left, Standard.Agents.Models.Brokers.Agents.RegisteredAgent? right) -> bool
 static Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.operator !=(Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? left, Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? right) -> bool
 static Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.operator ==(Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? left, Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? right) -> bool

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -35,6 +35,7 @@ Standard.Agents.StandardAgent.Identity(string! name, string! description = "") -
 Standard.Agents.StandardAgent.Name.get -> string!
 Standard.Agents.StandardAgent.OnAgents(System.Func<System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Agents.RegisteredAgent!>!>>! select) -> Standard.Agents.StandardAgent!
 Standard.Agents.StandardAgent.UseAgents(Standard.Agents.Brokers.Agents.IAgentRegistryBroker! broker) -> Standard.Agents.StandardAgent!
+const Standard.Agents.Tools.AgentTool.GroundedHandoff = "The user asked: {prompt}\n\nYour task: {input}" -> string!
 override Standard.Agents.Models.Brokers.Agents.RegisteredAgent.Equals(object? obj) -> bool
 override Standard.Agents.Models.Brokers.Agents.RegisteredAgent.GetHashCode() -> int
 override Standard.Agents.Models.Brokers.Agents.RegisteredAgent.ToString() -> string!

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -30,6 +30,9 @@ Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.Equals(Stan
 Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.ExternalToolCatalog(System.Func<System.Threading.Tasks.ValueTask<string!>>! DiscoverAsync) -> void
 Standard.Agents.Services.Orchestrations.Data.Retrievals.RetrievalOrchestrationService.RetrievalOrchestrationService(Standard.Agents.Services.Foundations.Skills.ISkillService! skillService, Standard.Agents.Services.Foundations.Knowledges.IKnowledgeService! knowledgeService, string! toolCatalog, Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker, Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? externalToolCatalog = null) -> void
 Standard.Agents.StandardAgent.Agents(string! path) -> Standard.Agents.StandardAgent!
+Standard.Agents.StandardAgent.Description.get -> string!
+Standard.Agents.StandardAgent.Identity(string! name, string! description = "") -> Standard.Agents.StandardAgent!
+Standard.Agents.StandardAgent.Name.get -> string!
 Standard.Agents.StandardAgent.OnAgents(System.Func<System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Agents.RegisteredAgent!>!>>! select) -> Standard.Agents.StandardAgent!
 Standard.Agents.StandardAgent.UseAgents(Standard.Agents.Brokers.Agents.IAgentRegistryBroker! broker) -> Standard.Agents.StandardAgent!
 override Standard.Agents.Models.Brokers.Agents.RegisteredAgent.Equals(object? obj) -> bool

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -68,6 +68,19 @@ public partial class StandardAgent
     {
         switch (key)
         {
+            // Identity rides in the document, so the file IS the agent: a registry reads the
+            // name a handoff calls and the description that advertises it from the same JSON
+            // that composes it. Each key preserves the other, so their order cannot matter.
+            case "name":
+                agent.Identity(Text(value, key), agent.Description);
+
+                break;
+
+            case "description":
+                agent.Identity(agent.Name, Text(value, key));
+
+                break;
+
             case "brain":
                 agent.Brain(
                     Text(value, key, "apiUrl"),

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -5,6 +5,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Standard.Agents.Models.Brokers.Agents;
 using Standard.Agents.Models.Clients.Agents.Exceptions;
 using Standard.Agents.Models.Foundations.Brains;
 using Standard.Agents.Models.Loggings;
@@ -153,6 +154,19 @@ public partial class StandardAgent
 
             case "mcp":
                 ApplyMcpServer(agent, value, key);
+
+                break;
+
+            case "agents" when value is JsonArray fleet:
+                foreach (JsonNode? member in fleet)
+                {
+                    ApplyFleetMember(agent, member, key);
+                }
+
+                break;
+
+            case "agents":
+                agent.Agents(Text(value, key));
 
                 break;
 
@@ -345,6 +359,33 @@ public partial class StandardAgent
                         + "control you believe is on and is not, so it refuses to compose. "
                         + "The keys are the builder verbs, camelCased — see docs/how-to.md.");
         }
+    }
+
+    // A fleet member is a path when the agents live beside the process (a folder of agent
+    // documents), an object when the agent rides inline — the same document FromJson composes,
+    // identity included, because the document IS the agent. An inline member must be named: a
+    // handoff calls agents by name, and a nameless agent is one the brain could never call.
+    private static void ApplyFleetMember(StandardAgent agent, JsonNode? member, string key)
+    {
+        if (member is JsonObject)
+        {
+            StandardAgent composed = FromJson(member.ToJsonString());
+
+            if (string.IsNullOrWhiteSpace(composed.Name))
+            {
+                throw new InvalidAgentConfigurationException(
+                    $"An inline '{key}' entry needs a 'name' — a handoff calls agents by name.");
+            }
+
+            IReadOnlyList<RegisteredAgent> one =
+                [new RegisteredAgent(composed.Name, composed.Description, composed)];
+
+            agent.OnAgents(() => new ValueTask<IReadOnlyList<RegisteredAgent>>(one));
+
+            return;
+        }
+
+        agent.Agents(Text(member, key));
     }
 
     // A server is a URL when it needs nothing else, an object when it carries auth — an API key

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -820,6 +820,30 @@ public sealed partial class StandardAgent : IAgent
     public StandardAgent OnAgents(Func<ValueTask<IReadOnlyList<RegisteredAgent>>> select) =>
         Set(() => this.agentSources.Add(new FunctionAgentRegistryBroker(select)));
 
+    /// <summary>What this agent is called — the name a registry offers it under, which is the
+    /// name a handoff calls. Empty until <see cref="Identity"/> or a document's <c>name</c> key
+    /// says otherwise.</summary>
+    public string Name { get; private set; } = string.Empty;
+
+    /// <summary>What this agent is for — the advertisement a registry shows an outer brain.
+    /// Empty means unadvertised, exactly like a tool without a description.</summary>
+    public string Description { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Names the agent and says what it is for. Identity is what makes an agent registrable:
+    /// the name a handoff calls, and the description that advertises it to an outer brain —
+    /// no description, no advertisement, the same opt-in a tool's description is.
+    /// </summary>
+    /// <param name="name">The name a registry offers this agent under.</param>
+    /// <param name="description">What it does and when to hand work to it.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent Identity(string name, string description = "") =>
+        Set(() =>
+        {
+            this.Name = name;
+            this.Description = description;
+        });
+
     /// <summary>
     /// Swaps in a custom generator (brain) broker — the extension point for a runtime that streams
     /// natively, an alternative to <see cref="Brain"/> or <see cref="LocalBrain"/>.

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -1000,7 +1000,7 @@ public sealed partial class StandardAgent : IAgent
     // be hit at the assignment, nowhere near the await they were guarding.
     public async ValueTask<string> ProcessPromptAsync(string prompt)
     {
-        return await ResolveAgent().ProcessPromptAsync(prompt);
+        return await (await ResolveAgentAsync()).ProcessPromptAsync(prompt);
     }
 
     /// <summary>
@@ -1016,7 +1016,7 @@ public sealed partial class StandardAgent : IAgent
     /// <param name="prompt">What to work on.</param>
     /// <returns>The answer, and how the run ended.</returns>
     public async ValueTask<AgentOutcome> RunAsync(string prompt) =>
-        await ResolveAgent().RunAsync(prompt, string.Empty, CancellationToken.None);
+        await (await ResolveAgentAsync()).RunAsync(prompt, string.Empty, CancellationToken.None);
 
     /// <summary>
     /// The same run, stoppable: cancellation stops it at the next turn boundary, so no effect
@@ -1030,7 +1030,7 @@ public sealed partial class StandardAgent : IAgent
     public async ValueTask<AgentOutcome> RunAsync(
         string prompt,
         CancellationToken cancellationToken) =>
-        await ResolveAgent().RunAsync(prompt, string.Empty, cancellationToken);
+        await (await ResolveAgentAsync()).RunAsync(prompt, string.Empty, cancellationToken);
 
     /// <summary>
     /// Runs the agent on a prompt and stops when <paramref name="cancellationToken"/> is
@@ -1044,7 +1044,7 @@ public sealed partial class StandardAgent : IAgent
         string prompt,
         CancellationToken cancellationToken)
     {
-        return await ResolveAgent().ProcessPromptAsync(prompt, cancellationToken);
+        return await (await ResolveAgentAsync()).ProcessPromptAsync(prompt, cancellationToken);
     }
 
     /// <summary>
@@ -1068,7 +1068,8 @@ public sealed partial class StandardAgent : IAgent
         string sessionId,
         CancellationToken cancellationToken = default)
     {
-        return await ResolveAgent().ProcessPromptAsync(prompt, sessionId, cancellationToken);
+        return await (await ResolveAgentAsync())
+            .ProcessPromptAsync(prompt, sessionId, cancellationToken);
     }
 
     /// <summary>
@@ -1099,7 +1100,8 @@ public sealed partial class StandardAgent : IAgent
         string answer,
         CancellationToken cancellationToken = default)
     {
-        return await ResolveAgent().ProcessPromptAsync(answer, sessionId, cancellationToken);
+        return await (await ResolveAgentAsync())
+            .ProcessPromptAsync(answer, sessionId, cancellationToken);
     }
 
     /// <summary>
@@ -1313,7 +1315,7 @@ public sealed partial class StandardAgent : IAgent
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         IAsyncEnumerable<AgentStreamEvent> events =
-            ResolveAgent().ProcessPromptStreamAsync(prompt, cancellationToken);
+            (await ResolveAgentAsync()).ProcessPromptStreamAsync(prompt, cancellationToken);
 
         await foreach (AgentStreamEvent streamEvent in events.WithCancellation(cancellationToken))
         {
@@ -1339,8 +1341,8 @@ public sealed partial class StandardAgent : IAgent
         string sessionId,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        IAsyncEnumerable<AgentStreamEvent> events =
-            ResolveAgent().ProcessPromptStreamAsync(prompt, sessionId, cancellationToken);
+        IAsyncEnumerable<AgentStreamEvent> events = (await ResolveAgentAsync())
+            .ProcessPromptStreamAsync(prompt, sessionId, cancellationToken);
 
         await foreach (AgentStreamEvent streamEvent in events.WithCancellation(cancellationToken))
         {
@@ -1351,11 +1353,35 @@ public sealed partial class StandardAgent : IAgent
     // Composes once and reuses. Guarded because one agent serves prompts concurrently
     // (SPEC.md §4.4) and an unguarded `??=` lets two arriving prompts each build a graph —
     // two brokers over one audit sink, two of everything, one silently discarded.
-    private IRunManagementService ResolveAgent()
+    //
+    // Registry selection is async (a registry can be a service call away) and a lock cannot
+    // hold an await, so resolution is three steps: reuse under the lock, select outside it,
+    // compose under it again. A builder call landing between the steps nulls the cache, so
+    // the very next resolution selects and composes afresh — nothing configured is lost.
+    private async ValueTask<IRunManagementService> ResolveAgentAsync()
     {
+        IAgentRegistryBroker[] registries;
+
         lock (this.compositionLock)
         {
-            return this.agent ??= Compose();
+            if (this.agent is not null)
+            {
+                return this.agent;
+            }
+
+            registries = [.. this.agentSources];
+        }
+
+        List<RegisteredAgent> registeredAgents = [];
+
+        foreach (IAgentRegistryBroker registry in registries)
+        {
+            registeredAgents.AddRange(await registry.SelectAgentsAsync());
+        }
+
+        lock (this.compositionLock)
+        {
+            return this.agent ??= Compose(registeredAgents);
         }
     }
 
@@ -1397,7 +1423,7 @@ public sealed partial class StandardAgent : IAgent
     private static string ComposeGuardianRubric(params string[] parts) =>
         string.Join("\n\n", parts.Where(part => string.IsNullOrWhiteSpace(part) is false));
 
-    private IRunManagementService Compose()
+    private IRunManagementService Compose(IReadOnlyList<RegisteredAgent> registeredAgents)
     {
         ValidateComposition();
 
@@ -1435,6 +1461,27 @@ public sealed partial class StandardAgent : IAgent
             : new MemoryService(this.memoryBroker, logging);
 
         List<ITool> allTools = [.. this.tools, new RememberTool(memoryService.RememberAsync)];
+
+        // The fleet materializes as tools — which is the whole design: a handoff is an act, so
+        // the advertisement opt-in, the perimeter, the audit and cancellation across the seam
+        // all apply because they already applied to tools. First to claim a name keeps it, the
+        // rule MCP servers live by, so a registry cannot shadow a tool the host wired in code.
+        HashSet<string> claimedNames =
+            new(allTools.Select(tool => tool.Name), StringComparer.OrdinalIgnoreCase);
+
+        foreach (RegisteredAgent registered in registeredAgents)
+        {
+            if (claimedNames.Add(registered.Name) is false)
+            {
+                continue;
+            }
+
+            allTools.Add(new AgentTool(
+                registered.Name,
+                registered.Agent,
+                AgentTool.GroundedHandoff,
+                registered.Description));
+        }
 
         string constitution = ReadOptionalFile(file, this.constitutionPath);
         string consumption = ReadOptionalFile(file, this.consumptionPath);

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using Lock = System.Object;
 #endif
 using Microsoft.Extensions.Logging.Abstractions;
+using Standard.Agents.Brokers.Agents;
 using Standard.Agents.Brokers.Audits;
 using Standard.Agents.Brokers.Approvals;
 using Standard.Agents.Brokers.Classifiers;
@@ -31,6 +32,7 @@ using Standard.Agents.Brokers.Telemetries;
 using Standard.Agents.Brokers.Times;
 using Standard.Agents.Brokers.Tools;
 using Standard.Agents.Brokers.Verifiers;
+using Standard.Agents.Models.Brokers.Agents;
 using Standard.Agents.Models.Brokers.Audits;
 using Standard.Agents.Models.Brokers.Generators.V1;
 using Standard.Agents.Models.Brokers.Sessions;
@@ -80,6 +82,10 @@ public sealed partial class StandardAgent : IAgent
     // agent the way a second .Tool() always has.
     private readonly List<ISkillBroker> skillSources = [];
     private readonly List<IMcpBroker> mcpSources = [];
+
+    // The fleet accumulates too: each registry is one more place agents come from, and every
+    // registered agent materializes as a tool at composition.
+    private readonly List<IAgentRegistryBroker> agentSources = [];
 
     private string constitutionPath = string.Empty;
     private string consumptionPath = string.Empty;
@@ -780,6 +786,39 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent OnSkills(Func<ValueTask<IReadOnlyList<Skill>>> select) =>
         Set(() => this.skillSources.Add(new FunctionSkillBroker(select)));
+
+    /// <summary>
+    /// Points the agent at a folder of agent documents — the <b>Local</b> mode of the fleet
+    /// (SPEC.md §4.8). Every <c>.json</c> file in the folder is an agent (the same documents
+    /// <see cref="FromJson"/> composes), and each one materializes as a tool the brain can hand
+    /// work to: advertised by its <c>description</c>, called by its <c>name</c>, and governed by
+    /// the same perimeter every act crosses.
+    /// </summary>
+    /// <param name="path">Folder of agent documents, relative to the build output.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    /// <remarks>Registries accumulate: a second call adds another folder, and the first source
+    /// to claim a name keeps it — exactly the rule MCP servers already live by.</remarks>
+    public StandardAgent Agents(string path) =>
+        Set(() => this.agentSources.Add(
+            new FileAgentRegistryBroker(Path.Combine(AppContext.BaseDirectory, path))));
+
+    /// <summary>
+    /// Adds an agent registry broker — the <b>External</b> mode: a provider package that knows
+    /// where agents live (a directory service, a control plane, another team's fleet).
+    /// </summary>
+    /// <param name="broker">The registry broker to add.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent UseAgents(IAgentRegistryBroker broker) =>
+        Set(() => this.agentSources.Add(broker));
+
+    /// <summary>
+    /// Supplies registered agents from your own code — the <b>Custom</b> mode: a delegate that
+    /// answers with the fleet, however your host stores it.
+    /// </summary>
+    /// <param name="select">A <c>() =&gt; registered agents</c> delegate.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent OnAgents(Func<ValueTask<IReadOnlyList<RegisteredAgent>>> select) =>
+        Set(() => this.agentSources.Add(new FunctionAgentRegistryBroker(select)));
 
     /// <summary>
     /// Swaps in a custom generator (brain) broker — the extension point for a runtime that streams

--- a/Standard.Agents/Tools/AgentTool.cs
+++ b/Standard.Agents/Tools/AgentTool.cs
@@ -13,6 +13,13 @@ public sealed class AgentTool : ITool
     private const string InputPlaceholder = "{input}";
     private const string PromptPlaceholder = "{prompt}";
 
+    /// <summary>
+    /// The registry's default handoff: the task the outer brain wrote, grounded in what the
+    /// user originally asked — enough context to do the task, and nothing else. A custom
+    /// template replaces it wholesale, which is the whole configurability of a handoff.
+    /// </summary>
+    public const string GroundedHandoff = "The user asked: {prompt}\n\nYour task: {input}";
+
     private readonly IAgent agent;
     private readonly string handoff;
 


### PR DESCRIPTION
## The fleet, reached like everything else

Other agents are now a capability the matrix enforces — reachable three ways, exactly like OnBrain / LocalBrain / ExternalBrain:

| Mode | Verb | What it is |
|---|---|---|
| Local | `.Agents("Fleet")` | A folder where every `.json` document is an agent — the same documents `FromJson` composes |
| External | `.UseAgents(broker)` | An `IAgentRegistryBroker` from a provider package — a directory service, a control plane, another team's fleet |
| Custom | `.OnAgents(() => ...)` | A delegate that answers with the fleet, however the host stores it |

Registries accumulate like every other integration source, and the first source to claim a name keeps it — the rule MCP servers already live by.

## One design decision buys everything

A registered agent **materializes as an `AgentTool`** at composition. That single decision means the fleet inherits every control that already governs acts, with no second code path:

- **Advertisement**: a registered agent's description surfaces in `{{tools}}` under the same opt-in a tool's description is — no description, no advertisement.
- **Perimeter**: a handoff is an act, so permissions, allow-lists, approvals and risk govern it unchanged.
- **Grounded handoff by default**: each registered agent is handed `AgentTool.GroundedHandoff` — `"The user asked: {prompt}\n\nYour task: {input}"` — the task, plus just enough context to do it.
- **Cancellation**: the outer run's token already crosses the `AgentTool` seam.

## Identity rides in the document

`"name"` and `"description"` are now document keys (and an `.Identity(name, description)` verb), so the file IS the agent — a registry needs nothing beside it. `FileAgentRegistryBroker` falls back to the file's own name when a document is unnamed.

## The fleet is data

```json
{
  "agents": [
    "Fleet",
    { "name": "billing", "description": "Handles refunds and invoices.", "maxTurns": 2 }
  ]
}
```

A member is a path (a folder of agent documents) or an inline agent document, identity included. A nameless inline member refuses to compose — a handoff calls agents by name, and a nameless agent is one the brain could never call.

## Discipline

- Registry selection is async (a registry can be a service call away), so `ResolveAgent` became `ResolveAgentAsync`: reuse under the lock, select outside it, compose under it again.
- TDD throughout — four FAIL → PASS pairs, matrix row first.
- 593 unit tests green on net8.0 and net10.0; all 47 conformance vectors pass; zero warnings; Public API baseline updated.