### PR TITLE
MINOR BROKERS: The Fallback Degrades The Native Protocol Instead Of Throwing

### DIFF
--- a/Standard.Agents.Conformance/Brokers/ScriptedNativeGeneratorBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/ScriptedNativeGeneratorBroker.cs
@@ -19,9 +19,15 @@ public sealed class ScriptedNativeGeneratorBroker : IGeneratorBrokerV1
     private readonly IReadOnlyList<NativeReply> replies;
     private readonly List<IReadOnlyList<ConversationMessage>> conversations = [];
     private int index;
+    private int remainingTransientFailures;
 
-    public ScriptedNativeGeneratorBroker(IReadOnlyList<NativeReply> replies) =>
+    public ScriptedNativeGeneratorBroker(
+        IReadOnlyList<NativeReply> replies,
+        int transientFailures = 0)
+    {
         this.replies = replies;
+        this.remainingTransientFailures = transientFailures;
+    }
 
     public IReadOnlyList<IReadOnlyList<ConversationMessage>> Conversations => this.conversations;
 
@@ -33,6 +39,19 @@ public sealed class ScriptedNativeGeneratorBroker : IGeneratorBrokerV1
     {
         this.conversations.Add(messages);
         LastTools = tools;
+
+        // The same scripted transient failure the text-protocol Brain throws, so degradation is
+        // certified on the native seam against the category the framework actually localizes
+        // (SPEC.md §4.10) — a control that holds on one protocol only is not a control.
+        if (this.remainingTransientFailures > 0)
+        {
+            this.remainingTransientFailures--;
+
+            throw new HttpRequestException(
+                "scripted transient failure",
+                inner: null,
+                statusCode: System.Net.HttpStatusCode.ServiceUnavailable);
+        }
 
         NativeReply reply = this.index < this.replies.Count
             ? this.replies[this.index++]

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -290,7 +290,7 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     // One scripted native model for the whole vector, so its recorded conversations survive
     // across instances exactly as a real endpoint's would.
     ScriptedNativeGeneratorBroker? nativeGenerator = vector.NativeReplies is { Count: > 0 }
-        ? new ScriptedNativeGeneratorBroker(vector.NativeReplies)
+        ? new ScriptedNativeGeneratorBroker(vector.NativeReplies, vector.TransientFailures)
         : null;
 
     Queue<ApprovalDecision> approvalDecisions = new(

--- a/Standard.Agents.Tests.Unit/Acceptance/ResilienceTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/ResilienceTests.cs
@@ -8,6 +8,7 @@ using Moq;
 using Standard.Agents.Brokers.Knowledges;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Brokers.Generators.V1;
 using Standard.Agents.Models.Foundations.Skills;
 using Xunit;
 
@@ -38,6 +39,52 @@ public class ResilienceTests
             .UseMemory(memoryBroker.Object)
             .UseKnowledge(knowledgeBroker.Object)
             .OnBrain(async (systemPrompt, userPrompt) => replyForTurn(turn++));
+    }
+
+    private static StandardAgent AgentWithNativeBrainThatAlwaysFails()
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .OnNativeBrain((messages, tools) =>
+                throw new HttpRequestException(
+                    "the native provider is down",
+                    inner: null,
+                    statusCode: System.Net.HttpStatusCode.ServiceUnavailable));
+    }
+
+    // Found in the 2026-09-04 principal review (F-07): the fallback broker cast the configured
+    // string answer to whatever T the caller asked for. On the text protocol T is string and the
+    // cast is free; on the native protocol T is GenerationResult, so the moment the circuit
+    // opened — exactly when the control is supposed to work — the fallback threw
+    // InvalidCastException instead of degrading. A control that holds on one protocol and not
+    // the other is a control a caller can step around by changing configuration.
+    [Fact]
+    public async Task ShouldFallBackOnTheNativeProtocolWhenTheCircuitOpensAsync()
+    {
+        // given
+        StandardAgent agent = AgentWithNativeBrainThatAlwaysFails()
+            .Fallback(
+                fallback: async () => "Answering from the standby model.",
+                failuresBeforeOpen: 1);
+
+        // when
+        string actualAnswer = await agent.ProcessPromptAsync("what is the answer");
+
+        // then
+        actualAnswer.Should().Be("Answering from the standby model.");
     }
 
     [Fact]

