### PR TITLE
[ACCEPTANCE]: Conformance - Fleet Vectors 48-51

### DIFF
--- a/Standard.Agents.Conformance/Models/Expectation.cs
+++ b/Standard.Agents.Conformance/Models/Expectation.cs
@@ -97,4 +97,9 @@ public sealed record Expectation(
     //   ConfigurationRefusalNames — the composition refusal must carry this text: a refusal
     //                               that does not name the offending entry leaves the host
     //                               searching the document by hand (SPEC.md §4.8 v1.4).
-    string? ConfigurationRefusalNames = null);
+    string? ConfigurationRefusalNames = null,
+
+    //   AgentInput — each named fleet agent must have RECEIVED a handoff containing this text,
+    //                which is how grounding is certified (SPEC.md §4.8 v1.6): the specialist
+    //                saw the user's actual ask (or the transfer's task), not the task alone.
+    Dictionary<string, string>? AgentInput = null);

--- a/Standard.Agents.Conformance/Models/FleetAgent.cs
+++ b/Standard.Agents.Conformance/Models/FleetAgent.cs
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Conformance;
+
+// One scripted specialist in the vector's fleet (SPEC.md §4.8 v1.6): the name a handoff calls,
+// the description that advertises it, and a scripted brain of its own — so a handoff and a
+// transfer can be certified without a network. RuleGate arms the specialist's own deterministic
+// gate, which is how a specialist that REFUSES is scripted: the refusal is real, produced by
+// the same control a host would configure.
+[System.Text.Json.Serialization.JsonUnmappedMemberHandling(
+    System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow)]
+public sealed record FleetAgent(
+    string Name,
+    string Description,
+    List<string> Replies,
+    List<string>? RuleGate = null);

--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -128,4 +128,9 @@ public sealed record Vector(
     // Composition from data (SPEC.md §4.8 v1.4). When set, the vector certifies composition
     // alone — the document must refuse with the named text and no run ever happens, so
     // GeneratorReplies and Prompt are carried empty.
-    string? ConfigurationJson = null);
+    string? ConfigurationJson = null,
+
+    // The fleet (SPEC.md §4.8 v1.6). Each entry is a registered agent the outer agent may hand
+    // work to — or transfer the whole run to — with a scripted brain of its own, created once
+    // per vector so its script keeps its place across instance rebuilds.
+    List<FleetAgent>? Agents = null);

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Standard.Agents;
 using Standard.Agents.Brokers.Approvals;
 using Standard.Agents.Conformance;
+using Standard.Agents.Models.Brokers.Agents;
 using Standard.Agents.Models.Brokers.Audits;
 using Standard.Agents.Models.Brokers.Generators.V1;
 using Standard.Agents.Models.Foundations.Skills;
@@ -117,12 +118,21 @@ foreach (string vectorFile in
     bool guardianInputConformant =
         GuardianInputConformant(vector, run, actualResult, out string? guardianFailure);
 
+    // The handoff's content, certified at the specialist: grounding is only real if the text
+    // actually arrived (SPEC.md §4.8 v1.6).
+    bool agentInputConformant = vector.Expect.AgentInput is null
+        || vector.Expect.AgentInput.All(expected =>
+            run.AgentInputs.TryGetValue(expected.Key, out List<string>? handed)
+                && handed.Any(input =>
+                    input.Contains(expected.Value, StringComparison.Ordinal)));
+
     if (resultConformant
         && perPromptResultsConformant
         && toolInputConformant
         && rubricConformant
         && auditConformant
-        && guardianInputConformant)
+        && guardianInputConformant
+        && agentInputConformant)
     {
         passed++;
         passedVectors.Add(vector.Name);
@@ -164,6 +174,25 @@ foreach (string vectorFile in
 
                 Console.WriteLine($"        tool '{expected.Key}' expected input: {Show(expected.Value)}");
                 Console.WriteLine($"        tool '{expected.Key}' actual inputs:  {actualInputs}");
+            }
+        }
+
+        if (agentInputConformant is false)
+        {
+            foreach (KeyValuePair<string, string> expected in vector.Expect.AgentInput!)
+            {
+                string actualHandoffs =
+                    run.AgentInputs.TryGetValue(expected.Key, out List<string>? handed)
+                        && handed.Count > 0
+                        ? string.Join(" | ", handed.Select(Show))
+                        : "(agent never ran)";
+
+                Console.WriteLine(
+                    $"        agent '{expected.Key}' expected handoff containing: "
+                        + Show(expected.Value));
+
+                Console.WriteLine(
+                    $"        agent '{expected.Key}' actually received: {actualHandoffs}");
             }
         }
 
