### PR TITLE
CLIENTS: The Stateless Caller Gets The Call, And The Run Gets The Transcript

### DIFF
--- a/Standard.Agents.Conformance/Models/RequestSpec.cs
+++ b/Standard.Agents.Conformance/Models/RequestSpec.cs
@@ -17,7 +17,14 @@ public sealed record RequestSpec(
     List<string>? Stop = null,
     string? ResponseSchemaJson = null,
     string? ProviderOptionsJson = null,
-    List<CallerToolSpec>? CallerTools = null);
+    List<CallerToolSpec>? CallerTools = null,
+
+    // The caller-owned transcript (design §3): the exposed protocols are stateless and the
+    // client re-posts the conversation. When a session exists it wins.
+    List<TurnSpec>? History = null);
+
+/// <summary>One prior exchange in the caller-owned transcript, oldest first.</summary>
+public sealed record TurnSpec(string Prompt, string Answer);
 
 /// <summary>
 /// A tool the CALLER will execute, declared so the model may name it. The agent never runs one

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -678,6 +678,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
 
     string result;
     AgentStatus? runStatus = null;
+    string? outcomePendingEffectTool = null;
     List<string> promptResults = [];
 
     PromptRequest ToRequest(string prompt, RequestSpec spec) => new()
@@ -690,6 +691,10 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         Stop = spec.Stop ?? [],
         ResponseSchemaJson = spec.ResponseSchemaJson,
         ProviderOptionsJson = spec.ProviderOptionsJson,
+
+        History =
+            [.. (spec.History ?? []).Select(turn =>
+                new AgentTurn(turn.Prompt, turn.Answer))],
 
         CallerTools =
             [.. (spec.CallerTools ?? []).Select(tool =>
@@ -708,6 +713,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
 
         result = outcomes[0].Result;
         runStatus = outcomes[0].Status;
+        outcomePendingEffectTool = outcomes[0].PendingEffect?.ToolName;
     }
     else if (vector.Request is not null)
     {
@@ -733,6 +739,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
             AgentOutcome outcome = await agent.RunAsync(promptRequest, runCancellation.Token);
             result = outcome.Result;
             runStatus = outcome.Status;
+            outcomePendingEffectTool = outcome.PendingEffect?.ToolName;
         }
     }
     else if (vector.Concurrent)
@@ -763,11 +770,14 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         }
     }
 
-    // The pending effect rode out on the session, which is where a different process — and this
-    // harness — reads it (design §6.2).
-    string? pendingEffectTool = null;
+    // The pending effect rides the OUTCOME as well as the session (design §6.2): the outcome is
+    // what a stateless exposer reads, the session is what a different process reads. The harness
+    // prefers the outcome and falls back to the session, so a vector can certify either seam.
+    string? pendingEffectTool = outcomePendingEffectTool;
 
-    if (vector.SessionId is not null && vector.Expect.PendingEffectTool is not null)
+    if (pendingEffectTool is null
+        && vector.SessionId is not null
+        && vector.Expect.PendingEffectTool is not null)
     {
         AgentSession? session = await new FileSessionBroker(
             Path.Combine(AppContext.BaseDirectory, $"sessions-{vector.Name}"))

--- a/Standard.Agents.Tests.Unit/Acceptance/CallerToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/CallerToolTests.cs
@@ -299,4 +299,148 @@ public class CallerToolTests : IDisposable
         outcome.PendingEffect.CallId.Should().Be("call_9");
         outcome.PendingEffect.Arguments.Should().Contain("jane@acme.com");
     }
