### PR TITLE
MANAGEMENTS: The Streamed Outcome - Events That End In An Answer's Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,22 @@ hold here exactly as they do on `ProcessPromptAsync` — a control you can step 
 method is not a control. Pass a session id to stream inside a conversation:
 `agent.StreamPromptAsync(prompt, sessionId, cancellationToken)`.
 
+And when you need the events **and** how the run ended — every exposer that yields a pending
+tool call back to its own caller does — the **streamed outcome** (SPEC.md §4.14) ends the
+choice between them:
+
+```csharp
+AgentRunStream run = agent.RunStreamAsync(request, cancellationToken);
+
+await foreach (AgentStreamEvent streamEvent in run)
+{
+    /* every event, live — narration included */
+}
+
+AgentOutcome outcome = run.Outcome; // the same outcome RunAsync returns: status,
+                                    // result, pending effect with its call id
+```
+
 No DI container. `Compose()` hand-wires the whole graph — SPEC.md §9: *"DI is OPTIONAL. A
 hand-wired composition root is fully conformant."*
 

--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -150,6 +150,11 @@ public sealed record Vector(
     bool BrokerHonorsRequest = true,
     bool Streamed = false,
 
+    // The streamed outcome (SPEC.md §4.14): run the request through the third door — the
+    // enumeration's events AND the structured outcome its completion carries, so status and
+    // pending-effect expectations certify on the streamed door too.
+    bool StreamedOutcome = false,
+
     // Narration (SPEC.md §6.0). ToolNarrations gives a stub tool its declared templates;
     // GateVerdictOnNarration is the verdict the scripted Gate returns for model narration —
     // screened text that is neither the prompt nor a tool's output.

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -752,7 +752,28 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     {
         PromptRequest promptRequest = ToRequest(vector.Prompt, vector.Request);
 
-        if (vector.Streamed)
+        if (vector.StreamedOutcome)
+        {
+            // The third door (SPEC.md §4.14): every event live, and the completion carrying
+            // the same structured outcome the batched door returns.
+            AgentRunStream runStream = agent.RunStreamAsync(promptRequest, runCancellation.Token);
+            List<string> responses = [];
+
+            await foreach (AgentStreamEvent streamEvent in runStream)
+            {
+                streamedEvents.Add(streamEvent);
+
+                if (streamEvent.Type is AgentStreamEventType.Response)
+                {
+                    responses.Add(streamEvent.Content);
+                }
+            }
+
+            result = string.Join(string.Empty, responses);
+            runStatus = runStream.Outcome.Status;
+            outcomePendingEffectTool = runStream.Outcome.PendingEffect?.ToolName;
+        }
+        else if (vector.Streamed)
         {
             List<string> responses = [];
 
@@ -1274,9 +1295,9 @@ static bool NarrationConformant(Vector vector, VectorRun run, out string? failur
         return true;
     }
 
-    if (vector.Streamed is false)
+    if (vector.Streamed is false && vector.StreamedOutcome is false)
     {
-        failure = "narration expectations require \"streamed\": true — "
+        failure = "narration expectations require \"streamed\" or \"streamedOutcome\": true — "
             + "the batched door produces and discards its events";
 
         return false;

--- a/Standard.Agents.Tests.Unit/Acceptance/LoopParityTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/LoopParityTests.cs
@@ -423,6 +423,103 @@ public class LoopParityTests
                 + "test ever having to name it");
     }
 
+    // The third door (SPEC.md §4.14): the streamed outcome must be the batched door's outcome —
+    // structure included — while the stream itself keeps every guarantee the second door has.
+    // Derived, not enumerated, exactly like the two-door theory above: outcome, answer, effects
+    // and the full trace, across every scenario this file will ever hold.
+    [Theory]
+    [MemberData(nameof(ScenarioNames))]
+    public async Task ShouldCarryTheBatchedOutcomeThroughTheStreamedDoorAsync(string scenario)
+    {
+        // given — one composition, built fresh for each door
+        Rig batched = Scenarios[scenario]();
+        Rig streamed = Scenarios[scenario]();
+
+        batched.Agent.OnAudit(record =>
+        {
+            lock (batched.Trace)
+            {
+                batched.Trace.Add(record);
+            }
+
+            return ValueTask.CompletedTask;
+        });
+
+        streamed.Agent.OnAudit(record =>
+        {
+            lock (streamed.Trace)
+            {
+                streamed.Trace.Add(record);
+            }
+
+            return ValueTask.CompletedTask;
+        });
+
+        // when
+        AgentOutcome batchedOutcome =
+            await batched.Agent.RunAsync(batched.Prompt, batched.Cancellation);
+
+        AgentRunStream runStream =
+            streamed.Agent.RunStreamAsync(streamed.Prompt, streamed.Cancellation);
+
+        List<AgentStreamEvent> streamedEvents = [];
+
+        await foreach (AgentStreamEvent streamEvent in runStream)
+        {
+            streamedEvents.Add(streamEvent);
+        }
+
+        // then — 1. the outcome, structure included. The effects of two separate runs carry
+        // run-scoped keys, so the comparison is the act's identity, not the record's.
+        runStream.Outcome.Status.Should().Be(
+            batchedOutcome.Status,
+            because: $"on {scenario}, how the run ended must not depend on the door");
+
+        runStream.Outcome.Result.Should().Be(
+            batchedOutcome.Result,
+            because: $"on {scenario}, what the run delivered must not depend on the door");
+
+        (runStream.Outcome.PendingEffect?.ToolName).Should().Be(
+            batchedOutcome.PendingEffect?.ToolName,
+            because: $"on {scenario}, a pending act must ride the streamed outcome exactly as "
+                + "it rides the batched one");
+
+        (runStream.Outcome.PendingEffect?.CallId).Should().Be(
+            batchedOutcome.PendingEffect?.CallId,
+            because: $"on {scenario}, the model-minted call id is the whole mechanism");
+
+        // then — 2. the stream and the outcome are two readings of one run
+        string responses = string.Concat(streamedEvents
+            .Where(streamEvent => streamEvent.Type == AgentStreamEventType.Response)
+            .Select(streamEvent => streamEvent.Content));
+
+        if (batched.DeliversAnswer)
+        {
+            responses.Should().Be(
+                runStream.Outcome.Result,
+                because: $"on {scenario}, concatenating the stream's answer events must equal "
+                    + "the outcome's result (SPEC.md §4.14)");
+        }
+
+        // then — 3. the effects
+        streamed.ToolExecutions().Should().Be(
+            batched.ToolExecutions(),
+            because: $"on {scenario}, the world must not be touched a different number of "
+                + "times depending on which door the prompt entered by");
+
+        // then — 4. the trace, in full
+        var batchedTrace = batched.Trace
+            .Select(record => (record.Kind, record.Actor, record.Message, record.Detail));
+
+        var streamedTrace = streamed.Trace
+            .Select(record => (record.Kind, record.Actor, record.Message, record.Detail));
+
+        streamedTrace.Should().Equal(
+            batchedTrace,
+            because: $"on {scenario}, the streamed outcome adds a reading, not a path — a "
+                + "forked loop diverges here without this test ever having to name it");
+    }
+
     private static StandardAgent BareShell()
     {
         var skillBroker = new Mock<ISkillBroker>();

--- a/Standard.Agents.Tests.Unit/Acceptance/StreamedOutcomeTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/StreamedOutcomeTests.cs
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// The streamed outcome (SPEC.md §4.14): one enumeration, every event live, and — once it
+// completes — the SAME structured outcome the batched door returns. A caller never chooses
+// between the answer's structure and the run's story.
+public class StreamedOutcomeTests
+{
+    private static StandardAgent BareAgent(Func<string, string, ValueTask<string>> brain)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .OnBrain(brain);
+    }
+
+    private sealed class ScriptedTool : ITool
+    {
+        public string Name => "wire_transfer";
+        public string Description => "A scripted tool.";
+        public int Executions { get; private set; }
+
+        public ValueTask<string> ExecuteAsync(string input)
+        {
+            Executions++;
+
+            return ValueTask.FromResult("paid");
+        }
+    }
+
+    [Fact]
+    public async Task ShouldCarryTheHeldActOnTheStreamedOutcomeAsync()
+    {
+        // given — a run that ends held for approval: the batched door reports the hold and
+        // the act itself; the streamed door must report exactly the same ending
+        var tool = new ScriptedTool();
+
+        StandardAgent agent = BareAgent((_, _) =>
+            ValueTask.FromResult("ACTION: wire_transfer: 10"))
+            .Tool(tool)
+            .RequireApproval("wire_transfer");
+
+        // when — through the contract, which is where a host calls it
+        IAgent contract = agent;
+        AgentRunStream runStream = contract.RunStreamAsync("pay the invoice");
+        List<AgentStreamEvent> events = [];
+
+        await foreach (AgentStreamEvent streamEvent in runStream)
+        {
+            events.Add(streamEvent);
+        }
+
+        // then — the events flowed AND the outcome is the batched door's, structure included
+        events.Should().NotBeEmpty();
+        tool.Executions.Should().Be(0);
+
+        runStream.Outcome.Status.Should().Be(AgentStatus.AwaitingApproval);
+        runStream.Outcome.PendingEffect.Should().NotBeNull();
+        runStream.Outcome.PendingEffect!.ToolName.Should().Be("wire_transfer");
+    }
+}

--- a/Standard.Agents/IAgent.cs
+++ b/Standard.Agents/IAgent.cs
@@ -45,4 +45,44 @@ public interface IAgent
     IAsyncEnumerable<AgentStreamEvent> StreamPromptAsync(
         string prompt,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The streamed run (SPEC.md §4.14): every event live, and — once the enumeration
+    /// completes — the same structured outcome <see cref="RunAsync(string)"/> returns. One
+    /// run, two readings; a caller never chooses between the answer's structure and the
+    /// run's story.
+    /// </summary>
+    /// <remarks>
+    /// The default adapts <see cref="StreamPromptAsync"/> and assumes the run answered —
+    /// exactly the assumption <see cref="RunAsync(string)"/>'s default documents, and no less
+    /// accurate than it was. It cannot know a pending effect or a refusal from the events
+    /// alone, so an implementation that runs the loop — and every implementation that runs the
+    /// loop knows how its run ended — should override it.
+    /// </remarks>
+    AgentRunStream RunStreamAsync(
+        string prompt,
+        CancellationToken cancellationToken = default) =>
+        new(setOutcome => AdaptedStreamAsync(prompt, setOutcome, cancellationToken));
+
+    private async IAsyncEnumerable<AgentStreamEvent> AdaptedStreamAsync(
+        string prompt,
+        Action<AgentOutcome> setOutcome,
+        [System.Runtime.CompilerServices.EnumeratorCancellation]
+        CancellationToken cancellationToken)
+    {
+        var answer = new System.Text.StringBuilder();
+
+        await foreach (AgentStreamEvent streamEvent in
+            StreamPromptAsync(prompt, cancellationToken))
+        {
+            if (streamEvent.Type is AgentStreamEventType.Response)
+            {
+                answer.Append(streamEvent.Content);
+            }
+
+            yield return streamEvent;
+        }
+
+        setOutcome(new AgentOutcome(answer.ToString(), AgentStatus.Responded));
+    }
 }

--- a/Standard.Agents/Models/Clients/Agents/AgentRunStream.cs
+++ b/Standard.Agents/Models/Clients/Agents/AgentRunStream.cs
@@ -1,0 +1,34 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Models.Orchestrations.Agents;
+
+namespace Standard.Agents.Models.Clients.Agents;
+
+/// <summary>
+/// The streamed run (SPEC.md §4.14): an enumeration of the run's events that, once the
+/// enumeration completes, carries the same structured outcome the batched door returns — one
+/// run, two readings: the events as they happen, and how it ended. The same shape the decision
+/// tier has always had (a stream whose result rides beside it), one tier up.
+/// </summary>
+public sealed class AgentRunStream : IAsyncEnumerable<AgentStreamEvent>
+{
+    private readonly IAsyncEnumerable<AgentStreamEvent> events;
+
+    /// <summary>
+    /// How the run ended — defined once the enumeration completes (SPEC.md §4.14). Before
+    /// that it reads as a failed run, exactly the seed the batched door starts from.
+    /// </summary>
+    public AgentOutcome Outcome { get; private set; } =
+        new(string.Empty, AgentStatus.Failed);
+
+    public AgentRunStream(
+        Func<Action<AgentOutcome>, IAsyncEnumerable<AgentStreamEvent>> build) =>
+        this.events = build(outcome => this.Outcome = outcome);
+
+    public IAsyncEnumerator<AgentStreamEvent> GetAsyncEnumerator(
+        CancellationToken cancellationToken = default) =>
+        this.events.GetAsyncEnumerator(cancellationToken);
+}

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -4,3 +4,12 @@ Standard.Agents.Models.Clients.Agents.AgentRunStream
 Standard.Agents.Models.Clients.Agents.AgentRunStream.AgentRunStream(System.Func<System.Action<Standard.Agents.Models.Clients.Agents.AgentOutcome!>!, System.Collections.Generic.IAsyncEnumerable<Standard.Agents.Models.Clients.Agents.AgentStreamEvent!>!>! build) -> void
 Standard.Agents.Models.Clients.Agents.AgentRunStream.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerator<Standard.Agents.Models.Clients.Agents.AgentStreamEvent!>!
 Standard.Agents.Models.Clients.Agents.AgentRunStream.Outcome.get -> Standard.Agents.Models.Clients.Agents.AgentOutcome!
+Standard.Agents.Services.Managements.IRunManagementService.RunStreamAsync(Standard.Agents.Models.Clients.Agents.PromptRequest! request) -> Standard.Agents.Models.Clients.Agents.AgentRunStream!
+Standard.Agents.Services.Managements.IRunManagementService.RunStreamAsync(Standard.Agents.Models.Clients.Agents.PromptRequest! request, System.Threading.CancellationToken cancellationToken) -> Standard.Agents.Models.Clients.Agents.AgentRunStream!
+Standard.Agents.Services.Managements.RunManagementService.RunStreamAsync(Standard.Agents.Models.Clients.Agents.PromptRequest! request) -> Standard.Agents.Models.Clients.Agents.AgentRunStream!
+Standard.Agents.Services.Managements.RunManagementService.RunStreamAsync(Standard.Agents.Models.Clients.Agents.PromptRequest! request, System.Threading.CancellationToken cancellationToken) -> Standard.Agents.Models.Clients.Agents.AgentRunStream!
+Standard.Agents.StandardAgent.RunStreamAsync(Standard.Agents.Models.Clients.Agents.PromptRequest! request) -> Standard.Agents.Models.Clients.Agents.AgentRunStream!
+Standard.Agents.StandardAgent.RunStreamAsync(Standard.Agents.Models.Clients.Agents.PromptRequest! request, System.Threading.CancellationToken cancellationToken) -> Standard.Agents.Models.Clients.Agents.AgentRunStream!
+Standard.Agents.StandardAgent.RunStreamAsync(string! prompt, string! sessionId) -> Standard.Agents.Models.Clients.Agents.AgentRunStream!
+Standard.Agents.StandardAgent.RunStreamAsync(string! prompt, string! sessionId, System.Threading.CancellationToken cancellationToken) -> Standard.Agents.Models.Clients.Agents.AgentRunStream!
+Standard.Agents.StandardAgent.RunStreamAsync(string! prompt, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Standard.Agents.Models.Clients.Agents.AgentRunStream!

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Standard.Agents.IAgent.RunStreamAsync(string! prompt, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Standard.Agents.Models.Clients.Agents.AgentRunStream!
+Standard.Agents.Models.Clients.Agents.AgentRunStream
+Standard.Agents.Models.Clients.Agents.AgentRunStream.AgentRunStream(System.Func<System.Action<Standard.Agents.Models.Clients.Agents.AgentOutcome!>!, System.Collections.Generic.IAsyncEnumerable<Standard.Agents.Models.Clients.Agents.AgentStreamEvent!>!>! build) -> void
+Standard.Agents.Models.Clients.Agents.AgentRunStream.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerator<Standard.Agents.Models.Clients.Agents.AgentStreamEvent!>!
+Standard.Agents.Models.Clients.Agents.AgentRunStream.Outcome.get -> Standard.Agents.Models.Clients.Agents.AgentOutcome!

--- a/Standard.Agents/Services/Managements/IRunManagementService.cs
+++ b/Standard.Agents/Services/Managements/IRunManagementService.cs
@@ -73,4 +73,16 @@ public interface IRunManagementService
     IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
         PromptRequest request,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The streamed outcome (SPEC.md §4.14): the same loop, every event live, and — once the
+    /// enumeration completes — the same structured outcome <see cref="RunAsync(PromptRequest)"/>
+    /// returns. One run, two readings; never a choice between the answer's structure and the
+    /// run's story.
+    /// </summary>
+    AgentRunStream RunStreamAsync(PromptRequest request);
+
+    AgentRunStream RunStreamAsync(
+        PromptRequest request,
+        CancellationToken cancellationToken);
 }

--- a/Standard.Agents/Services/Managements/RunManagementService.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.cs
@@ -262,15 +262,33 @@ public partial class RunManagementService : IRunManagementService
         PromptRequest request) =>
         ProcessPromptStreamAsync(request, CancellationToken.None);
 
-    public async IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
+    public IAsyncEnumerable<AgentStreamEvent> ProcessPromptStreamAsync(
         PromptRequest request,
+        CancellationToken cancellationToken) =>
+        MappedStreamAsync(request, setOutcome: _ => { }, cancellationToken);
+
+    // The third reading of the one loop (SPEC.md §4.14): every event live, and the outcome the
+    // batched door returns. RunCoreAsync has always computed it on this door too — this routine
+    // simply stops discarding it, so a caller never chooses between the answer's structure and
+    // the run's story.
+    public AgentRunStream RunStreamAsync(PromptRequest request) =>
+        RunStreamAsync(request, CancellationToken.None);
+
+    public AgentRunStream RunStreamAsync(
+        PromptRequest request,
+        CancellationToken cancellationToken) =>
+        new(setOutcome => MappedStreamAsync(request, setOutcome, cancellationToken));
+
+    private async IAsyncEnumerable<AgentStreamEvent> MappedStreamAsync(
+        PromptRequest request,
+        Action<AgentOutcome> setOutcome,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         await using IAsyncEnumerator<AgentStreamEvent> events =
             RunCoreAsync(
                 request,
                 streaming: true,
-                setOutcome: _ => { },
+                setOutcome,
                 cancellationToken)
                     .GetAsyncEnumerator(cancellationToken);
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -1432,6 +1432,74 @@ public sealed partial class StandardAgent : IAgent
         }
     }
 
+    /// <summary>
+    /// The streamed outcome (SPEC.md §4.14): the same run as <see cref="StreamPromptAsync(string, CancellationToken)"/>,
+    /// whose enumeration also carries — once it completes — the same structured outcome
+    /// <see cref="RunAsync(PromptRequest, CancellationToken)"/> returns: status, result, and any
+    /// pending effect with its model-minted call id. One run, two readings; a caller never
+    /// chooses between the answer's structure and the run's story.
+    /// </summary>
+    /// <param name="prompt">The user's prompt.</param>
+    /// <param name="cancellationToken">Token to stop the run at its next turn boundary.</param>
+    /// <returns>The run's events, carrying its outcome at completion.</returns>
+    public AgentRunStream RunStreamAsync(
+        string prompt,
+        CancellationToken cancellationToken = default) =>
+        RunStreamAsync(new PromptRequest { Prompt = prompt }, cancellationToken);
+
+    /// <summary>The same streamed outcome, inside a conversation.</summary>
+    /// <param name="prompt">The user's prompt.</param>
+    /// <param name="sessionId">Which conversation this belongs to.</param>
+    /// <returns>The run's events, carrying its outcome at completion.</returns>
+    public AgentRunStream RunStreamAsync(string prompt, string sessionId) =>
+        RunStreamAsync(prompt, sessionId, CancellationToken.None);
+
+    /// <summary>The same conversation-carrying streamed outcome, cancellable.</summary>
+    /// <param name="prompt">The user's prompt.</param>
+    /// <param name="sessionId">Which conversation this belongs to.</param>
+    /// <param name="cancellationToken">Token to stop the run at its next turn boundary.</param>
+    /// <returns>The run's events, carrying its outcome at completion.</returns>
+    public AgentRunStream RunStreamAsync(
+        string prompt,
+        string sessionId,
+        CancellationToken cancellationToken) =>
+        RunStreamAsync(
+            new PromptRequest { Prompt = prompt, SessionId = sessionId },
+            cancellationToken);
+
+    /// <summary>The same streamed outcome, asked for by a caller's request.</summary>
+    /// <param name="request">The caller's prompt and per-request inference options.</param>
+    /// <returns>The run's events, carrying its outcome at completion.</returns>
+    public AgentRunStream RunStreamAsync(PromptRequest request) =>
+        RunStreamAsync(request, CancellationToken.None);
+
+    /// <summary>The same request-carrying streamed outcome, cancellable.</summary>
+    /// <param name="request">The caller's prompt and per-request inference options.</param>
+    /// <param name="cancellationToken">Token to stop the run at its next turn boundary.</param>
+    /// <returns>The run's events, carrying its outcome at completion.</returns>
+    public AgentRunStream RunStreamAsync(
+        PromptRequest request,
+        CancellationToken cancellationToken) =>
+        new(setOutcome => ResolvedRunStreamAsync(request, setOutcome, cancellationToken));
+
+    // The inner stream's outcome is handed outward when the enumeration ends, so the wrapper
+    // the caller holds carries what the composed agent's run concluded — same seam, one tier up.
+    private async IAsyncEnumerable<AgentStreamEvent> ResolvedRunStreamAsync(
+        PromptRequest request,
+        Action<AgentOutcome> setOutcome,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        AgentRunStream events =
+            (await ResolveAgentAsync()).RunStreamAsync(request, cancellationToken);
+
+        await foreach (AgentStreamEvent streamEvent in events.WithCancellation(cancellationToken))
+        {
+            yield return streamEvent;
+        }
+
+        setOutcome(events.Outcome);
+    }
+
     // Composes once and reuses. Guarded because one agent serves prompts concurrently
     // (SPEC.md §4.4) and an unguarded `??=` lets two arriving prompts each build a graph —
     // two brokers over one audit sink, two of everything, one silently discarded.

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -73,6 +73,7 @@ capability it configures did not exist, which is why the early vectors still des
 | `contractSchema`, `configuredTemperature`, `configuredMaxTokens` | the deployment's side of precedence: hard configuration a request can never move |
 | `brokerHonorsRequest` | `false` swaps in the scripted Brain that never opted in, so degradation runs through the interface's real default members |
 | `streamed` | run the request through the streamed loop, which enforces every control the batched one does |
+| `streamedOutcome` | run the request through the third door (§4.14): the enumeration's events AND the structured outcome its completion carries, so `status` / `pendingEffectTool` certify on the streamed door too |
 | `toolNarrations` | a stub tool's declared narration templates, `{tool: {starting, observed}}` — `{tool}` and `{payload}` slots interpolate |
 | `gateVerdictOnNarration` | the verdict the scripted Gate returns for model narration — screened text that is neither the prompt nor a tool's output |
 | `nativeReplies[].narration` | the SAY line's native twin: narration riding the structured result |
@@ -204,6 +205,7 @@ the deterministic core of the Standard.
 | `a-refused-narration-is-withheld` | A refused narration reaches no channel at all, and the run is unharmed (Invariant 5, §4.9) |
 | `a-tool-narrates-and-the-model-says-nothing` | A tool's declared templates are the floor: the run never goes silent because the model was terse (§6.0) |
 | `native-narration-rides-the-result` | A V1 result's narration flows through the same loop seam, and model prose beats the template (§6.0, §6.2) |
+| `the-streamed-outcome-carries-the-pending-call` | The streamed run's completion carries the batched door's outcome — pending call included — while narration flows live (§4.14) |
 
 ## Readiness profiles
 

--- a/conformance/profiles/enterprise.json
+++ b/conformance/profiles/enterprise.json
@@ -31,6 +31,7 @@
     "provider-options-cannot-touch-core-owned-keys",
     "caller-tool-never-executes",
     "caller-tool-call-ends-run-as-pending-effect",
+    "the-streamed-outcome-carries-the-pending-call",
     "caller-tool-name-collision-drops-caller-tool",
     "pending-call-rides-the-outcome-without-a-session",
     "the-callers-transcript-reaches-the-brain"

--- a/conformance/vectors/68-the-streamed-outcome-carries-the-pending-call.json
+++ b/conformance/vectors/68-the-streamed-outcome-carries-the-pending-call.json
@@ -1,0 +1,25 @@
+{
+  "name": "the-streamed-outcome-carries-the-pending-call",
+  "description": "SPEC.md 4.14: an implementation offering both doors MUST offer a streamed run whose enumeration yields every event live and whose completion carries the same structured outcome the batched door returns. This vector runs the seam's hardest case through the third door at once: a narrated caller-tool yield. The narration must flow on the stream (6.0), and the completion must carry AwaitingInput with the pending call - because an implementation that discards the outcome on the streamed door forces every outcome-needing exposer onto the batched door, where the run's story is produced and discarded, which is exactly how the first production consumer watched five narration lines land in one lump with the answer.",
+  "generatorReplies": [
+    "SAY: Asking your mail tool to send it...\nACTION: send_email: {\"to\":\"jane@acme.com\"}"
+  ],
+  "tools": {},
+  "prompt": "email jane the report",
+  "maxTurns": 2,
+  "streamedOutcome": true,
+  "request": {
+    "callerTools": [
+      {
+        "name": "send_email",
+        "description": "Sends an email from the caller's own outbox."
+      }
+    ]
+  },
+  "expect": {
+    "resultContains": "send_email",
+    "status": "AwaitingInput",
+    "pendingEffectTool": "send_email",
+    "narrationsContain": [ "Asking your mail tool to send it..." ]
+  }
+}

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1458,6 +1458,54 @@ native carry — each proven able to fail.
 
 ---
 
+## 20 · The streamed outcome — events that end in an answer's structure
+
+The loop has always had two doors: `RunAsync` returns the structured outcome — status, result,
+any pending effect with its model-minted call id — and discards the run's events;
+`StreamPromptAsync` yields the events and loses the outcome. Every *control* held on both
+(§7.6), but the *capabilities* split consumers: an exposer that yields a pending call to its own
+caller needs the outcome, so it ran batched — and watched the run's narration land in one lump
+with the answer. The streamed outcome (SPEC.md §4.14) is the third reading that ends the choice:
+
+```csharp
+AgentRunStream run = agent.RunStreamAsync(request, cancellationToken);
+
+await foreach (AgentStreamEvent streamEvent in run)
+{
+    // Status, Thinking, Narration, Tool, Response — live, exactly as StreamPromptAsync
+    // yields them, with every control and every screening intact.
+}
+
+AgentOutcome outcome = run.Outcome;
+// The SAME outcome RunAsync returns for this run: outcome.Status, outcome.Result,
+// outcome.PendingEffect (tool name, arguments, the model-minted CallId).
+```
+
+Three guarantees, each pinned by `LoopParityTests`' derived third-door theory and by
+conformance vector 68 (`the-streamed-outcome-carries-the-pending-call`):
+
+- **The outcome is the batched door's.** Status, result and the pending act's identity are
+  identical to what `RunAsync` returns for the same scenario — a caller-tool yield arrives
+  as `AwaitingInput` with the call id the model minted, ready to hand back to the caller.
+- **The stream and the outcome are two readings of one run.** Concatenating the `Response`
+  events equals `Outcome.Result`; the decision-log trace is record-for-record identical to
+  the batched door's. The streamed outcome adds a reading, not a path — the loop is still
+  the only copy.
+- **`Outcome` is a completion product.** It is defined once the enumeration ends; before
+  that it reads as a failed run, exactly the seed the batched door starts from.
+
+`RunStreamAsync` is also on `IAgent`, with an honest default for implementations that do not
+run the loop: it adapts `StreamPromptAsync` and assumes the run answered — the same assumption
+`RunAsync`'s default documents — so an implementation that knows how its run ended should
+override it, and every implementation that runs the loop does.
+
+For a host bridging this to an OpenAI-style SSE endpoint, the shape is now one enumeration:
+forward each event as it arrives (narration as its own delta field, §19), and when the
+enumeration completes read `Outcome` to decide the terminal frame — a `stop` with the answer,
+or a `tool_calls` yield carrying the pending call.
+
+---
+
 ## Putting it together
 
 The builder composes cleanly — take only what you need:


### PR DESCRIPTION
Implements SPEC.md v1.10 section 4.14 (spec-first, merged in the specs repo as PR #30): the loop's third reading. `RunStreamAsync` yields every event live and its completion carries the same structured outcome `RunAsync` returns - status, result, and the pending effect with its model-minted call id. One run, two readings; a caller never chooses between the answer's structure and the run's story.

The implementation is one honest sentence: `RunCoreAsync` has always computed the outcome on the streamed door - `ProcessPromptStreamAsync` discarded it with `setOutcome: _ => { }`. The new routine stops discarding it. `AgentRunStream` is the decision tier's stream-plus-result shape, one tier up; `IAgent.RunStreamAsync` ships as a default interface member whose adaptation assumes the run answered (the same documented assumption `RunAsync`'s default makes), so external implementations keep compiling and the genuine FAIL in the TDD arc was the default guessing where the loop knows.

Pinned three ways: the FAIL/PASS pair (a held act's outcome through the streamed door), LoopParityTests' derived third-door theory (outcome, answer, effects, and full trace across all 15 scenarios - sabotage-verified), and conformance vector 68, which runs a narrated caller-tool yield through the third door and is proven able to fail.

650 tests x net8.0/net10.0, 68/68 vectors, Critical certified, zero warnings, 16 API symbols in Unshipped.

This is the framework prerequisite for LLooMA 2.0's live narration: the orchestrator can now stream mid-run and still read the outcome, and drop its OnAudit log-format coupling for the first-class event stream.