### PR TITLE
[RELEASES]: Standard Agents One Dot Twelve - The Stateless Caller

### DIFF
--- a/Standard.Agents/PublicAPI.Shipped.txt
+++ b/Standard.Agents/PublicAPI.Shipped.txt
@@ -495,8 +495,10 @@ Standard.Agents.Models.Brokers.Sessions.AgentTurn.Prompt.get -> string!
 Standard.Agents.Models.Brokers.Sessions.AgentTurn.Prompt.init -> void
 Standard.Agents.Models.Clients.Agents.AgentOutcome
 Standard.Agents.Models.Clients.Agents.AgentOutcome.AgentOutcome(Standard.Agents.Models.Clients.Agents.AgentOutcome! original) -> void
-Standard.Agents.Models.Clients.Agents.AgentOutcome.AgentOutcome(string! Result, Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status) -> void
-Standard.Agents.Models.Clients.Agents.AgentOutcome.Deconstruct(out string! Result, out Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status) -> void
+Standard.Agents.Models.Clients.Agents.AgentOutcome.AgentOutcome(string! Result, Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status, Standard.Agents.Models.Orchestrations.Effects.AgentEffect? PendingEffect = null) -> void
+Standard.Agents.Models.Clients.Agents.AgentOutcome.Deconstruct(out string! Result, out Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status, out Standard.Agents.Models.Orchestrations.Effects.AgentEffect? PendingEffect) -> void
+Standard.Agents.Models.Clients.Agents.AgentOutcome.PendingEffect.get -> Standard.Agents.Models.Orchestrations.Effects.AgentEffect?
+Standard.Agents.Models.Clients.Agents.AgentOutcome.PendingEffect.init -> void
 Standard.Agents.Models.Clients.Agents.AgentOutcome.Result.get -> string!
 Standard.Agents.Models.Clients.Agents.AgentOutcome.Result.init -> void
 Standard.Agents.Models.Clients.Agents.AgentOutcome.Status.get -> Standard.Agents.Models.Orchestrations.Agents.AgentStatus
@@ -524,6 +526,8 @@ Standard.Agents.Models.Clients.Agents.PromptRequest.<Clone>$() -> Standard.Agent
 Standard.Agents.Models.Clients.Agents.PromptRequest.CallerTools.get -> System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Generators.V1.ToolDefinition!>!
 Standard.Agents.Models.Clients.Agents.PromptRequest.CallerTools.init -> void
 Standard.Agents.Models.Clients.Agents.PromptRequest.Equals(Standard.Agents.Models.Clients.Agents.PromptRequest? other) -> bool
+Standard.Agents.Models.Clients.Agents.PromptRequest.History.get -> System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Sessions.AgentTurn!>!
+Standard.Agents.Models.Clients.Agents.PromptRequest.History.init -> void
 Standard.Agents.Models.Clients.Agents.PromptRequest.MaxTokens.get -> int?
 Standard.Agents.Models.Clients.Agents.PromptRequest.MaxTokens.init -> void
 Standard.Agents.Models.Clients.Agents.PromptRequest.Prompt.get -> string!
@@ -541,6 +545,8 @@ Standard.Agents.Models.Clients.Agents.PromptRequest.Stop.get -> System.Collectio
 Standard.Agents.Models.Clients.Agents.PromptRequest.Stop.init -> void
 Standard.Agents.Models.Clients.Agents.PromptRequest.Temperature.get -> double?
 Standard.Agents.Models.Clients.Agents.PromptRequest.Temperature.init -> void
+Standard.Agents.Models.Clients.Agents.PromptRequest.ToolExchanges.get -> System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Orchestrations.Agents.ToolExchange!>!
+Standard.Agents.Models.Clients.Agents.PromptRequest.ToolExchanges.init -> void
 Standard.Agents.Models.Coordinations.Agents.AgentBudget
 Standard.Agents.Models.Coordinations.Agents.AgentBudget.<Clone>$() -> Standard.Agents.Models.Coordinations.Agents.AgentBudget!
 Standard.Agents.Models.Coordinations.Agents.AgentBudget.AgentBudget() -> void
@@ -955,6 +961,8 @@ Standard.Agents.Models.Orchestrations.Effects.AgentEffect.ApprovalRequired.get -
 Standard.Agents.Models.Orchestrations.Effects.AgentEffect.ApprovalRequired.init -> void
 Standard.Agents.Models.Orchestrations.Effects.AgentEffect.Arguments.get -> string!
 Standard.Agents.Models.Orchestrations.Effects.AgentEffect.Arguments.init -> void
+Standard.Agents.Models.Orchestrations.Effects.AgentEffect.CallId.get -> string!
+Standard.Agents.Models.Orchestrations.Effects.AgentEffect.CallId.init -> void
 Standard.Agents.Models.Orchestrations.Effects.AgentEffect.Equals(Standard.Agents.Models.Orchestrations.Effects.AgentEffect? other) -> bool
 Standard.Agents.Models.Orchestrations.Effects.AgentEffect.IdempotencyKey.get -> string!
 Standard.Agents.Models.Orchestrations.Effects.AgentEffect.IdempotencyKey.init -> void

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,13 +1,1 @@
 #nullable enable