+
+    private sealed class MessageRecordingNativeBroker : IGeneratorBrokerV1
+    {
+        public IReadOnlyList<ConversationMessage> CapturedMessages { get; private set; } = [];
+
+        public ValueTask<GenerationResult> GenerateAsync(
+            IReadOnlyList<ConversationMessage> messages,
+            IReadOnlyList<ToolDefinition> tools)
+        {
+            this.CapturedMessages = messages;
+
+            return ValueTask.FromResult(new GenerationResult { Content = "ok" });
+        }
+    }
+
+    private static StandardAgent BareAgent()
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+
+        skillBroker.Setup(b => b.SelectSkillsAsync())
+            .ReturnsAsync(new List<Skill> { new() { Content = "You are a helpful agent." } });
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(b => b.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object);
+    }
+
+    // The exposed protocols this seam exists for are stateless: the client re-posts the whole
+    // conversation, prior tool exchanges included. A run that cannot receive that transcript
+    // starts from nothing every time — and the second half of the yield (the caller answering a
+    // call the run handed out) becomes impossible to express.
+    [Fact]
+    public async Task ShouldCarryTheCallerOwnedTranscriptToTheNativeBrainAsync()
+    {
+        // given
+        var broker = new MessageRecordingNativeBroker();
+        StandardAgent agent = BareAgent().UseNativeBrain(broker);
+
+        var request = new PromptRequest
+        {
+            Prompt = "and then?",
+            History = [new AgentTurn("What is 2+2?", "4")],
+
+            ToolExchanges =
+            [
+                new ToolExchange(
+                    CallId: "call_9",
+                    ToolName: "send_email",
+                    ArgumentsJson: """{"to":"jane@acme.com"}""",
+                    Result: "sent")
+            ]
+        };
+
+        // when
+        await agent.ProcessPromptAsync(request);
+
+        // then — the prior turn as user/assistant messages, and the exchange as a tool message
+        // still naming the call the model minted
+        broker.CapturedMessages.Should().Contain(message =>
+            message.Role == MessageRole.User && message.Content == "What is 2+2?");
+
+        broker.CapturedMessages.Should().Contain(message =>
+            message.Role == MessageRole.Assistant && message.Content == "4");
+
+        broker.CapturedMessages.Should().Contain(message =>
+            message.Role == MessageRole.Tool
+                && message.ToolCallId == "call_9"
+                && message.Content == "sent");
+    }
+
+    // The same transcript on the text protocol: history renders into the conversation the
+    // model is shown, exactly as a session's history would.
+    [Fact]
+    public async Task ShouldCarryTheCallerOwnedTranscriptOnTheTextProtocolAsync()
+    {
+        // given
+        string capturedUserPrompt = string.Empty;
+
+        StandardAgent agent = BareAgent().OnBrain((systemPrompt, userPrompt) =>
+        {
+            capturedUserPrompt = userPrompt;
+
+            return ValueTask.FromResult("FINAL: ok");
+        });
+
+        var request = new PromptRequest
+        {
+            Prompt = "and then?",
+            History = [new AgentTurn("What is 2+2?", "4")]
+        };
+
+        // when
+        await agent.ProcessPromptAsync(request);
+
+        // then
+        capturedUserPrompt.Should().Contain("What is 2+2?");
+        capturedUserPrompt.Should().Contain("4");
+    }
+
+    // When a session exists it wins: the deployment's record of the conversation beats the
+    // caller's retelling of it — the same precedence every request field obeys (design §4).
+    [Fact]
+    public async Task ShouldLetTheSessionsHistoryWinOverTheRequestsAsync()
+    {
+        // given — a real session holding a real prior turn
+        string capturedUserPrompt = string.Empty;
+        int call = 0;
+
+        StandardAgent agent = BareAgent()
+            .Sessions(this.sessionsPath)
+            .OnBrain((systemPrompt, userPrompt) =>
+            {
+                capturedUserPrompt = userPrompt;
+
+                return ValueTask.FromResult(call++ == 0
+                    ? "FINAL: Tokyo"
+                    : "FINAL: ok");
+            });
+
+        await agent.ProcessPromptAsync("Capital of Japan?", "transcript-1", CancellationToken.None);
+
+        var request = new PromptRequest
+        {
+            Prompt = "and then?",
+            SessionId = "transcript-1",
+            History = [new AgentTurn("a retelling that never happened", "made up")]
+        };
+
+        // when
+        await agent.ProcessPromptAsync(request);
+
+        // then — the session's turn is what the brain saw, not the caller's retelling
+        capturedUserPrompt.Should().Contain("Capital of Japan?");
+        capturedUserPrompt.Should().NotContain("a retelling that never happened");
+    }
 }

--- a/Standard.Agents.Tests.Unit/Acceptance/CallerToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/CallerToolTests.cs
@@ -231,4 +231,72 @@ public class CallerToolTests : IDisposable
         outcome.Status.Should().Be(AgentStatus.Responded);
         outcome.Result.Should().Be("4183");
     }
