### PR TITLE
MINOR CLIENTS: Budget Refuses A Cost Bound Without A Rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ var agent = new StandardAgent(url, key, "LLooMA2.0")
     .EffectLedger("ledger")                    // run once, even across a crash
     .ScreenToolOutput()                        // tool results are untrusted input
     .Sessions("sessions")                      // conversation that survives the process
-    .Budget(maxCostUsd: 0.25m)                 // bound what one prompt may spend — any protocol
+    .Budget(maxCostUsd: 0.25m, costPerThousandTokens: 0.002m) // bound what one prompt may spend, at your rate
     .Resilience(retries: 3)                    // survive a blip without paying twice
     .CompensateOnFailure();                    // unwind a run that died halfway
 ```
@@ -163,7 +163,7 @@ var agent = StandardAgent.FromJson(formBody);   // data
 {
   "brain": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "LLooMA2.0" },
   "ruleGate": ["password"], "redact": true, "maxTurns": 5,
-  "requireApproval": ["wire_transfer"], "budget": { "maxCostUsd": 0.25 },
+  "requireApproval": ["wire_transfer"], "budget": { "maxCostUsd": 0.25, "costPerThousandTokens": 0.002 },
   "telemetry": "form-built-agent"
 }
 ```

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
@@ -91,6 +91,43 @@ public class StandardAgentFromJsonTests
             .WithMessage("*agents*name*");
     }
 