--- a/Standard.Agents/Brokers/Resiliences/FallbackResilienceBroker.cs
+++ b/Standard.Agents/Brokers/Resiliences/FallbackResilienceBroker.cs
@@ -9,6 +9,8 @@
 using Lock = System.Object;
 #endif
 
+using Standard.Agents.Models.Brokers.Generators.V1;
+
 namespace Standard.Agents.Brokers.Resiliences;
 
 // Degradation before failure (SPEC.md §4.10). After enough consecutive failures the primary is
@@ -129,6 +131,29 @@ public sealed class FallbackResilienceBroker : IResilienceBroker
 
         string answer = await this.alternative();
 
-        return (T)(object)answer;
+        return Degrade<T>(answer);
+    }
+
+    // The alternative is text — what a host can write without knowing which protocol will ask
+    // for it — so each protocol's result is shaped from that text explicitly: the text seam
+    // takes it as the reply, the native seam takes it as a final answer with no tool calls. A
+    // bare cast to T held on the first and threw on the second, at the exact moment the control
+    // was meant to work (principal review 2026-09-04, F-07). A T this broker has not been taught
+    // is named rather than guessed at.
+    private static T Degrade<T>(string answer)
+    {
+        if (typeof(T) == typeof(string))
+        {
+            return (T)(object)answer;
+        }
+
+        if (typeof(T) == typeof(GenerationResult))
+        {
+            return (T)(object)new GenerationResult { Content = answer };
+        }
+
+        throw new InvalidOperationException(
+            $"No degraded {typeof(T).Name} can be shaped from a text fallback. Supply a "
+                + "resilience broker that understands this result type (UseResilience).");
     }
 }

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -1385,7 +1385,11 @@ public sealed partial class StandardAgent : IAgent
     /// to <paramref name="fallback"/>; it closes again after a cool-down, so a recovered provider
     /// is used again without a restart. With no fallback the agent fails rather than fabricating.
     /// </summary>