+
+    private sealed class YieldingNativeBroker : IGeneratorBrokerV1
+    {
+        public ValueTask<GenerationResult> GenerateAsync(
+            IReadOnlyList<ConversationMessage> messages,
+            IReadOnlyList<ToolDefinition> tools) =>
+            ValueTask.FromResult(new GenerationResult
+            {
+                ToolCalls =
+                [
+                    new ModelToolCall(
+                        Id: "call_9",
+                        Name: "send_email",
+                        ArgumentsJson: """{"to":"jane@acme.com"}""")
+                ]
+            });
+    }
+
+    // A stateless deployment has no session, and the client owns the transcript — the exposed
+    // protocol this seam exists for (docs/per-request-inference.md §6.2). The pending call must
+    // therefore reach the caller on the OUTCOME itself, carrying the id the model minted, or the
+    // exposer cannot render the yield at all.
+    [Fact]
+    public async Task ShouldHandTheCallerTheirCallOnTheOutcomeWithoutASessionAsync()
+    {
+        // given — no sessions configured, a native brain that wants the caller's tool
+        var skillBroker = new Mock<ISkillBroker>();
+
+        skillBroker.Setup(b => b.SelectSkillsAsync())
+            .ReturnsAsync(new List<Skill> { new() { Content = "You are a helpful agent." } });
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(b => b.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(b => b.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        StandardAgent agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .UseNativeBrain(new YieldingNativeBroker());
+
+        var request = new PromptRequest
+        {
+            Prompt = "email jane the report",
+
+            CallerTools =
+            [
+                new ToolDefinition(
+                    Name: "send_email",
+                    Description: "Sends an email from the caller's own outbox.",
+                    ParametersJson: "{}")
+            ]
+        };
+
+        // when
+        AgentOutcome outcome = await agent.RunAsync(request);
+
+        // then — the call itself, on the outcome, with the model's own id
+        outcome.Status.Should().Be(AgentStatus.AwaitingInput);
+        outcome.PendingEffect.Should().NotBeNull();
+        outcome.PendingEffect!.ToolName.Should().Be("send_email");
+        outcome.PendingEffect.CallId.Should().Be("call_9");
+        outcome.PendingEffect.Arguments.Should().Contain("jane@acme.com");
+    }
 }

--- a/Standard.Agents/Models/Clients/Agents/AgentOutcome.cs
+++ b/Standard.Agents/Models/Clients/Agents/AgentOutcome.cs
@@ -18,4 +18,14 @@ namespace Standard.Agents.Models.Clients.Agents;
 /// output as though it were an answer. A caller that cannot tell these apart will eventually report
 /// unfinished work as done.
 /// </param>
-public record AgentOutcome(string Result, AgentStatus Status);
+/// <param name="PendingEffect">
+/// The act the run is waiting on, when it ended waiting — a caller's tool call, or an act held
+/// for approval. It rides the session too (SPEC.md §4.11), but a stateless deployment has no
+/// session, and an exposer that cannot reach the pending call cannot yield it to the caller —
+/// which is the whole mechanism (docs/per-request-inference.md §6.2). Null when the run is not
+/// waiting on anything.
+/// </param>
+public record AgentOutcome(
+    string Result,
+    AgentStatus Status,
+    Standard.Agents.Models.Orchestrations.Effects.AgentEffect? PendingEffect = null);

--- a/Standard.Agents/Models/Clients/Agents/PromptRequest.cs
+++ b/Standard.Agents/Models/Clients/Agents/PromptRequest.cs
@@ -4,6 +4,8 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Orchestrations.Agents;
 
 namespace Standard.Agents.Models.Clients.Agents;
 
@@ -27,6 +29,22 @@ public sealed record PromptRequest
     // does not — it is runtime control, not a statement about the request — so the entry keeps
     // it as a parameter.
     public string SessionId { get; init; } = "";
+
+    /// <summary>
+    /// The caller-owned transcript: what was said before, oldest first. The exposed protocols
+    /// this seam exists for are stateless — the client re-posts the conversation — and a run
+    /// that cannot receive it starts from nothing every time. When a session exists it wins:
+    /// the deployment's record of the conversation beats the caller's retelling of it, the
+    /// same precedence every field on this record obeys.
+    /// </summary>
+    public IReadOnlyList<AgentTurn> History { get; init; } = [];
+
+    /// <summary>
+    /// Tool calls the caller already executed and is answering — the second half of the yield:
+    /// a run ended AwaitingInput holding a caller's call, the caller ran it, and this is the
+    /// result coming back, still naming the call id the model minted.
+    /// </summary>
+    public IReadOnlyList<ToolExchange> ToolExchanges { get; init; } = [];
 
     /// <summary>The shape the answer must take. Null means the caller expressed no opinion.</summary>
     public string? ResponseSchemaJson { get; init; }

--- a/Standard.Agents/Models/Orchestrations/Effects/AgentEffect.cs
+++ b/Standard.Agents/Models/Orchestrations/Effects/AgentEffect.cs
@@ -33,6 +33,14 @@ public sealed record AgentEffect
     public string Arguments { get; init; } = "";
 
     /// <summary>
+    /// The model-issued call id, when this effect is a caller's tool call being handed back
+    /// (docs/per-request-inference.md §6.2). An exposed protocol requires the result to answer
+    /// the id the model minted; an id the exposer invents is one the caller cannot match.
+    /// Empty for every other kind of effect, and on the text protocol, which has no ids.
+    /// </summary>
+    public string CallId { get; init; } = "";
+
+    /// <summary>
     /// What the act is about to touch — a path, a host, an account — as the tool named it
     /// (ITool.ScopeOf). Empty when the tool touches nothing addressable. Permission is not only
     /// what but where, and a policy that can only see a tool name cannot express the difference.

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -7,3 +7,7 @@ Standard.Agents.Models.Orchestrations.Effects.AgentEffect.CallId.get -> string!
 Standard.Agents.Models.Orchestrations.Effects.AgentEffect.CallId.init -> void
 *REMOVED*Standard.Agents.Models.Clients.Agents.AgentOutcome.AgentOutcome(string! Result, Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status) -> void
 *REMOVED*Standard.Agents.Models.Clients.Agents.AgentOutcome.Deconstruct(out string! Result, out Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status) -> void
+Standard.Agents.Models.Clients.Agents.PromptRequest.History.get -> System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Sessions.AgentTurn!>!
+Standard.Agents.Models.Clients.Agents.PromptRequest.History.init -> void
+Standard.Agents.Models.Clients.Agents.PromptRequest.ToolExchanges.get -> System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Orchestrations.Agents.ToolExchange!>!
+Standard.Agents.Models.Clients.Agents.PromptRequest.ToolExchanges.init -> void

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Standard.Agents.Models.Clients.Agents.AgentOutcome.AgentOutcome(string! Result, Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status, Standard.Agents.Models.Orchestrations.Effects.AgentEffect? PendingEffect = null) -> void
+Standard.Agents.Models.Clients.Agents.AgentOutcome.Deconstruct(out string! Result, out Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status, out Standard.Agents.Models.Orchestrations.Effects.AgentEffect? PendingEffect) -> void
+Standard.Agents.Models.Clients.Agents.AgentOutcome.PendingEffect.get -> Standard.Agents.Models.Orchestrations.Effects.AgentEffect?
+Standard.Agents.Models.Clients.Agents.AgentOutcome.PendingEffect.init -> void
+Standard.Agents.Models.Orchestrations.Effects.AgentEffect.CallId.get -> string!
+Standard.Agents.Models.Orchestrations.Effects.AgentEffect.CallId.init -> void
+*REMOVED*Standard.Agents.Models.Clients.Agents.AgentOutcome.AgentOutcome(string! Result, Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status) -> void
+*REMOVED*Standard.Agents.Models.Clients.Agents.AgentOutcome.Deconstruct(out string! Result, out Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status) -> void

--- a/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.cs
@@ -114,7 +114,11 @@ public partial class DirectionCoordinationService : IDirectionCoordinationServic
             runId: AgentRun.Current?.Id ?? string.Empty,
             toolName: context.DirectionType,
             arguments: context.Payload,
-            principal: this.identityResolver?.Invoke());
+            principal: this.identityResolver?.Invoke()) with
+        {
+            // The id the model minted, preserved so the caller's result can answer it.
+            CallId = context.ToolCallId
+        };
 
         await this.loggingBroker.LogProcessAsync(
             "Direction",

--- a/Standard.Agents/Services/Managements/RunManagementService.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.cs
@@ -679,6 +679,9 @@ public partial class RunManagementService : IRunManagementService
         this.telemetryBroker.RecordRunOutcome(
             context.Status.ToString(), runPromptTokens, runCompletionTokens);
 
-        setOutcome(new AgentOutcome(context.Result, context.Status));
+        // The pending effect rides the outcome as well as the session (SPEC.md §4.11):
+        // a stateless deployment has no session, and an exposer that cannot reach the
+        // pending call cannot yield it to the caller (docs/per-request-inference.md §6.2).
+        setOutcome(new AgentOutcome(context.Result, context.Status, context.PendingEffect));
     }
 }