+    // A dollar bound priced at zero per token is zero dollars forever: the document looks bounded
+    // and is not, so it refuses to compose rather than composing an agent whose cost budget can
+    // never trip (principal review 2026-09-04, F-01). The builder's own refusal rides along as
+    // the inner exception; the document-level message names the entries the author must fix.
+    [Fact]
+    public void ShouldThrowInvalidAgentConfigurationExceptionOnFromJsonIfCostBudgetHasNoRate()
+    {
+        // given
+        var invalidAgentBudgetException =
+            new InvalidAgentBudgetException(
+                message:
+                    "Invalid agent budget: a cost bound (maxCostUsd) needs a positive "
+                        + "costPerThousandTokens. Cost is the token count times that rate, so at "
+                        + "zero the bound can never trip. Pass your model's rate, or bound by "
+                        + "maxTokens instead.");
+
+        var expectedInvalidAgentConfigurationException =
+            new InvalidAgentConfigurationException(
+                message:
+                    "The 'budget' entry sets 'maxCostUsd' without a positive "
+                        + "'costPerThousandTokens'. Cost is priced off the token count times that "
+                        + "rate, so without it the spend is zero forever and the bound can never "
+                        + "trip. Add your model's rate, or bound by 'maxTokens' instead.",
+                innerException: invalidAgentBudgetException);
+
+        // when
+        Action composeAction = () =>
+            StandardAgent.FromJson("""{ "budget": { "maxCostUsd": 0.25 } }""");
+
+        InvalidAgentConfigurationException actualInvalidAgentConfigurationException =
+            Assert.Throws<InvalidAgentConfigurationException>(composeAction);
+
+        // then
+        actualInvalidAgentConfigurationException.Should()
+            .BeEquivalentTo(expectedInvalidAgentConfigurationException);
+    }
+
     [Fact]
     public void ShouldRejectMalformedConfigurationJson()
     {

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Validations.Budget.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Validations.Budget.cs
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Standard.Agents.Models.Clients.Agents.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+public partial class StandardAgentTests
+{
+    // Found in the 2026-09-04 principal review (F-01): cost is priced off the token count times
+    // the rate, and the rate defaulted to zero. A cost bound with no rate computed zero dollars
+    // forever and never tripped — a guardrail the host believed was armed and was not. The
+    // framework cannot know a model's price, so it cannot fill the rate in; what it can do is
+    // refuse the contradiction of a dollar bound on a model declared free.
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-0.002)]
+    public void ShouldThrowInvalidAgentBudgetExceptionOnBudgetIfCostBoundHasNoRate(
+        decimal invalidCostPerThousandTokens)
+    {
+        // given
+        var expectedInvalidAgentBudgetException =
+            new InvalidAgentBudgetException(
+                message:
+                    "Invalid agent budget: a cost bound (maxCostUsd) needs a positive "
+                        + "costPerThousandTokens. Cost is the token count times that rate, so at "
+                        + "zero the bound can never trip. Pass your model's rate, or bound by "
+                        + "maxTokens instead.");
+
+        // when
+        Action budgetAction = () =>
+            new StandardAgent().Budget(
+                maxCostUsd: 0.25m,
+                costPerThousandTokens: invalidCostPerThousandTokens);
+
+        InvalidAgentBudgetException actualInvalidAgentBudgetException =
+            Assert.Throws<InvalidAgentBudgetException>(budgetAction);
+
+        // then
+        actualInvalidAgentBudgetException.Should()
+            .BeEquivalentTo(expectedInvalidAgentBudgetException);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -21,7 +21,7 @@ using Standard.Agents.Models.Brokers.Generators;
 
 namespace Standard.Agents.Tests.Unit.Clients;
 
-public class StandardAgentTests
+public partial class StandardAgentTests
 {
     private static StandardAgent CreateFullyStubbedAgent(string brainReply)
     {

--- a/Standard.Agents/Models/Clients/Agents/Exceptions/InvalidAgentBudgetException.cs
+++ b/Standard.Agents/Models/Clients/Agents/Exceptions/InvalidAgentBudgetException.cs
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Clients.Agents.Exceptions;
+
+/// <summary>
+/// A budget the agent cannot honestly enforce — a cost bound with no rate to price it. Spend is
+/// the token count times the rate, so a dollar bound priced at zero is zero dollars forever: a
+/// guardrail that looks armed and never trips. The framework cannot know what a model costs, so
+/// it refuses the contradiction rather than composing it silently.
+/// </summary>
+public class InvalidAgentBudgetException : Xeption
+{
+    public InvalidAgentBudgetException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/Models/Clients/Agents/Exceptions/InvalidAgentConfigurationException.cs
+++ b/Standard.Agents/Models/Clients/Agents/Exceptions/InvalidAgentConfigurationException.cs
@@ -17,4 +17,8 @@ public class InvalidAgentConfigurationException : Xeption
     public InvalidAgentConfigurationException(string message)
         : base(message)
     { }
+
+    public InvalidAgentConfigurationException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
 }

--- a/Standard.Agents/Models/Coordinations/Agents/AgentBudget.cs
+++ b/Standard.Agents/Models/Coordinations/Agents/AgentBudget.cs
@@ -15,7 +15,11 @@ public sealed record AgentBudget
     public decimal? MaxCostUsd { get; init; }
     public TimeSpan? MaxWallClock { get; init; }
 
-    /// <summary>Cost per 1,000 tokens, when the host wants a cost bound rather than a token one.</summary>
+    /// <summary>
+    /// Cost per 1,000 tokens, when the host wants a cost bound rather than a token one. The
+    /// builder requires it to be positive whenever <see cref="MaxCostUsd"/> is set: spend is
+    /// the token count times this rate, so a zero rate is a cost bound that can never trip.
+    /// </summary>
     public decimal CostPerThousandTokens { get; init; }
 
     public bool IsBounded =>

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
 Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentBudgetException
 Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentBudgetException.InvalidAgentBudgetException(string! message) -> void
+Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentConfigurationException.InvalidAgentConfigurationException(string! message, System.Exception! innerException) -> void

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentBudgetException
+Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentBudgetException.InvalidAgentBudgetException(string! message) -> void

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -322,11 +322,7 @@ public partial class StandardAgent
                 break;
 
             case "budget":
-                agent.Budget(
-                    OptionalWhole(value, "maxTokens"),
-                    OptionalMoney(value, "maxCostUsd"),
-                    OptionalSeconds(value, "maxWallClockSeconds"),
-                    OptionalMoney(value, "costPerThousandTokens") ?? 0m);
+                ApplyBudget(agent, budgetNode: value);
 
                 break;
 
@@ -358,6 +354,32 @@ public partial class StandardAgent
                     $"Unknown configuration key '{key}'. A key this agent does not know is a "
                         + "control you believe is on and is not, so it refuses to compose. "
                         + "The keys are the builder verbs, camelCased — see docs/how-to.md.");
+        }
+    }
+
+    // The builder is the one place the budget's rules live; the document reaches it through the
+    // same verb code does. A refusal there is rewrapped into the document's own exception —
+    // naming the entries the author must fix, with the builder's refusal preserved beneath it —
+    // so a cost bound with no rate fails the way a typo'd key does: loudly, and by name.
+    private static void ApplyBudget(StandardAgent agent, JsonNode? budgetNode)
+    {
+        try
+        {
+            agent.Budget(
+                maxTokens: OptionalWhole(budgetNode, "maxTokens"),
+                maxCostUsd: OptionalMoney(budgetNode, "maxCostUsd"),
+                maxWallClock: OptionalSeconds(budgetNode, "maxWallClockSeconds"),
+                costPerThousandTokens: OptionalMoney(budgetNode, "costPerThousandTokens") ?? 0m);
+        }
+        catch (InvalidAgentBudgetException invalidAgentBudgetException)
+        {
+            throw new InvalidAgentConfigurationException(
+                message:
+                    "The 'budget' entry sets 'maxCostUsd' without a positive "
+                        + "'costPerThousandTokens'. Cost is priced off the token count times that "
+                        + "rate, so without it the spend is zero forever and the bound can never "
+                        + "trip. Add your model's rate, or bound by 'maxTokens' instead.",
+                innerException: invalidAgentBudgetException);
         }
     }
 

