### PR TITLE
TOOLS: A Tool's Parameters Are A Schema The Wire Can Hold

### DIFF
--- a/Standard.Agents.Tests.Unit/Tools/RememberToolTests.cs
+++ b/Standard.Agents.Tests.Unit/Tools/RememberToolTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Text.Json;
 using FluentAssertions;
 using Moq;
 using Standard.Agents.Services.Foundations.Memorys;
@@ -75,5 +76,26 @@ public class RememberToolTests
         memoryService.Verify(service =>
             service.RememberAsync("a fact worth keeping"),
                 Times.Once);
+    }
+
+    // A tool's Parameters is a JSON SCHEMA the wire validates strictly — Azure OpenAI rejects
+    // the WHOLE request when any advertised tool's parameters is not a schema of type object.
+    // This tool shipped plain JSON ('{ "fact": "..." }') and production found it: every native
+    // run against a strict provider 400'd the moment memory was composed in.
+    [Fact]
+    public void ShouldDeclareParametersAsAJsonSchemaObject()
+    {
+        // given
+        var tool = new RememberTool(_ => ValueTask.CompletedTask);
+
+        // when
+        using JsonDocument schema = JsonDocument.Parse(tool.Parameters);
+
+        // then
+        schema.RootElement.GetProperty("type").GetString().Should().Be("object");
+
+        schema.RootElement.GetProperty("properties")
+            .GetProperty("fact")
+            .GetProperty("type").GetString().Should().Be("string");
     }
 }

--- a/Standard.Agents/Brokers/Generators/GeneratorBrokerV1.cs
+++ b/Standard.Agents/Brokers/Generators/GeneratorBrokerV1.cs
@@ -210,9 +210,11 @@ public sealed class GeneratorBrokerV1 : IGeneratorBrokerV1
             }
         };
 
-    // A tool's parameters are the host's JSON schema. If it does not parse, an empty object is
-    // sent rather than a malformed request: the tool is then callable with no arguments instead
-    // of the whole turn failing on one bad schema.
+    // A tool's parameters are the host's JSON schema — and the wire validates that strictly:
+    // a hosted provider rejects the WHOLE request when any tool's parameters is not a schema
+    // of type object. One bad tool must never take down the turn, so anything that is not an
+    // object schema degrades: a schema that forgot its type but has properties is salvaged,
+    // everything else becomes the empty object schema (callable with no arguments).
     private static JsonNode ParseParameters(string parametersJson)
     {
         if (string.IsNullOrWhiteSpace(parametersJson))
@@ -222,12 +224,33 @@ public sealed class GeneratorBrokerV1 : IGeneratorBrokerV1
 
         try
         {
-            return JsonNode.Parse(parametersJson) ?? new JsonObject { ["type"] = "object" };
+            if (JsonNode.Parse(parametersJson) is JsonObject schema)
+            {
+                string? schemaType = schema["type"] is JsonValue typeValue
+                    ? typeValue.GetValue<string>()
+                    : null;
+
+                if (string.Equals(schemaType, "object", StringComparison.Ordinal))
+                {
+                    return schema;
+                }
+
+                if (schemaType is null && schema.ContainsKey("properties"))
+                {
+                    schema["type"] = "object";
+
+                    return schema;
+                }
+            }
         }
         catch (JsonException)
         {
-            return new JsonObject { ["type"] = "object" };
         }
+        catch (InvalidOperationException)
+        {
+        }
+
+        return new JsonObject { ["type"] = "object" };
     }
 
     private static GenerationResult ReadResult(JsonNode? body)

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -446,7 +446,14 @@
          wins when both exist. Parallel caller calls stay one-per-run, recorded as a ruling.
          New routines and additively-widened models: segment 2 advances, 3/4 reset. Tracks
          SPEC.md v1.8. -->
-    <Version>1.12.0.0</Version>
+    <!-- 1.12.1.0 "The Wire Validates": the first production consumer found what no scripted
+         broker could - RememberTool's Parameters was example JSON, not a JSON Schema, and a
+         strict hosted provider (Azure OpenAI) rejects the WHOLE request over one bad tool
+         schema, failing every native run the moment memory was composed in. The tool now ships
+         a real schema, and GeneratorBrokerV1 degrades any non-object schema (salvaging a
+         type-less one with properties) so one bad tool can never take down the turn again.
+         Bug fix, no API change: segment 3 advances, 4 resets. -->
+    <Version>1.12.1.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>

--- a/Standard.Agents/Tools/RememberTool.cs
+++ b/Standard.Agents/Tools/RememberTool.cs
@@ -22,7 +22,14 @@ public sealed class RememberTool : ITool
         "Store a fact to remember across sessions. Use it when the user tells you "
             + "something worth keeping — their name, where they are, their preferences.";
 
-    public string Parameters => "{ \"fact\": \"the fact to remember\" }";
+    // A JSON SCHEMA, not example JSON. The wire validates this strictly: a hosted provider
+    // rejects the WHOLE request when any advertised tool's parameters is not a schema of type
+    // object — which made every native run against a strict endpoint fail the moment memory
+    // was composed in. Found by the first production consumer, not by any scripted test,
+    // because scripted brokers accept anything.
+    public string Parameters =>
+        "{\"type\":\"object\",\"properties\":{\"fact\":{\"type\":\"string\","
+            + "\"description\":\"the fact to remember\"}},\"required\":[\"fact\"]}";
 
     public RememberTool(Func<string, ValueTask> remember) =>
         this.remember = remember;

--- a/docs/releases/v1.12.1.md
+++ b/docs/releases/v1.12.1.md
@@ -1,0 +1,17 @@
+The patch the wire wrote. The first production consumer — LLooMA 2.0 on the PeerLLM
+orchestrator, running against strict Azure OpenAI — found what no scripted broker could:
+`RememberTool.Parameters` was example JSON (`{ "fact": "..." }`), not a JSON Schema, and a strict
+provider rejects the WHOLE request when any advertised tool's parameters is not a schema of type
+object. Since memory is composed into every agent and the remember tool is advertised by
+default, every native run against a strict endpoint failed with a 400 the caller saw as a 503.
+
+Two fixes, one lesson:
+
+- **`RememberTool` ships a real schema** — `type: object`, a `fact` string property, `required`.
+- **`GeneratorBrokerV1` guards the turn**: a proper object schema passes through; a schema that
+  forgot its `type` but has `properties` is salvaged; anything else degrades to the empty object
+  schema, so one bad tool — the framework's or a host's — can never take down the request again.
+
+The lesson is recorded where it belongs: scripted brokers accept anything, so wire-strictness
+bugs are found only by consumers on real providers. 621 tests × two TFMs, 63/63 vectors, four
+profiles certified, zero warnings, no API change.


### PR DESCRIPTION
The first production consumer (LLooMA 2.0 against strict Azure OpenAI) found what no scripted broker could: RememberTool.Parameters was example JSON, not a JSON Schema, and a strict provider rejects the WHOLE request over one bad tool schema — failing every native run the moment memory was composed in (the caller saw an opaque 503).

- FAIL/PASS: RememberTool ships a real schema (type object, fact:string, required).
- BROKERS: GeneratorBrokerV1 degrades any non-object schema (salvaging type-less-with-properties) so one bad tool never takes down the turn.
- RELEASES: 1.12.1.0 — bug fix, segment 3, no API change.

621 tests × two TFMs, 63/63 vectors, four profiles certified, zero warnings.