@@ -248,6 +277,36 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     // server's would.
     List<ScriptedMcpServer> scriptedMcpServers =
         [.. (vector.McpServers ?? []).Select(catalog => new ScriptedMcpServer(catalog))];
+
+    // The fleet (SPEC.md §4.8 v1.6): scripted specialists, created once per vector so their
+    // scripted brains keep their place across instance rebuilds, exactly as real endpoints
+    // would. What each was HANDED is recorded, because the grounded handoff — the user's
+    // actual ask crossing the seam — is the thing worth certifying.
+    Dictionary<string, List<string>> agentInputs = new(StringComparer.OrdinalIgnoreCase);
+    List<RegisteredAgent> fleet = [];
+    object fleetLock = new();
+
+    foreach (FleetAgent member in vector.Agents ?? [])
+    {
+        List<string> handed = [];
+        agentInputs[member.Name] = handed;
+
+        StandardAgent specialist = new StandardAgent()
+            .UseSkills(new StubSkillBroker())
+            .UseMemory(new StubMemoryBroker())
+            .UseKnowledge(new StubKnowledgeBroker())
+            .UseMcp(new NotConfiguredMcpBroker())
+            .UseGenerator(new RecordingGeneratorBroker(
+                new ScriptedGeneratorBroker(member.Replies),
+                input => { lock (fleetLock) { handed.Add(input); } }));
+
+        if (member.RuleGate is { Count: > 0 })
+        {
+            specialist.RuleGate([.. member.RuleGate]);
+        }
+
+        fleet.Add(new RegisteredAgent(member.Name, member.Description, specialist));
+    }
 
     Dictionary<string, StubTool> stubTools =
         (vector.Tools ?? []).ToDictionary(
@@ -334,6 +393,14 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
 
             agent.OnSkills(() => new ValueTask<IReadOnlyList<Skill>>(
                 [new Skill { Name = $"extra-{content.GetHashCode():x}", Content = content }]));
+        }
+
+        // The fleet registers through the same client verb a host would use, so what is
+        // certified is the registry path itself — materialization as tools, the grounded
+        // default handoff, and transfer semantics included.
+        if (fleet.Count > 0)
+        {
+            agent.OnAgents(() => new ValueTask<IReadOnlyList<RegisteredAgent>>(fleet));
         }
 
         agent
@@ -598,7 +665,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         }
     }
 
-    return new VectorRun(result, promptResults, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, promptScreenings, auditRecords, compensationOrder, nativeGenerator, policyPrincipals, [.. scriptedMcpServers.Select(server => server.CallCount)]);
+    return new VectorRun(result, promptResults, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs, brainInputs, promptScreenings, auditRecords, compensationOrder, nativeGenerator, policyPrincipals, [.. scriptedMcpServers.Select(server => server.CallCount)], agentInputs);
 }
 
 // The decision log's guarantees, certified from the records themselves: one run per prompt,
@@ -1011,4 +1078,5 @@ internal sealed record VectorRun(
     List<string> CompensationOrder,
     ScriptedNativeGeneratorBroker? NativeGenerator,
     List<string?> PolicyPrincipals,
-    List<int> McpServerCalls);
+    List<int> McpServerCalls,
+    Dictionary<string, List<string>> AgentInputs);

--- a/conformance/vectors/48-a-registered-agent-answers-a-handoff.json
+++ b/conformance/vectors/48-a-registered-agent-answers-a-handoff.json
@@ -1,0 +1,21 @@
+{
+  "name": "a-registered-agent-answers-a-handoff",
+  "description": "The fleet (SPEC.md 4.8 v1.6): the outer Brain hands a task to a registered agent exactly as it calls a tool. The specialist answers, the answer returns as an observation for the outer Brain to synthesize - and the handoff itself MUST carry the user's original ask, because the grounded default template shares the task plus just enough context to do it.",
+  "agents": [
+    {
+      "name": "billing",
+      "description": "Handles refunds and invoices.",
+      "replies": ["FINAL: the refund is booked"]
+    }
+  ],
+  "generatorReplies": [
+    "ACTION: billing: refund order 7741",
+    "FINAL: done - billing booked the refund."
+  ],
+  "prompt": "please refund my last order, number 7741",
+  "expect": {
+    "resultContains": "billing booked the refund",
+    "brainSees": "the refund is booked",
+    "agentInput": { "billing": "please refund my last order, number 7741" }
+  }
+}

