### PR TITLE
MINOR BROKERS: Redaction Covers Replayed Tool-Call Arguments On The Native Path

### DIFF
--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -856,6 +856,8 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         pendingEffectTool = session?.PendingEffect?.ToolName;
     }
 
+    RecordNativeModelInputs(nativeGenerator, modelInputs, brainInputs);
+
     return new VectorRun(
         result, promptResults, stubTools, gateRubric, judgeRubric, judgeInput, modelInputs,
         brainInputs, promptScreenings, auditRecords, compensationOrder, nativeGenerator,
@@ -1183,6 +1185,36 @@ static bool GuardianInputConformant(
     }
 
     return true;
+}
+
+// A native conversation is a model call too (SPEC.md §4.6): everything the scripted V1 model
+// was shown joins what the text models saw — message content AND the arguments of every tool
+// call replayed to it — so a replayed call carrying a value in the clear is a leak this harness
+// can see. Without this, a native vector asserting NoModelSees certified nothing at all.
+static void RecordNativeModelInputs(
+    ScriptedNativeGeneratorBroker? nativeGenerator,
+    List<string> modelInputs,
+    List<string> brainInputs)
+{
+    if (nativeGenerator is null)
+    {
+        return;
+    }
+
+    foreach (IReadOnlyList<ConversationMessage> nativeConversation in nativeGenerator.Conversations)
+    {
+        foreach (ConversationMessage nativeMessage in nativeConversation)
+        {
+            modelInputs.Add(nativeMessage.Content);
+            brainInputs.Add(nativeMessage.Content);
+
+            foreach (ModelToolCall nativeToolCall in nativeMessage.ToolCalls)
+            {
+                modelInputs.Add(nativeToolCall.ArgumentsJson);
+                brainInputs.Add(nativeToolCall.ArgumentsJson);
+            }
+        }
+    }
 }
 
 // The request seam's guarantees, certified from what the run reported and what the scripted

--- a/Standard.Agents.Tests.Unit/Acceptance/RedactionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/RedactionTests.cs
@@ -10,8 +10,10 @@ using Standard.Agents.Brokers.Generators;
 using Standard.Agents.Brokers.Knowledges;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Brokers.Generators.V1;
 using Standard.Agents.Models.Clients.Agents;
 using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Tools;
 using Xunit;
 
 namespace Standard.Agents.Tests.Unit.Acceptance;
@@ -307,6 +309,107 @@ public class RedactionTests
         // then
         seenByBrain.Should().NotContain("INC-004512");
         seenByBrain.Should().Contain("{{TICKET_0}}");
+    }
+
+    private sealed class SendEmailTool : ITool
+    {
+        public string Name => "send_email";
+        public string Description => "Sends an email.";
+        public string ReceivedInput { get; private set; } = string.Empty;
+
+        public async ValueTask<string> ExecuteAsync(string input)
+        {
+            ReceivedInput = input;
+
+            return "sent";
+        }
+    }
+
+    // Found in the 2026-09-04 principal review (F-02): the native decorator redacted each
+    // message's Content and rehydrated the tool-call arguments coming BACK, but never redacted
+    // the arguments going OUT. A value the model echoed into an argument on turn one was
+    // rehydrated for the tool, recorded in the exchange, and replayed to the model in the clear
+    // on turn two. §4.6 says every model call, and a replayed tool call is part of a model call.
+    [Fact]
+    public async Task ShouldHideTheValueFromTheNativeBrainOnReplayedToolCallArgumentsAsync()
+    {
+        // given
+        var tool = new SendEmailTool();
+        List<string> seenByBrainOnSecondCall = [];
+        int brainCalls = 0;
+
+        StandardAgent agent = AgentBareNative(
+            tool,
+            async (messages, tools) =>
+            {
+                brainCalls++;
+
+                if (brainCalls == 1)
+                {
+                    return new GenerationResult
+                    {
+                        ToolCalls =
+                        [
+                            new ModelToolCall(
+                                Id: "call_1",
+                                Name: "send_email",
+                                ArgumentsJson: """{"to":"{{EMAIL_0}}","subject":"report"}""")
+                        ]
+                    };
+                }
+
+                seenByBrainOnSecondCall =
+                [
+                    .. messages.Select(message => message.Content),
+                    .. messages.SelectMany(message => message.ToolCalls)
+                        .Select(toolCall => toolCall.ArgumentsJson)
+                ];
+
+                return new GenerationResult { Content = "Sent the report to {{EMAIL_0}}." };
+            })
+            .Redact();
+
+        // when
+        string actualAnswer =
+            await agent.ProcessPromptAsync($"please email {SecretEmail} the report");
+
+        // then — the tool got the real address, the model never did, the caller got it back
+        tool.ReceivedInput.Should().Contain(SecretEmail);
+        seenByBrainOnSecondCall.Should().NotBeEmpty();
+
+        seenByBrainOnSecondCall.Should().NotContain(modelInput =>
+            modelInput.Contains(SecretEmail));
+
+        seenByBrainOnSecondCall.Should().Contain(modelInput =>
+            modelInput.Contains("{{EMAIL_0}}") && modelInput.Contains("\"to\""));
+
+        actualAnswer.Should().Be($"Sent the report to {SecretEmail}.");
+    }
+
+    private static StandardAgent AgentBareNative(
+        ITool tool,
+        Func<
+            IReadOnlyList<ConversationMessage>,
+            IReadOnlyList<ToolDefinition>,
+            ValueTask<GenerationResult>> brain)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .Tool(tool)
+            .OnNativeBrain(brain);
     }
 
     private static StandardAgent AgentBare(Func<string, string, ValueTask<string>> brain)