--- a/Standard.Agents/Services/Managements/RunManagementService.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.cs
@@ -420,10 +420,16 @@ public partial class RunManagementService : IRunManagementService
         // Precedence resolved once, at the top of the run, and never again below it: a loop
         // that can re-resolve is a loop where two turns of one run can disagree
         // (docs/per-request-inference.md §2).
+        // The caller-owned transcript seeds the run; a session, when one exists, overwrites
+        // the history below — the deployment's record of the conversation beats the caller's
+        // retelling of it, the same precedence every request field obeys
+        // (docs/per-request-inference.md §4).
         AgentContext context = new()
         {
             Prompt = prompt,
             SessionId = sessionId,
+            History = request.History,
+            ToolExchanges = request.ToolExchanges,
             Inference = Resolve(request)
         };
 

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -3,7 +3,7 @@
 A **language-neutral** set of behavioral test vectors that any Standard-Agents
 implementation runs to self-certify against
 [`SPEC.md`](https://github.com/hassanhabib/The-Standard-Agent-Specs/blob/main/SPEC.md).
-Sixty-one vectors, four readiness profiles, every vector proven able to fail.
+Sixty-three vectors, four readiness profiles, every vector proven able to fail.
 
 The vectors are the executable half of the specification. Prose can be read two ways; a vector
 cannot, which is why "conformant" here means *this suite passes* rather than *we believe we
@@ -69,6 +69,7 @@ capability it configures did not exist, which is why the early vectors still des
 | `allowTools`, `permissionMode` | the allow-list (`"tool"` or `"tool:scopePrefix"`) and the disposition toward acts nothing permitted |
 | `toolRisk`, `toolScopeFirstWord` | what a stub tool declares about itself: how consequential it is, and what it is about to touch |
 | `request`, `requests` | per-request inference options — one caller's ask, or one per prompt driven concurrently |
+| `request.history` | the caller-owned transcript, oldest first |
 | `contractSchema`, `configuredTemperature`, `configuredMaxTokens` | the deployment's side of precedence: hard configuration a request can never move |
 | `brokerHonorsRequest` | `false` swaps in the scripted Brain that never opted in, so degradation runs through the interface's real default members |
 | `streamed` | run the request through the streamed loop, which enforces every control the batched one does |
@@ -193,6 +194,8 @@ the deterministic core of the Standard.
 | `caller-tool-never-executes` | A caller's tool is vocabulary, never capability — the agent performs nothing |
 | `caller-tool-call-ends-run-as-pending-effect` | The caller's call rides the session out as a pending effect, `AwaitingInput` |
 | `caller-tool-name-collision-drops-caller-tool` | A caller cannot shadow the deployment's own tool; configured wins |
+| `pending-call-rides-the-outcome-without-a-session` | A stateless exposer reads the caller's call off the outcome itself |
+| `the-callers-transcript-reaches-the-brain` | A prior turn re-posted by the caller reaches the Brain; the run never starts from nothing |
 
 ## Readiness profiles
 

--- a/conformance/profiles/enterprise.json
+++ b/conformance/profiles/enterprise.json
@@ -31,6 +31,8 @@
     "provider-options-cannot-touch-core-owned-keys",
     "caller-tool-never-executes",
     "caller-tool-call-ends-run-as-pending-effect",
-    "caller-tool-name-collision-drops-caller-tool"
+    "caller-tool-name-collision-drops-caller-tool",
+    "pending-call-rides-the-outcome-without-a-session",
+    "the-callers-transcript-reaches-the-brain"
   ]
 }