--- a/Standard.Agents/StandardAgent.Validations.cs
+++ b/Standard.Agents/StandardAgent.Validations.cs
@@ -27,4 +27,21 @@ public sealed partial class StandardAgent
                         + "before processing a prompt.");
         }
     }
+
+    // Spend is the token count times the rate, so a cost bound with no positive rate computes
+    // zero forever and never trips. The framework cannot know what a model costs and so cannot
+    // fill the rate in; it can refuse the contradiction of a dollar bound on a model declared
+    // free. Token and wall-clock bounds need no price and are not checked here.
+    private static void ValidateBudget(decimal? maxCostUsd, decimal costPerThousandTokens)
+    {
+        if (maxCostUsd is not null && costPerThousandTokens <= 0m)
+        {
+            throw new InvalidAgentBudgetException(
+                message:
+                    "Invalid agent budget: a cost bound (maxCostUsd) needs a positive "
+                        + "costPerThousandTokens. Cost is the token count times that rate, so at "
+                        + "zero the bound can never trip. Pass your model's rate, or bound by "
+                        + "maxTokens instead.");
+        }
+    }
 }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -1243,22 +1243,35 @@ public sealed partial class StandardAgent : IAgent
     /// provider volunteered its numbers was not a bound.
     /// </summary>
     /// <param name="maxTokens">Total tokens across the run.</param>
-    /// <param name="maxCostUsd">Total cost, priced by <paramref name="costPerThousandTokens"/>.</param>
+    /// <param name="maxCostUsd">
+    /// Total cost, priced by <paramref name="costPerThousandTokens"/>. A cost bound requires a
+    /// positive rate: the framework cannot know what a model costs, and a dollar bound priced at
+    /// zero is zero dollars forever — a guardrail that looks armed and never trips. That
+    /// contradiction refuses rather than composing silently.
+    /// </param>
     /// <param name="maxWallClock">Total elapsed time.</param>
-    /// <param name="costPerThousandTokens">Your rate, when bounding by cost.</param>
+    /// <param name="costPerThousandTokens">Your rate, required when bounding by cost.</param>
     /// <returns>The same agent, so calls can be chained.</returns>