--- a/Standard.Agents/Brokers/Redactions/RedactingGeneratorBrokerV1.cs
+++ b/Standard.Agents/Brokers/Redactions/RedactingGeneratorBrokerV1.cs
@@ -11,7 +11,10 @@ namespace Standard.Agents.Brokers.Redactions;
 
 // The same guarantee on the native path. §4.6 says every model call, and a second contract is
 // still a model call — the tool-call arguments coming back are rehydrated too, because a value
-// the model echoed into an argument is a value that reaches a tool.
+// the model echoed into an argument is a value that reaches a tool. And the whole message goes
+// out redacted, not only its prose: a replayed tool call carries arguments that were rehydrated
+// for the tool on an earlier turn, so they are tokenized again like the text around them. The
+// 2026-09-04 principal review (F-02) found them going out in the clear.
 public sealed class RedactingGeneratorBrokerV1 : IGeneratorBrokerV1
 {
     private readonly IGeneratorBrokerV1 generatorBroker;
@@ -47,27 +50,48 @@ public sealed class RedactingGeneratorBrokerV1 : IGeneratorBrokerV1
     {
         var vault = new Dictionary<string, string>();
 
-        IReadOnlyList<ConversationMessage> redacted =
-            [.. messages.Select(message => message with
-            {
-                Content = this.redactionBroker.Redact(message.Content, vault)
-            })];
+        IReadOnlyList<ConversationMessage> redactedMessages =
+            [.. messages.Select(message => RedactMessage(message, vault))];
 
         GenerationResult result = inference is null
-            ? await this.generatorBroker.GenerateAsync(redacted, tools)
-            : await this.generatorBroker.GenerateAsync(redacted, tools, inference);
+            ? await this.generatorBroker.GenerateAsync(redactedMessages, tools)
+            : await this.generatorBroker.GenerateAsync(redactedMessages, tools, inference);
 
+        return RehydrateResult(result, vault);
+    }
+
+    private ConversationMessage RedactMessage(
+        ConversationMessage message,
+        IDictionary<string, string> vault)
+    {
+        return message with
+        {
+            Content = this.redactionBroker.Redact(message.Content, vault),
+            ToolCalls = [.. message.ToolCalls.Select(toolCall => RedactToolCall(toolCall, vault))]
+        };
+    }
+
+    private ModelToolCall RedactToolCall(ModelToolCall toolCall, IDictionary<string, string> vault) =>
+        toolCall with { ArgumentsJson = this.redactionBroker.Redact(toolCall.ArgumentsJson, vault) };
+
+    private GenerationResult RehydrateResult(
+        GenerationResult result,
+        IReadOnlyDictionary<string, string> vault)
+    {
         return result with
         {
             Content = this.redactionBroker.Rehydrate(result.Content, vault),
+            ToolCalls = [.. result.ToolCalls.Select(toolCall => RehydrateToolCall(toolCall, vault))]
+        };
+    }
 
-            ToolCalls =
-            [
-                .. result.ToolCalls.Select(call => call with
-                {
-                    ArgumentsJson = this.redactionBroker.Rehydrate(call.ArgumentsJson, vault)
-                })
-            ]
+    private ModelToolCall RehydrateToolCall(
+        ModelToolCall toolCall,
+        IReadOnlyDictionary<string, string> vault)
+    {
+        return toolCall with
+        {
+            ArgumentsJson = this.redactionBroker.Rehydrate(toolCall.ArgumentsJson, vault)
         };
     }
 }

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -3,7 +3,7 @@
 A **language-neutral** set of behavioral test vectors that any Standard-Agents
 implementation runs to self-certify against
 [`SPEC.md`](https://github.com/hassanhabib/The-Standard-Agent-Specs/blob/main/SPEC.md).
-Seventy vectors, four readiness profiles, every vector proven able to fail.
+Seventy-one vectors, four readiness profiles, every vector proven able to fail.
 
 The vectors are the executable half of the specification. Prose can be read two ways; a vector
 cannot, which is why "conformant" here means *this suite passes* rather than *we believe we
@@ -188,6 +188,7 @@ the deterministic core of the Standard.
 | `effect-outcome-survives-a-crash` | A new instance resumes and does not repeat the act (§4.9, §4.11) |
 | `awaiting-approval-resumes-in-a-new-process` | A held act runs once the authority says yes, elsewhere |
 | `native-tool-call-round-trips` | A result returns as a tool message naming its call (§6.2) |
+| `native-tool-call-replay-never-leaks-a-redacted-value` | A replayed tool call goes out tokenized; the tool got the value, the model never does (§4.6, §6) |
 | `policy-authorizes-on-identity` | The principal reaches the decision, not only the log (§3.3, §4.9) |
 | `injected-knowledge-cannot-widen-the-perimeter` | A poisoned passage fools the Brain; the fooled Brain still cannot act (§4.9) |
 | `poisoned-memory-cannot-widen-the-perimeter` | Data can never grant what policy did not, whichever seam it rode in on (§4.9) |

--- a/conformance/profiles/critical.json
+++ b/conformance/profiles/critical.json
@@ -6,6 +6,7 @@
     "conversation-carries-history",
     "failed-run-unwinds-in-reverse",
     "native-tool-call-round-trips",
+    "native-tool-call-replay-never-leaks-a-redacted-value",
     "a-tool-narrates-and-the-model-says-nothing",
     "native-narration-rides-the-result",
     "awaiting-approval-resumes-in-a-new-process",

--- a/conformance/profiles/critical.json
+++ b/conformance/profiles/critical.json
@@ -6,7 +6,6 @@
     "conversation-carries-history",
     "failed-run-unwinds-in-reverse",
     "native-tool-call-round-trips",
-    "native-tool-call-replay-never-leaks-a-redacted-value",
     "a-tool-narrates-and-the-model-says-nothing",
     "native-narration-rides-the-result",
     "awaiting-approval-resumes-in-a-new-process",

--- a/conformance/profiles/reliable.json
+++ b/conformance/profiles/reliable.json
@@ -11,6 +11,7 @@
     "concurrent-runs-are-isolated",
     "judge-receives-the-task",
     "redaction-covers-every-model-call",
+    "native-tool-call-replay-never-leaks-a-redacted-value",
     "guardian-overreach-is-neutralized",
     "cancellation-stops-the-loop",
     "transient-failure-recovers",

--- a/conformance/vectors/71-native-tool-call-replay-never-leaks-a-redacted-value.json
+++ b/conformance/vectors/71-native-tool-call-replay-never-leaks-a-redacted-value.json
@@ -1,0 +1,26 @@
+{
+  "name": "native-tool-call-replay-never-leaks-a-redacted-value",
+  "description": "SPEC.md 4.6 meets SPEC.md 6: every model call is redacted, and a replayed tool call is part of a model call. The prompt carries an email address; the native model asks for send_email with the placeholder in its arguments; the framework rehydrates those arguments so the TOOL receives the real address, records the exchange, and on the next turn replays the assistant's request with its id. That replayed request MUST carry the placeholder again, not the address the tool received. The 2026-09-04 principal review (F-02) found the native decorator redacted message content and rehydrated arguments coming back, but never redacted arguments going out, so the second call sent the address in the clear. The tool must still receive the real value, and the caller must still get it back.",
+  "generatorReplies": [],
+  "nativeReplies": [
+    {
+      "toolCalls": [
+        {
+          "id": "call_1",
+          "name": "send_email",
+          "argumentsJson": "{\"to\":\"{{EMAIL_0}}\",\"subject\":\"report\"}"
+        }
+      ]
+    },
+    { "content": "Sent the report to {{EMAIL_0}}." }
+  ],
+  "tools": { "send_email": "sent" },
+  "prompt": "email the report to ada@example.com",
+  "redact": true,
+  "expect": {
+    "resultContains": "ada@example.com",
+    "noModelSees": "ada@example.com",
+    "toolRunCount": { "send_email": 1 },
+    "toolInput": { "send_email": "{\"to\":\"ada@example.com\",\"subject\":\"report\"}" }
+  }
+}

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -568,6 +568,11 @@ the Custom mode for rules no pattern can express. Whichever supplies the redacto
 by decorating every model broker at composition — Brain, Gate and Judge alike — so a fourth model
 call added tomorrow cannot forget.
 
+On the native protocol the whole message is redacted, not only its prose. A tool call the model
+asked for is rehydrated so the tool receives the real value, and when that call is replayed to the
+model on the next turn its arguments go out tokenized again, alongside the tool's result. The
+model never sees the value in the clear on any turn; the tool and the caller always do.
+
 ```csharp
 var agent = new StandardAgent(url, key, "LLooMA2.0")
     .Redact();                         // ← new this section


### PR DESCRIPTION
Closes F-02 of docs/PRINCIPAL-ARCHITECTURE-REVIEW-2026-09-04.md.

## The defect

`RedactingGeneratorBrokerV1` redacted each outbound message's `Content` and rehydrated the tool-call arguments coming back, but never redacted the arguments going out. A value the model echoed into a tool argument on turn one was rehydrated for the tool, recorded in the `ToolExchange`, and replayed to the model in the clear on turn two. SPEC.md 4.6 says every model call; a replayed tool call is part of a model call.

## The fix

The decorator now redacts every outbound message whole: content and each tool call's `ArgumentsJson`, through the same per-call vault, so a replayed argument carries the same token the prompt did. The generate routine stays at level 0; the work lives in four named methods. Tool results were already covered because they ride in `Content`. The tool still receives the real value and the caller still gets it back.

## Tests

- `ShouldHideTheValueFromTheNativeBrainOnReplayedToolCallArgumentsAsync` in the redaction acceptance file, FAIL then PASS. The FAIL output showed the exact leaking message.
- Conformance vector 71 `native-tool-call-replay-never-leaks-a-redacted-value`.
- The runner now feeds native conversations, tool-call arguments included, into what `noModelSees` inspects. Before this, a native vector asserting `noModelSees` reported that no model was called and certified nothing. All seventy prior vectors pass with the runner change alone; vector 71 failed with `1 of 11 model call(s) saw ada@example.com in the clear` until the fix.

## Placement

Vector 71 is required by **Reliable**, beside `redaction-covers-every-model-call`, not by Critical. It proves a 4.6 guarantee on a seam Reliable and Enterprise implementations already ship, not a section 6 capability. A team certifying Enterprise with a native brain and redaction now has that path exercised; before, none of the native vectors ran below Critical. A Reliable implementation without a native seam will show 71 as unmet; a not-applicable profile state is a separate change.

## Verification

- Release build: 0 warnings, 0 errors.
- Unit tests: 667 passed on net8.0 and on net10.0.
- Conformance: 71 passed. Reliable, Enterprise and Critical certified.

## Not covered here, by design

The clear value still lands in the audit trace line for the tool payload, in the narration floor's prose, and in the in-memory performed-effect record for compensation. Those are logging and narration boundaries, not model calls, and belong to F-14.

## Versioning

A correctness fix inside an existing routine. Third segment on its own; the pending F-01 change already claims the second segment, so the next release is 1.17.0.0 either way.