--- a/conformance/vectors/49-a-transfer-delivers-the-specialists-answer.json
+++ b/conformance/vectors/49-a-transfer-delivers-the-specialists-answer.json
@@ -1,0 +1,19 @@
+{
+  "name": "a-transfer-delivers-the-specialists-answer",
+  "description": "TRANSFER hands the whole run to a registered agent (SPEC.md 4.8 v1.6): the specialist's answer IS the run's answer, verbatim - no synthesis turn, no rewriting. The handoff states the transfer's task in its own words while the grounded template carries the user's actual ask, so nothing is repeated and nothing is lost.",
+  "agents": [
+    {
+      "name": "billing",
+      "description": "Handles refunds and invoices.",
+      "replies": ["FINAL: the refund is booked"]
+    }
+  ],
+  "generatorReplies": [
+    "TRANSFER: billing"
+  ],
+  "prompt": "please refund my last order, number 7741",
+  "expect": {
+    "result": "the refund is booked",
+    "agentInput": { "billing": "answer the user's request in full." }
+  }
+}

--- a/conformance/vectors/50-a-refused-transfer-stays-an-observation.json
+++ b/conformance/vectors/50-a-refused-transfer-stays-an-observation.json
@@ -1,0 +1,21 @@
+{
+  "name": "a-refused-transfer-stays-an-observation",
+  "description": "A transfer that does not deliver is an observation, never the answer (SPEC.md 4.8 v1.6). The specialist's own gate refuses the handed-off task; the refusal comes back marked '[did not complete]' with the specialist's status, the outer Brain keeps working the task, and the run's answer is the outer agent's own - a refusal presented as the user's answer would be the dishonesty the marker exists to prevent.",
+  "agents": [
+    {
+      "name": "billing",
+      "description": "Handles refunds and invoices.",
+      "ruleGate": ["refund"],
+      "replies": ["FINAL: should never be reached"]
+    }
+  ],
+  "generatorReplies": [
+    "TRANSFER: billing",
+    "FINAL: billing could not take this; here is the path forward."
+  ],
+  "prompt": "please refund order 7741",
+  "expect": {
+    "resultContains": "path forward",
+    "brainSees": "[did not complete]"
+  }
+}

--- a/conformance/vectors/51-a-nameless-fleet-member-refuses-to-compose.json
+++ b/conformance/vectors/51-a-nameless-fleet-member-refuses-to-compose.json
@@ -1,0 +1,10 @@
+{
+  "name": "a-nameless-fleet-member-refuses-to-compose",
+  "description": "The fleet is data like everything else (SPEC.md 4.8 v1.6), and its members are called by name - so an inline 'agents' entry with no name is an agent no handoff could ever reach. The document MUST refuse to compose and the refusal MUST name what is missing, rather than silently registering an unreachable agent.",
+  "configurationJson": "{ \"agents\": [ { \"maxTurns\": 2 } ] }",
+  "generatorReplies": [],
+  "prompt": "",
+  "expect": {
+    "configurationRefusalNames": "name"
+  }
+}


### PR DESCRIPTION
## Four vectors certify the fleet

| # | Vector | What it proves |
|---|---|---|
| 48 | `a-registered-agent-answers-a-handoff` | A handoff reaches the specialist **grounded** — the user's original ask crossed the seam, not the task alone — and the answer returns for the outer brain to synthesize |
| 49 | `a-transfer-delivers-the-specialists-answer` | `TRANSFER:` ends the run with the specialist's answer **verbatim** (exact-match assertion), and the handoff carries the transfer's own task statement |
| 50 | `a-refused-transfer-stays-an-observation` | A specialist whose own gate refuses comes back marked `[did not complete]`, the outer brain keeps working, and the run's answer is the outer agent's own |
| 51 | `a-nameless-fleet-member-refuses-to-compose` | An inline `"agents"` member with no name refuses to compose, naming what is missing |

## Harness additions

- **`FleetAgent`** vector field: scripted specialists with their own scripted brains and an optional `ruleGate` — so a specialist that *refuses* is scripted through the same real control a host would configure, not faked.
- **`agentInput`** expectation: each named specialist must have *received* a handoff containing the text — grounding certified at the receiving end, where it either arrived or it didn't.
- Specialists are created once per vector so their scripts keep their place across instance rebuilds, and they register through the same `.OnAgents(...)` verb a host uses — the registry path itself is what gets certified.

## Sabotage-proofed

All three run-based vectors were verified to FAIL under flipped expectations — including proof from the failure output that the specialist actually received `The user asked: please refund my last order… Your task: refund order 7741`, and that the outer brain's synthesis line is *not* what a transfer delivers.

51 vectors pass, zero warnings.