### PR TITLE
RELEASES: Standard.Agents 1.16.0.0 - Enforced Selection

### DIFF
--- a/Standard.Agents/PublicAPI.Shipped.txt
+++ b/Standard.Agents/PublicAPI.Shipped.txt
@@ -599,8 +599,12 @@ Standard.Agents.Models.Coordinations.Agents.ToolSelector.SelectAsync(string! tas
 Standard.Agents.Models.Coordinations.Agents.ToolSelector.ToolSelector(System.Func<string!, System.Collections.Generic.IReadOnlyList<string!>!, System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<string!>!>>! select) -> void
 Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy
 Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.<Clone>$() -> Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy!
+Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.AdvertisedTools.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.AdvertisedTools.init -> void
 Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.DeclaredRisk.get -> System.Collections.Generic.IReadOnlyDictionary<string!, Standard.Agents.Models.Orchestrations.Effects.RiskLevel>!
 Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.DeclaredRisk.init -> void
+Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.EnforceSelection.get -> bool
+Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.EnforceSelection.init -> void
 Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.Equals(Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy? other) -> bool
 Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.ExplicitlyPermits.get -> System.Func<Standard.Agents.Models.Orchestrations.Effects.AgentEffect!, bool>?
 Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.ExplicitlyPermits.init -> void
@@ -1284,6 +1288,7 @@ Standard.Agents.StandardAgent.Consumption(string! path) -> Standard.Agents.Stand
 Standard.Agents.StandardAgent.Contract(string! jsonSchema) -> Standard.Agents.StandardAgent!
 Standard.Agents.StandardAgent.Description.get -> string!
 Standard.Agents.StandardAgent.EffectLedger(string! path) -> Standard.Agents.StandardAgent!
+Standard.Agents.StandardAgent.EnforceSelection() -> Standard.Agents.StandardAgent!
 Standard.Agents.StandardAgent.Fallback(System.Func<System.Threading.Tasks.ValueTask<string!>>! fallback, int retries = 0, int failuresBeforeOpen = 3) -> Standard.Agents.StandardAgent!
 Standard.Agents.StandardAgent.Gate(string! apiUrl, string! apiKey, string! model, double temperature = 0, int maxTokens = 16, int timeoutSeconds = 30) -> Standard.Agents.StandardAgent!
 Standard.Agents.StandardAgent.Identity(string! name, string! description = "") -> Standard.Agents.StandardAgent!

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.AdvertisedTools.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
-Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.AdvertisedTools.init -> void
-Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.EnforceSelection.get -> bool
-Standard.Agents.Models.Coordinations.Directions.PerimeterPolicy.EnforceSelection.init -> void
-Standard.Agents.StandardAgent.EnforceSelection() -> Standard.Agents.StandardAgent!

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -484,7 +484,21 @@
          offering; identical on all three doors. ToolSelector carries the delegate per the tier
          discipline; AgentRun.OfferedTools carries the offering per run. Spec-first: tracks
          SPEC.md v1.11 (SS4.15). New routines and models: segment 2 advances, 3/4 reset. -->
-    <Version>1.15.0.0</Version>
+    <!-- 1.16.0.0 "Enforced Selection": selection governs what a run is SHOWN; it cannot govern
+         what a Brain already knows. A Brain the loop fully mediates can only call what it was
+         offered, but a Brain is configuration - a custom brain, a gateway, a model router - and
+         configuration can carry side-channel knowledge of the catalog (the motivating production
+         finding: a custom routing brain advertised the full catalog to its backend, and a
+         greeting kept web-searching AFTER selection was live). EnforceSelection(), off by
+         default, makes the offering BINDING at the Direction perimeter as step 0 of the
+         sequence: an act naming an advertised tool the run was not offered is denied - told,
+         non-terminal, recoverable, exactly as a policy denial is. Caller tools are never denied
+         (classified before the perimeter); an undescribed tool keeps its 6.1 treatment; with no
+         selector there is no offering to enforce. PerimeterPolicy carries the standing orders
+         (EnforceSelection, AdvertisedTools - derived from the same 6.1 rendering the catalogs
+         use). Spec-first: tracks SPEC.md v1.12 (SS4.15). New routines and models: segment 2
+         advances, 3/4 reset. -->
+    <Version>1.16.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>

--- a/docs/releases/v1.16.0.md
+++ b/docs/releases/v1.16.0.md
@@ -1,0 +1,41 @@
+The release that makes the offering binding, found the way this framework finds everything: in
+production, within a day of the feature it hardens. Selection (v1.15.0) separated what an agent
+carries from what a run is offered — and a greeting kept web-searching anyway, because the
+deployment's Brain was a custom routing brain that handed its backend the full catalog.
+Selection governs what a run is *shown*; it cannot govern what a Brain already knows. A Brain
+the loop fully mediates can only call what it was shown, but a Brain is configuration — a
+custom brain, a gateway, a model router — and configuration can carry side-channel knowledge
+of the catalog. Spec-first again: SPEC.md v1.12 §4.15 was written and merged before this
+release.
+
+## The offering binds
+
+`EnforceSelection()`, off by default, adds step **0 — the offering** to the perimeter
+sequence, before authorize: an act naming an advertised tool the run was not offered is
+denied — told, non-terminal, recoverable, exactly as a policy denial is — and the agent
+chooses a permitted path on the next turn. The trace says so plainly:
+`Selection → DENIED 'web_search': not offered to this run`.
+
+## The boundaries hold under enforcement
+
+Caller tools are never denied: they are the caller's own vocabulary (§4.13), classified before
+the perimeter, so there is nothing for enforcement to reach. An undescribed tool keeps its
+§6.1 treatment — a name selection never saw is not selection's to withhold. With no selector
+configured there is no offering, and enforcement changes nothing. And off remains off: without
+`EnforceSelection()`, an unoffered tool keeps the v1.15.0 treatment — reachable if the Brain
+names it — so no existing composition changes behavior.
+
+## The shapes the tiers demanded
+
+The standing orders ride `PerimeterPolicy`, where policy already travels as Data:
+`EnforceSelection` beside the permission mode, and `AdvertisedTools` derived at composition
+from the same §6.1 rendering the catalogs use, so the perimeter's reading of "advertised" and
+the model's can never disagree.
+
+## The record
+
+663 tests × net8.0/net10.0 — five new, FAIL→PASS, and two sabotage runs each caught by exactly
+the intended tests (dropping the flag broke the default-off and no-selector guards; dropping
+the advertised check broke the undescribed guard). Two API symbols shipped on `PerimeterPolicy`
+and one on `StandardAgent`. Tracks **SPEC.md v1.12**, whose §4.15 amendment this release
+implements — the third consecutive release built spec-first.


### PR DESCRIPTION
Ships Enforced Selection (PR #348, SPEC.md v1.12 §4.15): version bump, API surface moved Unshipped→Shipped (3 symbols), release notes. 663 tests green on net8.0/net10.0.