-Standard.Agents.Models.Clients.Agents.AgentOutcome.AgentOutcome(string! Result, Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status, Standard.Agents.Models.Orchestrations.Effects.AgentEffect? PendingEffect = null) -> void
-Standard.Agents.Models.Clients.Agents.AgentOutcome.Deconstruct(out string! Result, out Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status, out Standard.Agents.Models.Orchestrations.Effects.AgentEffect? PendingEffect) -> void
-Standard.Agents.Models.Clients.Agents.AgentOutcome.PendingEffect.get -> Standard.Agents.Models.Orchestrations.Effects.AgentEffect?
-Standard.Agents.Models.Clients.Agents.AgentOutcome.PendingEffect.init -> void
-Standard.Agents.Models.Orchestrations.Effects.AgentEffect.CallId.get -> string!
-Standard.Agents.Models.Orchestrations.Effects.AgentEffect.CallId.init -> void
-*REMOVED*Standard.Agents.Models.Clients.Agents.AgentOutcome.AgentOutcome(string! Result, Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status) -> void
-*REMOVED*Standard.Agents.Models.Clients.Agents.AgentOutcome.Deconstruct(out string! Result, out Standard.Agents.Models.Orchestrations.Agents.AgentStatus Status) -> void
-Standard.Agents.Models.Clients.Agents.PromptRequest.History.get -> System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Sessions.AgentTurn!>!
-Standard.Agents.Models.Clients.Agents.PromptRequest.History.init -> void
-Standard.Agents.Models.Clients.Agents.PromptRequest.ToolExchanges.get -> System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Orchestrations.Agents.ToolExchange!>!
-Standard.Agents.Models.Clients.Agents.PromptRequest.ToolExchanges.init -> void

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -437,7 +437,16 @@
          both doors carry the resolution, and one composition serves concurrent heterogeneous
          requests. New routines and models, core contracts widened additively: segment 2
          advances, 3/4 reset. Tracks SPEC.md v1.7. -->
-    <Version>1.11.0.0</Version>
+    <!-- 1.12.0.0 "The Stateless Caller": the first exposed consumer's two findings, closed.
+         The pending caller call rides the run's outcome as well as the session
+         (AgentOutcome.PendingEffect, AgentEffect.CallId - the model-minted id), because a
+         stateless deployment has no session and the yield is the whole mechanism. And the
+         request carries the caller-owned transcript (PromptRequest.History / ToolExchanges),
+         rendered on both reply protocols exactly as a session's history would be - session
+         wins when both exist. Parallel caller calls stay one-per-run, recorded as a ruling.
+         New routines and additively-widened models: segment 2 advances, 3/4 reset. Tracks
+         SPEC.md v1.8. -->
+    <Version>1.12.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>

--- a/docs/releases/v1.12.0.md
+++ b/docs/releases/v1.12.0.md
@@ -1,0 +1,37 @@
+The release the first consumer wrote. Wiring LLooMA 2.0 — a stateless OpenAI-compatible exposer
+where the client owns the transcript — found two gaps the sessions-shaped design had hidden.
+Both close here, additively, and the finding is the system working: build first, specify second,
+and let the consumer be the test of the seam.
+
+## The pending call rides the outcome
+
+A run that ends `AwaitingInput` holding a caller's tool call used to hand that call out on the
+session alone. A stateless deployment has no session — and an exposer that cannot reach the
+pending call cannot yield it to the caller, which is the whole mechanism. `AgentOutcome` now
+carries `PendingEffect`, and `AgentEffect` carries `CallId` — the id the model minted — because
+the exposed protocol requires the caller's result to answer that id, and an id the exposer
+invents is one the caller cannot match. The session ride-out stays for stateful deployments;
+held-for-approval runs get the same courtesy for free.
+
+## The request carries the caller-owned transcript
+
+`PromptRequest` gains `History` and `ToolExchanges`. A stateless caller re-posts the
+conversation — prior turns, executed tool results still naming their call ids — and the run now
+receives it: turns render into the conversation on both reply protocols exactly as a session's
+history would, and a replayed exchange returns to the model as a tool message answering the call
+it answers. When a session exists it wins: the deployment's record of the conversation beats the
+caller's retelling of it, the same precedence every field on the request obeys.
+
+## One ruling, recorded
+
+Parallel caller tool calls stay one-per-run. They are yield, not acts — returning several would
+widen no perimeter — but the constraint is deliberate and cheap to hold
+(`parallel_tool_calls: false` at the decider), and plural pending calls are a named future
+widening rather than an accident waiting to be discovered.
+
+## The record
+
+620 tests × net8.0/net10.0, 63/63 conformance vectors — two new, each proven able to fail:
+`pending-call-rides-the-outcome-without-a-session` and
+`the-callers-transcript-reaches-the-brain`. Four profiles certified, zero warnings, 10 new API
+symbols shipped. Tracks **SPEC.md v1.8**, whose §4.13 now states both seams and the ruling.


### PR DESCRIPTION
Ships 1.12.0.0: the first consumer's findings (#342) as a release. PublicAPI: 10 symbols shipped, 2 retired (AgentOutcome widened additively). Release notes in docs/releases/v1.12.0.md. Tracks SPEC.md v1.8 (Specs #28). 620 tests × two TFMs, 63/63 vectors, four profiles certified, zero warnings.