--- a/conformance/vectors/62-pending-call-rides-the-outcome-without-a-session.json
+++ b/conformance/vectors/62-pending-call-rides-the-outcome-without-a-session.json
@@ -1,0 +1,23 @@
+{
+  "name": "pending-call-rides-the-outcome-without-a-session",
+  "description": "A stateless deployment has no session, and an exposer that cannot reach the pending call cannot yield it to the caller - which is the whole mechanism. The caller's call must arrive on the outcome itself.",
+  "generatorReplies": [
+    "ACTION: send_email: {\"to\":\"jane@acme.com\"}"
+  ],
+  "tools": {},
+  "prompt": "email jane the report",
+  "maxTurns": 2,
+  "request": {
+    "callerTools": [
+      {
+        "name": "send_email",
+        "description": "Sends an email from the caller's own outbox."
+      }
+    ]
+  },
+  "expect": {
+    "resultContains": "send_email",
+    "status": "AwaitingInput",
+    "pendingEffectTool": "send_email"
+  }
+}

--- a/conformance/vectors/63-the-callers-transcript-reaches-the-brain.json
+++ b/conformance/vectors/63-the-callers-transcript-reaches-the-brain.json
@@ -1,0 +1,21 @@
+{
+  "name": "the-callers-transcript-reaches-the-brain",
+  "description": "The exposed protocols are stateless: the client re-posts the conversation, and a run that cannot receive that transcript starts from nothing every time. A prior turn carried on the request must reach the Brain.",
+  "generatorReplies": [
+    "FINAL: ok"
+  ],
+  "tools": {},
+  "prompt": "and then?",
+  "request": {
+    "history": [
+      {
+        "prompt": "What is 2+2?",
+        "answer": "4"
+      }
+    ]
+  },
+  "expect": {
+    "result": "ok",
+    "brainSees": "What is 2+2?"
+  }
+}

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1382,10 +1382,21 @@ Two more fields deserve a word:
 
 - **`CallerTools`** — tools the **caller** will execute, OpenAI-style. They are vocabulary for
   the model, never capability for the agent: a call naming one ends the run `AwaitingInput` with