+    /// <exception cref="Models.Clients.Agents.Exceptions.InvalidAgentBudgetException">
+    /// <paramref name="maxCostUsd"/> is set and <paramref name="costPerThousandTokens"/> is not
+    /// positive.
+    /// </exception>
     public StandardAgent Budget(
         int? maxTokens = null,
         decimal? maxCostUsd = null,
         TimeSpan? maxWallClock = null,
-        decimal costPerThousandTokens = 0m) =>
-        Set(() => this.budget = new AgentBudget
+        decimal costPerThousandTokens = 0m)
+    {
+        ValidateBudget(maxCostUsd, costPerThousandTokens);
+
+        return Set(() => this.budget = new AgentBudget
         {
             MaxTokens = maxTokens,
             MaxCostUsd = maxCostUsd,
             MaxWallClock = maxWallClock,
             CostPerThousandTokens = costPerThousandTokens
         });
+    }
 
     /// <summary>
     /// Counts tokens in the box — the <b>Local</b> mode, and the default. Every run is measured

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -3,7 +3,7 @@
 A **language-neutral** set of behavioral test vectors that any Standard-Agents
 implementation runs to self-certify against
 [`SPEC.md`](https://github.com/hassanhabib/The-Standard-Agent-Specs/blob/main/SPEC.md).
-Sixty-three vectors, four readiness profiles, every vector proven able to fail.
+Seventy vectors, four readiness profiles, every vector proven able to fail.
 
 The vectors are the executable half of the specification. Prose can be read two ways; a vector
 cannot, which is why "conformant" here means *this suite passes* rather than *we believe we
@@ -172,6 +172,7 @@ the deterministic core of the Standard.
 | `budget-bounds-cost-on-any-protocol` | A cost bound holds there too — cost is priced off the count |
 | `a-budget-counts-every-turn` | The bound tracks actual cumulative spend, not turn 1 re-billed (§4.10) |
 | `a-generous-budget-lets-the-run-finish` | A budget is a bound, not a switch: under it, the run completes |
+| `a-cost-budget-without-a-rate-refuses-to-compose` | A dollar bound with no rate computes zero forever; the document refuses and names the missing rate (§4.10) |
 | `a-repeat-in-a-session-is-a-new-act` | Run-once is scoped to a run; a repeat in a later run performs (§4.9) |
 | `an-allow-list-can-say-where` | Permission is what **and where**; the tool names the scope (§4.9) |
 | `ask-first-covers-what-nothing-permitted` | A mode answers for the acts no permission mentioned (§4.9) |

--- a/conformance/profiles/enterprise.json
+++ b/conformance/profiles/enterprise.json
@@ -17,6 +17,7 @@
     "budget-stops-the-loop",
     "budget-bounds-tokens-on-any-protocol",
     "budget-bounds-cost-on-any-protocol",
+    "a-cost-budget-without-a-rate-refuses-to-compose",
     "a-budget-counts-every-turn",
     "a-generous-budget-lets-the-run-finish",
     "guardian-screens-once-per-prompt",

--- a/conformance/vectors/70-a-cost-budget-without-a-rate-refuses-to-compose.json
+++ b/conformance/vectors/70-a-cost-budget-without-a-rate-refuses-to-compose.json
@@ -1,0 +1,10 @@
+{
+  "name": "a-cost-budget-without-a-rate-refuses-to-compose",
+  "description": "SPEC.md 4.10: a cost bound is priced off the token count times a rate the host supplies, because no implementation can know what a model costs. A document that bounds dollars without pricing tokens has asked for a bound that computes zero forever and never trips - a guardrail the host believes is armed and is not. The document MUST refuse to compose and the refusal MUST name the missing rate. No run happens; the refusal is the certification.",
+  "configurationJson": "{ \"budget\": { \"maxCostUsd\": 0.25 } }",
+  "generatorReplies": [],
+  "prompt": "",
+  "expect": {
+    "configurationRefusalNames": "costPerThousandTokens"
+  }
+}

--- a/docs/enterprise-plan.md
+++ b/docs/enterprise-plan.md
@@ -651,7 +651,7 @@ non-idempotent tools, because `IdempotencyKey` only binds when a tool declares a
 
 ```csharp
 await agent.ProcessPromptAsync(prompt, cancellationToken);   // new overload; old one stays
-.Budget(maxTokens: 50_000, maxCostUsd: 0.25m, maxWallClock: TimeSpan.FromSeconds(30))
+.Budget(maxTokens: 50_000, maxCostUsd: 0.25m, maxWallClock: TimeSpan.FromSeconds(30), costPerThousandTokens: 0.002m)
 .Resilience(retries: 3, breakAfter: 5)
 ```
 

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -38,6 +38,11 @@ Zero config still runs: without a Brain the host stands, heartbeats, and answers
 with what to configure — a first deployment fails loudly at the first prompt, never silently
 at startup.
 
+A document that refuses to compose (an unknown key, a cost budget with no rate) behaves
+differently from a missing brain: the agent is composed on the first request, not at startup,
+so the host still stands and heartbeats, and every prompt is a 500 whose log line names the
+offending entry. A green heartbeat is not proof the document composed; the first prompt is.
+
 The agent is registered as a **singleton**, which is the intended shape
 ([support.md](support.md)): one instance serves prompts concurrently, and run state is per
 invocation by SPEC.md §4.4. Enterprise controls — perimeter, budgets, sessions, redaction,
@@ -55,7 +60,7 @@ as data ([how-to.md §16](how-to.md)). Point `Agent:Config` at the file, or just
   "brain": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "k", "model": "LLooMA2.0" },
   "skills": "Skills",
   "ruleGate": ["password"],