-    /// <param name="fallback">What to answer with while the primary is unhealthy.</param>
+    /// <param name="fallback">
+    /// What to answer with while the primary is unhealthy. Text, degrading whichever protocol
+    /// asked: the reply the text loop reads (so it carries <c>FINAL:</c>), or a final native
+    /// answer with no tool calls, returned as written.
+    /// </param>
     /// <param name="retries">Attempts against the primary before a call counts as failed.</param>
     /// <param name="failuresBeforeOpen">Consecutive failures that open the circuit.</param>
     /// <returns>The same agent, so calls can be chained.</returns>

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -3,7 +3,7 @@
 A **language-neutral** set of behavioral test vectors that any Standard-Agents
 implementation runs to self-certify against
 [`SPEC.md`](https://github.com/hassanhabib/The-Standard-Agent-Specs/blob/main/SPEC.md).
-Seventy-one vectors, four readiness profiles, every vector proven able to fail.
+Seventy-two vectors, four readiness profiles, every vector proven able to fail.
 
 The vectors are the executable half of the specification. Prose can be read two ways; a vector
 cannot, which is why "conformant" here means *this suite passes* rather than *we believe we
@@ -183,6 +183,7 @@ the deterministic core of the Standard.
 | `knowledge-retrieves-by-relevance` | Retrieval returns the passage that answers, not the first found |
 | `guardian-screens-once-per-prompt` | An unchanged prompt is screened once, not once per turn |
 | `open-circuit-falls-back-to-secondary` | An unhealthy provider degrades rather than fails (§4.10) |
+| `open-circuit-falls-back-on-the-native-protocol` | The same degradation on the native seam; the text alternative becomes a final answer, never a cast (§4.10, §6) |
 | `conversation-carries-history` | A follow-up resolves against what came before (§4.11) |
 | `failed-run-unwinds-in-reverse` | Compensation undoes what was performed, newest first (§4.9) |
 | `effect-outcome-survives-a-crash` | A new instance resumes and does not repeat the act (§4.9, §4.11) |

--- a/conformance/profiles/enterprise.json
+++ b/conformance/profiles/enterprise.json
@@ -22,6 +22,7 @@
     "a-generous-budget-lets-the-run-finish",
     "guardian-screens-once-per-prompt",
     "open-circuit-falls-back-to-secondary",
+    "open-circuit-falls-back-on-the-native-protocol",
     "knowledge-retrieves-by-relevance",
     "request-schema-applies-when-unconfigured",
     "configured-contract-overrides-request-schema",

--- a/conformance/vectors/72-open-circuit-falls-back-on-the-native-protocol.json
+++ b/conformance/vectors/72-open-circuit-falls-back-on-the-native-protocol.json
@@ -1,0 +1,16 @@
+{
+  "name": "open-circuit-falls-back-on-the-native-protocol",
+  "description": "SPEC.md 4.10 on the native seam (SPEC.md 6): an unhealthy native provider degrades to the configured alternative exactly as the text-protocol Brain does. The native Brain fails repeatedly; once the circuit opens the agent answers from the fallback instead of throwing. The 2026-09-04 principal review (F-07) found the fallback cast its text answer to the native result type and threw InvalidCastException at the very moment the control was supposed to work. A control that holds on one protocol and not the other is a control a caller can step around by changing configuration, so the guarantee is certified on both.",
+  "generatorReplies": [],
+  "nativeReplies": [
+    { "content": "never reached" }
+  ],
+  "tools": {},
+  "prompt": "what is the answer",
+  "transientFailures": 99,
+  "fallbackReply": "Answering from the standby model",
+  "failuresBeforeOpen": 1,
+  "expect": {
+    "resultContains": "standby model"
+  }
+}

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1039,6 +1039,10 @@ run-once, which is the whole reason the two features have to ship together.
     failuresBeforeOpen: 3)             // circuit opens after 3, then the alternative answers
 ```
 
+The alternative is text, and it degrades whichever protocol asked. On the text protocol it is the
+reply the loop reads, so it carries a `FINAL:` prefix like any other reply. On the native protocol
+it becomes a final answer with no tool calls, returned as written, so leave the prefix off there.
+
 **Budgets, with `.Budget(...)`.** Bound what one prompt may consume — tokens, money, or time:
 
 ```csharp


### PR DESCRIPTION
Closes F-07 of docs/PRINCIPAL-ARCHITECTURE-REVIEW-2026-09-04.md.

## The defect

`FallbackResilienceBroker` cast the configured text alternative to whatever `T` the caller asked for. On the text protocol `T` is `string` and the cast is free. On the native protocol `T` is `GenerationResult`, so the moment the circuit opened, exactly when the control is supposed to work, the fallback threw `InvalidCastException` instead of degrading.

## The fix

The alternative stays text, which is what a host can write without knowing which protocol will ask for it. Each protocol's result is now shaped from that text explicitly: the text seam takes it as the reply, the native seam takes it as a final answer with no tool calls. A result type the broker has not been taught is named in an `InvalidOperationException` rather than guessed at.

## Tests

- `ShouldFallBackOnTheNativeProtocolWhenTheCircuitOpensAsync`, FAIL then PASS. The FAIL output showed the cast failing inside the coordination layer.
- Conformance vector 72 `open-circuit-falls-back-on-the-native-protocol`, required by Enterprise beside its text-protocol twin. The scripted native Brain gained the same transient-failure scripting the text Brain has, so degradation is certified against the category the framework actually localizes.

## Verification

- Release build: 0 warnings, 0 errors.
- Unit tests: 668 passed on net8.0 and on net10.0.
- Conformance: 72 passed. Reliable, Enterprise and Critical certified.

## Documentation

how-to.md and the verb's XML doc say the alternative degrades whichever protocol asked, and that on the native protocol it is returned as written, so the `FINAL:` prefix belongs only to the text protocol.

## Versioning

A correctness fix inside an existing routine: third segment on its own, subsumed by the second-segment bump F-01 already claims for the next release.