### PR TITLE
DOCUMENTATION: The Book And The Sessions - Chapter 22, The Trace's Privacy Line, And The Real Playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,17 @@ grows all the way up, never a rewrite.**
 [![Create Your First AI Agent from Scratch — The Standard for Agents](https://raw.githubusercontent.com/hassanhabib/The-Standard-Agent/main/assets/the-standard-agent-video-thumbnail.jpg)](https://www.youtube.com/watch?v=UE6QcvQsOyU)
 
 The sessions are live and ongoing on
-[Hassan Habib's YouTube channel](https://www.youtube.com/c/hassanhabib): start with
-[**Create Your First AI Agent from Scratch**](https://www.youtube.com/watch?v=UE6QcvQsOyU)
-above, then the
-[**The-Standard sessions playlist**](https://www.youtube.com/playlist?list=PLG2w4duP-rS2adJjAs4QvYIuKriacLQBU)
-for the engineering discipline every line of this framework is built on — subscribe there for
-the sessions on each new capability as it ships.
+[Hassan Habib's YouTube channel](https://www.youtube.com/@HassanHabib):
+
+- [**Create Your First AI Agent from Scratch**](https://www.youtube.com/watch?v=UE6QcvQsOyU) —
+  start here: a working Tri-Nature agent, from nothing, in one sitting.
+- [**PeerLLM Skills: Build, Test & Optimize Agent Skills Across Any LLM**](https://www.youtube.com/watch?v=qgmrPaQSjRc) —
+  the Data nature in practice: skills as Markdown, evaluated across models.
+- [**The Standard sessions playlist**](https://www.youtube.com/playlist?list=PLan3SCnsISTQqmSTZHQbGxBmVDwQdrlub) —
+  the engineering discipline every line of this framework is built on, from brokers to
+  orchestration.
+
+Subscribe there for the sessions on each new capability as it ships.
 
 ## Install
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -9,7 +9,10 @@ Sections **0–10** build a working agent and swap the simple file/HTTP defaults
 a local GGUF model, Redis, PostgreSQL, SQL Server — one line at a time. Sections **11–15** are what
 a regulated deployment adds on top: conversation, the perimeter, resilience, compensation and
 native tool calls. Nothing in the second half changes anything in the first. Section **16** is
-the whole surface again, as a single JSON document — the agent as data.
+the whole surface again, as a single JSON document — the agent as data. Sections **17–22** are
+the agent in service: the fleet, one agent serving many callers, narration, the streamed
+outcome, and selection — offering each run only what its task needs, enforced at the perimeter
+when the Brain is not fully mediated.
 
 ```bash
 dotnet add package Standard.Agents
@@ -643,6 +646,17 @@ the `Standard.Agents` source and meter and the spans flow to your collector —
 `.OnTelemetry((eventName, attributes) => …)` hands every loop boundary — `run.start`,
 `turn.start`, `turn.usage`, `run.outcome`, `run.end` — to your own delegate, for a StatsD
 pipeline or a metrics API no ActivityListener reaches.
+
+**What the trace carries — and where it may go.** Know this before pointing any of these at a
+central sink: the trace and the audit carry message **content** — the received prompt, the
+returned answer, tool lines. For a SIEM inside a bank that is the point. For a deployment whose
+promise to its users is that no central party reads their messages, it is a broken promise in
+one config line — the reference deployment wired its audit stream to a cloud log store and
+un-wired it the same day, on exactly this ground. Until a content-free audit mode ships
+(structure only: kind, actor, outcome, timings — never message text), a privacy-first
+deployment should keep content-bearing sinks local and user-owned (`LogTo`/`Audit` to the
+user's own disk), or not wire them at all. Telemetry is the exception: its events carry counts
+and outcomes, never text.
 
 ---
 
@@ -1548,7 +1562,9 @@ The boundaries, each pinned by tests and by conformance vector 69:
 Absent a selector, every described tool is offered — exactly the behavior every existing
 composition has today.
 
-### Enforced selection — when the Brain is not fully mediated
+---
+
+## 22 · Enforced selection — when the Brain is not fully mediated
 
 A brain the loop fully mediates can only call what it was shown. But a brain is
 configuration — a custom brain, a gateway, a model router — and configuration can carry
@@ -1585,6 +1601,8 @@ var agent = new StandardAgent(url, key, "LLooMA2.0")      // 0 · talking
     .Gate(apiUrl: url, apiKey: key, model: "LLooMA2.0")   // 4 · screen requests
     .Judge(apiUrl: url, apiKey: key, model: "LLooMA2.0")  // 5 · review answers
     .AllowTools("calculator")                             // 6 · least privilege
+    .OnSelectTools((task, tools) => Offer(task, tools))   // 21 · offer what the task needs
+    .EnforceSelection()                                   // 22 · the offering binds
     .Redact()                                             // 6 · hide PII from the brain
     .MaxTurns(5)                                          // 6 · cap the turn budget
     .Memory("agent-memory.txt")                           // 8 · remember across restarts


### PR DESCRIPTION
## The book (docs/how-to.md)

- **Enforced selection is promoted to its own chapter — 22** — every capability gets a chapter, and the 1.16.0 release earned one; it was riding as a subsection of 21.
- **Chapter 7 (Observability) gains the line the reference deployment learned in production**: the trace and the audit carry message content (the received prompt, the returned answer). Right for a bank''s SIEM; a broken promise in one config line for a deployment whose users were told no central party reads their messages — the reference deployment wired its audit stream to a cloud log store and un-wired it the same day. Guidance: content-bearing sinks stay local and user-owned until a content-free audit mode ships; telemetry (counts and outcomes, never text) is the exception.
- The intro''s section map now covers 17–22 (it stopped at 16), and the "Putting it together" composition includes `.OnSelectTools(...)` / `.EnforceSelection()`.

## The sessions (README)

- Adds the newest session: **PeerLLM Skills: Build, Test & Optimize Agent Skills Across Any LLM** (the Data nature in practice).
- **Fixes the playlist link**: it pointed at a third-party channel''s 4-year-old playlist, not the channel''s own — now the real **The Standard** sessions playlist (TS001+).