-  "budget": { "maxCostUsd": 0.25 },
+  "budget": { "maxCostUsd": 0.25, "costPerThousandTokens": 0.002 },
   "telemetry": "form-built-agent"
 }
 ```

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1048,6 +1048,11 @@ Checked at the turn boundary — the smallest unit the loop can stop between wit
 effect half-recorded. Exhaustion is reported *distinguishably*: a caller who cannot tell "I will
 not" from "I ran out" cannot decide whether to retry.
 
+A cost bound needs its rate. The framework cannot know what your model costs, and spend is the
+token count times `costPerThousandTokens`, so `maxCostUsd` with no positive rate is a bound that
+computes zero forever and never trips. That contradiction refuses to compose, in code and in JSON,
+naming the missing rate. A model that genuinely costs nothing is bounded by `maxTokens` instead.
+
 **Every protocol is bounded.** The provider's own report is used wherever there is one — it is
 what the invoice is drawn from — and where there is none the tokens are counted locally. That
 fallback covers the text protocol batched, the text protocol streamed, and any V1 endpoint that
@@ -1213,7 +1218,7 @@ var agent = StandardAgent.FromJson(json);        // or StandardAgent.FromJsonFil
   "sessions": "sessions",
   "effectLedger": "ledger",
   "screenToolOutput": true,
-  "budget": { "maxTokens": 50000, "maxCostUsd": 0.25 },
+  "budget": { "maxTokens": 50000, "maxCostUsd": 0.25, "costPerThousandTokens": 0.002 },
   "resilience": 3,
   "compensateOnFailure": true
 }

--- a/youtube-series/season-5-mission-critical.md
+++ b/youtube-series/season-5-mission-critical.md
@@ -230,7 +230,7 @@ on itself and the single most transferable practice in the whole series.
       .EffectLedger("ledger")
       .ScreenToolOutput()
       .Sessions("sessions")
-      .Budget(maxCostUsd: 0.25m)
+      .Budget(maxCostUsd: 0.25m, costPerThousandTokens: 0.002m)
       .Resilience(retries: 3)
       .CompensateOnFailure();
   ```

--- a/youtube-series/season-6-multi-agent-systems.md
+++ b/youtube-series/season-6-multi-agent-systems.md
@@ -143,7 +143,7 @@ deadlock, which is *better* than hanging and still an outage. Bound every agent 
       .OnPolicy(Authorize)
       .EffectLedger("ledger")
       .Audit("audit.jsonl")
-      .Budget(maxCostUsd: 0.05m);
+      .Budget(maxCostUsd: 0.05m, costPerThousandTokens: 0.002m);
   ```
 - Budget the **system**, not the agent: divide a total across the tree, and give the outer agent the
   smaller share because it multiplies.


### PR DESCRIPTION
Closes F-01 of docs/PRINCIPAL-ARCHITECTURE-REVIEW-2026-09-04.md.

## The defect

Cost is priced as tokens times `costPerThousandTokens`, and that rate defaulted to zero. A `.Budget(maxCostUsd:)` with no rate computed zero dollars forever and never tripped: a guardrail the host believed was armed and was not. The README, hosting.md and how-to.md all taught the rate-less form.

## The fix

- `Budget(...)` refuses when `maxCostUsd` is set and the rate is not positive, throwing `InvalidAgentBudgetException` from the client's Validations partial.
- `FromJson` rewraps that refusal as `InvalidAgentConfigurationException`, naming the `budget`, `maxCostUsd` and `costPerThousandTokens` entries, with the builder's exception preserved as the inner.
- Token and wall-clock bounds are untouched and still need no rate. A genuinely free model bounds by `maxTokens`.

## Tests

- `ShouldThrowInvalidAgentBudgetExceptionOnBudgetIfCostBoundHasNoRate` (Theory: zero and negative), FAIL then PASS.
- `ShouldThrowInvalidAgentConfigurationExceptionOnFromJsonIfCostBudgetHasNoRate`, FAIL then PASS.
- Conformance vector 70 `a-cost-budget-without-a-rate-refuses-to-compose`, required by the Enterprise profile and therefore Critical.

## Verification

- Release build: 0 warnings, 0 errors.
- Unit tests: 666 passed on net8.0 and on net10.0.
- Conformance: 70 passed. Enterprise and Critical certified.

## Documentation

Every documented cost budget now passes a rate (README, hosting.md, how-to.md, enterprise-plan.md, season 5 and 6 scripts). how-to.md explains why the rate is required. hosting.md now states what a refused document does in the host: the singleton composes on the first request, so the host still stands and heartbeats and every prompt is a 500 whose log line names the entry. CONFORMANCE.md count corrected to seventy with the new row.

## Versioning

A behavior change to an existing routine: a call that used to compose now refuses. Second segment on the next release, 1.17.0.0.