-  the call riding out as the session's pending effect — the same seam a held approval rides —
-  and the caller posts the result back on the session to resume. A caller tool sharing a
-  configured tool's name is dropped at the boundary: a caller cannot shadow the deployment's
-  own tool.
+  the call riding out on **both** seams — the session's pending effect for a different process
+  to read, and `AgentOutcome.PendingEffect` for the stateless exposer, carrying the model's own
+  `CallId` so the caller's result can answer it. A caller tool sharing a configured tool's name
+  is dropped at the boundary: a caller cannot shadow the deployment's own tool.
+
+- **`History` and `ToolExchanges`** — the caller-owned transcript. The exposed protocols are
+  stateless: the client re-posts the conversation, prior tool results included, and the run
+  receives it here — prior turns render into the conversation on both protocols, and a
+  replayed exchange returns as a tool message still naming the call the model minted. When a
+  session exists it wins: the deployment's record of the conversation beats the caller's
+  retelling of it.
+
+- **Parallel tool calls** — one pending call per run, today. A decider that can emit several
+  (set `parallel_tool_calls: false` where the provider supports it) hands them back one turn at
+  a time; plural pending caller-calls are a named future widening, not an accident.
 
 Per-request tools-the-agent-executes, permissions, budgets and approvals are deliberately
 **absent** — a request has no field in which to ask for them. Configuration only, always.

--- a/docs/per-request-inference.md
+++ b/docs/per-request-inference.md
@@ -9,6 +9,15 @@
 > what the entry would have seeded; and the entry also gained `RunAsync(PromptRequest)`, because
 > an exposer holding a caller's tool call needs how-the-run-ended, which the string alone cannot
 > say.
+>
+> **First-consumer amendments (v1.12).** Wiring LLooMA 2.0 — a stateless OpenAI-compatible
+> exposer — found two gaps the sessions-shaped design had hidden: the pending call now rides
+> `AgentOutcome.PendingEffect` too (with the model's `CallId`), because a deployment with no
+> session store otherwise cannot yield it; and `PromptRequest` gained `History` and
+> `ToolExchanges`, because a stateless caller re-posts the transcript and the run must receive
+> it — session wins when both exist. Parallel caller tool calls remain one-per-run, recorded as
+> a deliberate constraint (`parallel_tool_calls: false` at the decider) and a named future
+> widening.
 
 How a single composed agent serves many callers, each asking for something different, without
 rebuilding itself and without any caller widening the boundary the deployment set.


### PR DESCRIPTION
The first exposed consumer (LLooMA 2.0 — a stateless OpenAI-compatible endpoint where the client owns the transcript) found two gaps in the per-request seam. Both close here, additively.

- **The pending call rides the outcome.** `AgentOutcome` gains `PendingEffect`, and `AgentEffect` gains `CallId` (the model-minted id). A deployment with no session store could not previously reach the caller's yielded call at all — and the yield is the whole mechanism.
- **The request carries the caller-owned transcript.** `PromptRequest` gains `History` and `ToolExchanges`; turns render on both reply protocols exactly as a session's history would, and a replayed exchange returns as a tool message answering the call it answers. When a session exists it wins — the deployment's record beats the caller's retelling.
- **Parallel caller calls**: recorded ruling — one per run, constrain the decider (`parallel_tool_calls: false`); plural is a named future widening.

620 tests × two TFMs, 63/63 conformance vectors (two new, both sabotage-proven), four profiles certified, zero warnings. Tracks SPEC.md v1.8 (The-Standard-Agent-Specs #28).