### PR TITLE
MAJOR COORDINATIONS: Enforced Selection - The Offering Binds At The Perimeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,11 @@ agent.OnSelectTools((task, described) =>
         NeedsTheWeb(task) ? new[] { "web_search" } : Array.Empty<string>()));
 ```
 
+And when the Brain is not fully mediated by the loop — a custom brain, a gateway, a model
+router that could carry side-channel knowledge of the catalog — `.EnforceSelection()` makes
+the offering binding at the Direction perimeter: an unoffered tool is denied and the run
+recovers, exactly as a policy denial is handled.
+
 No DI container. `Compose()` hand-wires the whole graph — SPEC.md §9: *"DI is OPTIONAL. A
 hand-wired composition root is fully conformant."*
 

--- a/Standard.Agents.Tests.Unit/Acceptance/SelectionEnforcementTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/SelectionEnforcementTests.cs
@@ -132,4 +132,111 @@ public class SelectionEnforcementTests
         secondTurnMessages.Should().Contain(message =>
             message.Content != null && message.Content.Contains("not offered"));
     }
+
+    // Off by default: without enforcement, an unoffered tool keeps its §4.15 treatment —
+    // reachable if the Brain names it — so no existing deployment changes behavior.
+    [Fact]
+    public async Task ShouldKeepAnUnofferedToolReachableWithoutEnforcementAsync()
+    {
+        // given — the same disobedient brain, with no enforcement configured
+        var webSearch = new NamedTool("web_search");
+        var calculator = new NamedTool("calculator");
+
+        StandardAgent agent = AgentWith(
+            CallsThenAnswers("web_search", "done"),
+            webSearch, calculator)
+            .OnSelectTools((task, described) =>
+                new ValueTask<IReadOnlyList<string>>(new[] { "calculator" }));
+
+        // when
+        string result = await agent.ProcessPromptAsync("what is 2 + 2?");
+
+        // then — the unamended behavior: the named tool ran
+        webSearch.Executions.Should().Be(1);
+        result.Should().Be("done");
+    }
+
+    // Enforcement takes effect only when a selector recorded an offering: with no selector
+    // there is nothing to enforce, and every described tool remains offered and callable.
+    [Fact]
+    public async Task ShouldNotDenyAnythingWhenNoSelectorIsConfiguredAsync()
+    {
+        // given — enforcement on, but no selection judgment supplied
+        var webSearch = new NamedTool("web_search");
+
+        StandardAgent agent = AgentWith(
+            CallsThenAnswers("web_search", "done"),
+            webSearch)
+            .EnforceSelection();
+
+        // when
+        string result = await agent.ProcessPromptAsync("look something up");
+
+        // then
+        webSearch.Executions.Should().Be(1);
+        result.Should().Be("done");
+    }
+
+    // A name selection never saw is not selection's to withhold: an undescribed tool keeps its
+    // §6.1 treatment — callable if the Brain names it, never advertised — under enforcement too.
+    [Fact]
+    public async Task ShouldNotDenyAnUndescribedToolAsync()
+    {
+        // given — a tool with no description (selection operates over described names only) and
+        // a selector that offers nothing
+        var undescribed = new NamedTool("secret_helper", description: "");
+
+        StandardAgent agent = AgentWith(
+            CallsThenAnswers("secret_helper", "done"),
+            undescribed)
+            .OnSelectTools((task, described) =>
+                new ValueTask<IReadOnlyList<string>>(Array.Empty<string>()))
+            .EnforceSelection();
+
+        // when
+        string result = await agent.ProcessPromptAsync("hello");
+
+        // then
+        undescribed.Executions.Should().Be(1);
+        result.Should().Be("done");
+    }
+
+    // Caller tools are the caller's own vocabulary and are never subject to selection
+    // (SPEC.md §4.15): under enforcement, a call naming one still goes back to the caller as a
+    // pending effect — classified before the perimeter, so there is nothing here to deny.
+    [Fact]
+    public async Task ShouldNeverDenyACallerToolAsync()
+    {
+        // given — enforcement on and an offering of nothing; the brain names the CALLER's tool
+        StandardAgent agent = AgentWith(
+            (messages, tools) => new GenerationResult
+            {
+                Content = string.Empty,
+                ToolCalls = [new ModelToolCall("call_9", "send_email", """{"to":"jane"}""")],
+            })
+            .OnSelectTools((task, described) =>
+                new ValueTask<IReadOnlyList<string>>(Array.Empty<string>()))
+            .EnforceSelection();
+
+        var request = new PromptRequest
+        {
+            Prompt = "email jane the report",
+
+            CallerTools =
+            [
+                new ToolDefinition(
+                    Name: "send_email",
+                    Description: "Sends an email from the caller's own outbox.",
+                    ParametersJson: "{}")
+            ]
+        };
+
+        // when
+        AgentOutcome outcome = await agent.RunAsync(request);
+
+        // then — the run paused for the caller rather than denying or refusing
+        outcome.Status.Should().Be(AgentStatus.AwaitingInput);
+        outcome.PendingEffect.Should().NotBeNull();
+        outcome.PendingEffect!.ToolName.Should().Be("send_email");
+    }
 }

--- a/Standard.Agents.Tests.Unit/Acceptance/SelectionEnforcementTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/SelectionEnforcementTests.cs
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// Enforced selection (SPEC.md §4.15): selection narrows what a run is SHOWN, and a brain the
+// loop fully mediates can only call what it was shown. But a brain is configuration — a custom
+// brain, a gateway, a model router — and configuration can carry side-channel knowledge of the
+// catalog. With enforcement on, the offering also BINDS at the Direction perimeter: an act
+// naming an advertised tool the run was not offered is denied — told, non-terminal,
+// recoverable — exactly as a policy denial is. Off by default; the §4.15 treatment of an
+// unoffered tool (reachable if the Brain names it) remains the unamended behavior.
+public class SelectionEnforcementTests
+{
+    private sealed class NamedTool : ITool
+    {
+        private readonly string description;
+
+        public NamedTool(string name, string description = null!)
+        {
+            Name = name;
+            this.description = description ?? $"The {name} tool.";
+        }
+
+        public string Name { get; }
+        public string Description => this.description;
+        public string Parameters => """{"type":"object"}""";
+        public int Executions { get; private set; }
+
+        public ValueTask<string> ExecuteAsync(string input)
+        {
+            Executions++;
+
+            return ValueTask.FromResult("ran");
+        }
+    }
+
+    private static StandardAgent AgentWith(
+        Func<IReadOnlyList<ConversationMessage>, IReadOnlyList<ToolDefinition>, GenerationResult> reply,
+        params ITool[] tools)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+
+        skillBroker.Setup(broker => broker.SelectSkillsAsync())
+            .ReturnsAsync(new List<Skill> { new() { Content = "You are an assistant." } });
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        StandardAgent agent = new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .OnNativeBrain((messages, tools) => ValueTask.FromResult(reply(messages, tools)));
+
+        foreach (ITool tool in tools)
+        {
+            agent = agent.Tool(tool);
+        }
+
+        return agent;
+    }
+
+    // A brain that names a tool on its first decision and answers on its second — the shape of
+    // every disobedient-brain scenario below.
+    private static Func<IReadOnlyList<ConversationMessage>, IReadOnlyList<ToolDefinition>, GenerationResult>
+        CallsThenAnswers(string toolName, string answer, Action<IReadOnlyList<ConversationMessage>> onSecondTurn = null!)
+    {
+        int brainCalls = 0;
+
+        return (messages, tools) =>
+        {
+            if (++brainCalls == 1)
+            {
+                return new GenerationResult
+                {
+                    Content = string.Empty,
+                    ToolCalls = [new ModelToolCall("call_1", toolName, "{}")],
+                };
+            }
+
+            onSecondTurn?.Invoke(messages);
+
+            return new GenerationResult { Content = answer };
+        };
+    }
+
+    [Fact]
+    public async Task ShouldDenyAnUnofferedToolWhenTheOfferingIsEnforcedAsync()
+    {
+        // given — the run is offered only the calculator, yet the brain names web_search anyway
+        var webSearch = new NamedTool("web_search");
+        var calculator = new NamedTool("calculator");
+        IReadOnlyList<ConversationMessage> secondTurnMessages = null!;
+
+        StandardAgent agent = AgentWith(
+            CallsThenAnswers(
+                "web_search",
+                "answered among what was offered",
+                messages => secondTurnMessages = messages),
+            webSearch, calculator)
+            .OnSelectTools((task, described) =>
+                new ValueTask<IReadOnlyList<string>>(new[] { "calculator" }))
+            .EnforceSelection();
+
+        // when
+        string result = await agent.ProcessPromptAsync("what is 2 + 2?");
+
+        // then — the act never ran, the denial was told, and the run recovered
+        webSearch.Executions.Should().Be(0);
+        result.Should().Be("answered among what was offered");
+
+        secondTurnMessages.Should().Contain(message =>
+            message.Content != null && message.Content.Contains("not offered"));
+    }
+}

--- a/Standard.Agents/Models/Coordinations/Directions/PerimeterPolicy.cs
+++ b/Standard.Agents/Models/Coordinations/Directions/PerimeterPolicy.cs
@@ -52,4 +52,21 @@ public sealed record PerimeterPolicy
     /// can change between prompts on a shared agent (SPEC.md §4.4).
     /// </summary>
     public Func<AgentPrincipal?>? IdentityResolver { get; init; }
+
+    /// <summary>
+    /// Whether the run's offering (SPEC.md §4.15) binds at the perimeter. Off by default: an
+    /// unoffered tool keeps its §6.1 treatment — callable if the Brain names it. On, an act
+    /// naming an advertised tool the run was not offered is denied — told, non-terminal,
+    /// recoverable — because a Brain outside this loop's mediation can carry side-channel
+    /// knowledge of the catalog and name a tool the run was never shown. Caller tools are never
+    /// subject to selection, and an undescribed tool keeps its §6.1 treatment either way.
+    /// </summary>
+    public bool EnforceSelection { get; init; }
+
+    /// <summary>
+    /// The advertised tool names — what selection could have offered — so the perimeter can
+    /// tell a withheld tool from an undescribed one. Derived at composition from the same
+    /// rendering the catalogs use, so the two can never disagree.
+    /// </summary>
+    public IReadOnlyCollection<string> AdvertisedTools { get; init; } = [];
 }

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.AdvertisedTools.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.AdvertisedTools.init -> void
+Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.EnforceSelection.get -> bool
+Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.EnforceSelection.init -> void

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@ Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.AdvertisedTools.
 Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.AdvertisedTools.init -> void
 Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.EnforceSelection.get -> bool
 Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.EnforceSelection.init -> void
+Standard.Agents.StandardAgent.EnforceSelection() -> Standard.Agents.StandardAgent!

--- a/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Perimeter.cs
+++ b/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Perimeter.cs
@@ -22,6 +22,25 @@ public partial class DirectionCoordinationService
 {
     private async ValueTask<AgentContext> ActOnEffectAsync(AgentContext context)
     {
+        // 0 — the offering (SPEC.md §4.15, enforced). Selection narrows what a run is SHOWN;
+        // with enforcement on, the offering also binds here: an advertised tool the run was not
+        // offered is denied before it becomes an act, because a Brain outside this loop's
+        // mediation can carry side-channel knowledge of the catalog and name a tool the run was
+        // never shown. Caller tools never reach this method (classified before the perimeter),
+        // and an undescribed tool keeps its §6.1 treatment.
+        if (DeniedBecauseSelectionWithheldIt(context.DirectionType))
+        {
+            string withheld =
+                $"tool '{context.DirectionType}' was not offered to this run: selection "
+                    + "withheld it. Choose among the offered tools or answer directly.";
+
+            await this.loggingBroker.LogProcessAsync(
+                "Direction",
+                $"Selection → DENIED '{context.DirectionType}': not offered to this run");
+
+            return Denied(context, withheld);
+        }
+
         AgentEffect effect = AgentEffect.For(
             runId: AgentRun.Current?.Id ?? string.Empty,
             toolName: context.DirectionType,
@@ -328,4 +347,13 @@ public partial class DirectionCoordinationService
 
     private bool RequiresApproval(string toolName) =>
         this.irreversibleToolNames.Contains(toolName);
+
+    // Enforcement speaks only where selection spoke: a run with no recorded offering (no
+    // selector configured) has nothing to enforce, and a name selection never saw (undescribed,
+    // §6.1) is not selection's to withhold.
+    private bool DeniedBecauseSelectionWithheldIt(string toolName) =>
+        this.enforceSelection
+            && AgentRun.Current?.OfferedTools is { } offered
+            && this.advertisedToolNames.Contains(toolName)
+            && offered.Contains(toolName, StringComparer.OrdinalIgnoreCase) is false;
 }

--- a/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.cs
@@ -35,6 +35,8 @@ public partial class DirectionCoordinationService : IDirectionCoordinationServic
     private readonly IReadOnlyDictionary<string, RiskLevel> toolRisk;
     private readonly IReadOnlyDictionary<string, Func<string, string>> toolScope;
     private readonly Func<AgentEffect, bool>? explicitlyPermits;
+    private readonly bool enforceSelection;
+    private readonly HashSet<string> advertisedToolNames;
 
     // Asked once per act rather than captured once at composition, because who is acting can
     // change between prompts on the same agent — a singleton serving many callers is the shape
@@ -66,6 +68,11 @@ public partial class DirectionCoordinationService : IDirectionCoordinationServic
 
         this.irreversibleToolNames = new HashSet<string>(
             standingOrders.IrreversibleTools, StringComparer.OrdinalIgnoreCase);
+
+        this.enforceSelection = standingOrders.EnforceSelection;
+
+        this.advertisedToolNames = new HashSet<string>(
+            standingOrders.AdvertisedTools, StringComparer.OrdinalIgnoreCase);
     }
 
     public ValueTask<AgentContext> ActAsync(AgentContext context) =>

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -306,6 +306,26 @@ public sealed partial class StandardAgent : IAgent
         Func<string, IReadOnlyList<string>, ValueTask<IReadOnlyList<string>>> selector) =>
         Set(() => this.localToolSelector = selector);
 
+    // Whether the offering binds at the Direction perimeter, held until composition hands it
+    // to the perimeter's standing orders.
+    private bool enforceSelection;
+
+    /// <summary>
+    /// Makes the run's offering <b>binding</b> at the Direction perimeter (SPEC.md §4.15): an
+    /// act naming an advertised tool the run was not offered is denied — told, non-terminal,
+    /// recoverable — exactly as a policy denial is, and the agent may choose a permitted path
+    /// on the next turn. Off by default: without it, an unoffered tool keeps its §6.1
+    /// treatment, reachable if the Brain names it. Turn it on when the Brain is not fully
+    /// mediated by this loop — a custom brain, a gateway, a model router — where side-channel
+    /// knowledge of the catalog can name tools the run was never shown. Caller-declared tools
+    /// are never subject to selection, and an undescribed tool keeps its §6.1 treatment
+    /// either way. Takes effect only when a selector is configured: with no offering recorded,
+    /// there is nothing to enforce.
+    /// </summary>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent EnforceSelection() =>
+        Set(() => this.enforceSelection = true);
+
     /// <summary>
     /// Turns on the Judge using an in-process model — the local counterpart to <see cref="Judge"/>,
     /// with no API calls. The delegate receives the built-in judge rubric as the system prompt and
@@ -1874,7 +1894,14 @@ public sealed partial class StandardAgent : IAgent
                 ExplicitlyPermits =
                     policy is AllowListPolicyBroker allowList ? allowList.Mentions : null,
 
-                IdentityResolver = this.identityResolver
+                IdentityResolver = this.identityResolver,
+
+                EnforceSelection = this.enforceSelection,
+
+                // What selection could have offered, from the same rendering the catalogs use
+                // (SPEC.md §6.1: a description is the opt-in), so the perimeter can tell a
+                // withheld tool from an undescribed one and the two can never disagree.
+                AdvertisedTools = [.. Advertised(allTools).Select(tool => tool.Name)]
             });
 
         return new RunManagementService(

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1548,6 +1548,27 @@ The boundaries, each pinned by tests and by conformance vector 69:
 Absent a selector, every described tool is offered — exactly the behavior every existing
 composition has today.
 
+### Enforced selection — when the Brain is not fully mediated
+
+A brain the loop fully mediates can only call what it was shown. But a brain is
+configuration — a custom brain, a gateway, a model router — and configuration can carry
+side-channel knowledge of the catalog: production found this the day a custom routing brain
+handed its backend the full catalog and a greeting kept web-searching *after* selection was
+live. `EnforceSelection()` makes the offering **binding** at the Direction perimeter:
+
+```csharp
+agent
+    .OnSelectTools((task, described) => SelectFor(task, described))
+    .EnforceSelection();
+```
+
+An act naming an advertised tool the run was not offered is denied — told, non-terminal,
+recoverable, exactly as a policy denial is — and the agent chooses a permitted path on the
+next turn: `Selection → DENIED 'web_search': not offered to this run`. Off by default; the
+boundaries hold under enforcement too: caller tools are never denied (they are classified
+before the perimeter), an undescribed tool keeps its §6.1 treatment, and with no selector
+configured there is no offering to enforce, so nothing changes.
+
 ---
 
 ## Putting it together


### PR DESCRIPTION
## What

Selection (SPEC.md 4.15, v1.15.0) narrows what a run is SHOWN. This makes the offering optionally BINDING: `.EnforceSelection()` (off by default) denies an act naming an advertised tool the run was not offered — told, non-terminal, recoverable, exactly as a policy denial is — so the agent chooses a permitted path on the next turn.

## Why

A Brain the loop fully mediates can only call what it was shown. But a Brain is configuration — a custom brain, a gateway, a model router — and configuration can carry side-channel knowledge of the catalog. Production found exactly that: a custom routing brain handed its backend the full catalog, and a greeting kept web-searching *after* selection went live. The invariant "a model cannot over-call a tool it was never shown" now has an enforcement mode that holds for every Brain, not only the ones the framework fully mediates.

## Shape

- `DATA`: `PerimeterPolicy` carries `EnforceSelection` + `AdvertisedTools` (derived from the same §6.1 rendering the catalogs use, so they can never disagree).
- Step **0 — the offering** in the perimeter sequence, before authorize: `Selection → DENIED 'web_search': not offered to this run`.
- Boundaries held and sabotage-verified: **off by default** (no existing deployment changes behavior), **no selector → nothing to enforce**, **undescribed tools keep §6.1**, **caller tools are never denied** (classified before the perimeter).

663 tests green on net8.0 + net10.0 (5 new; FAIL→PASS and two sabotage runs each caught by exactly the intended tests).

Spec-first: The-Standard-Agent-Specs PR #32 (Version 1.12) writes the mode into §4.15.

Follow-up (separate PR): a conformance vector claiming the capability in the enterprise profile.
