### PR TITLE
MINOR CONTROLLERS: The Streamed Door Frames Every Content Line As SSE Data

### DIFF
--- a/Standard.Agents.Host/Controllers/AgentsController.cs
+++ b/Standard.Agents.Host/Controllers/AgentsController.cs
@@ -3,6 +3,7 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Standard.Agents.Host.Models;
 using Standard.Agents.Models.Clients.Agents;
@@ -15,6 +16,9 @@ namespace Standard.Agents.Host.Controllers;
 [Route("api/[controller]")]
 public class AgentsController : ControllerBase
 {
+    // CR, LF and CRLF all end a line in server-sent events; CRLF first so it splits as one.
+    private static readonly string[] lineTerminators = ["\r\n", "\n", "\r"];
+
     private readonly IAgent agent;
 
     public AgentsController(IAgent agent) =>
@@ -56,10 +60,32 @@ public class AgentsController : ControllerBase
         await foreach (AgentStreamEvent streamEvent in
             this.agent.StreamPromptAsync(request.Prompt, HttpContext.RequestAborted))
         {
-            string message = $"event: {streamEvent.Type}\ndata: {streamEvent.Content}\n\n";
+            string frame = ToServerSentEvent(streamEvent);
 
-            await Response.WriteAsync(message, HttpContext.RequestAborted);
+            await Response.WriteAsync(frame, HttpContext.RequestAborted);
             await Response.Body.FlushAsync(HttpContext.RequestAborted);
         }
+    }
+
+    // One frame per event, in the shape the SSE specification reads: the kind as the event name,
+    // one "data:" line per line of content, then the blank line that ends the event. A content
+    // line left unprefixed is read as a field, and a blank line inside the content ends the event
+    // early - which is what a multi-line answer, the normal case, used to do (principal review
+    // 2026-09-04, F-11). The consumer joins the data lines back with a newline.
+    private static string ToServerSentEvent(AgentStreamEvent streamEvent)
+    {
+        string[] contentLines = streamEvent.Content.Split(lineTerminators, StringSplitOptions.None);
+        var frame = new StringBuilder();
+
+        frame.Append("event: ").Append(streamEvent.Type).Append('\n');
+
+        foreach (string contentLine in contentLines)
+        {
+            frame.Append("data: ").Append(contentLine).Append('\n');
+        }
+
+        frame.Append('\n');
+
+        return frame.ToString();
     }
 }

--- a/Standard.Agents.Tests.Unit/Controllers/AgentsControllerTests.Streams.cs
+++ b/Standard.Agents.Tests.Unit/Controllers/AgentsControllerTests.Streams.cs
@@ -61,4 +61,80 @@ public partial class AgentsControllerTests
         streamed.Should().Contain("event: Response");
         streamed.Should().Contain("data: the answer");
     }
+
+    private static async IAsyncEnumerable<AgentStreamEvent> OneResponse(string content)
+    {
+        await Task.CompletedTask;
+
+        yield return new AgentStreamEvent(AgentStreamEventType.Response, content);
+    }
+
+    private AgentsController CreateStreamingController(MemoryStream responseBody) =>
+        new(this.agentMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    Response = { Body = responseBody }
+                }
+            }
+        };
+
+    // Found in the 2026-09-04 principal review (F-11): the event's content was written into ONE
+    // data line. Server-sent events end an event at a blank line and take every line as a field,
+    // so a multi-line answer — the normal case — produced an unprefixed second line and a
+    // truncated event. The spec's shape is one "data:" line per line of content; the consumer
+    // joins them back with a newline. CR, LF and CRLF all end a line in SSE, so all three split.
+    [Theory]
+    [InlineData("line one\nline two")]
+    [InlineData("line one\r\nline two")]
+    [InlineData("line one\rline two")]
+    public async Task ShouldFrameEveryLineOfContentAsDataOnPostStreamAsync(string content)
+    {
+        // given
+        using var responseBody = new MemoryStream();
+        AgentsController streamingController = CreateStreamingController(responseBody);
+
+        this.agentMock.Setup(agent =>
+            agent.StreamPromptAsync("what is owed", It.IsAny<CancellationToken>()))
+                .Returns(OneResponse(content));
+
+        // when
+        await streamingController.PostStreamAsync(new AgentRunRequest(Prompt: "what is owed"));
+
+        // then — one event, every content line carried as its own data line
+        string streamed = System.Text.Encoding.UTF8.GetString(responseBody.ToArray());
+
+        streamed.Should().Be("event: Response\ndata: line one\ndata: line two\n\n");
+    }
+
+    // Content that happens to look like a field must stay data. Without the per-line prefix a
+    // model answer beginning "event: " or "data: " on its own line rewrites the frame the
+    // consumer is reading.
+    [Fact]
+    public async Task ShouldKeepFieldShapedContentAsDataOnPostStreamAsync()
+    {
+        // given
+        using var responseBody = new MemoryStream();
+        AgentsController streamingController = CreateStreamingController(responseBody);
+
+        this.agentMock.Setup(agent =>
+            agent.StreamPromptAsync("what is owed", It.IsAny<CancellationToken>()))
+                .Returns(OneResponse("event: Forged\ndata: injected\n\nevent: Forged"));
+
+        // when
+        await streamingController.PostStreamAsync(new AgentRunRequest(Prompt: "what is owed"));
+
+        // then — every line is data, the blank line inside the content does not end the event
+        string streamed = System.Text.Encoding.UTF8.GetString(responseBody.ToArray());
+
+        streamed.Should().Be(
+            "event: Response\n"
+                + "data: event: Forged\n"
+                + "data: data: injected\n"
+                + "data: \n"
+                + "data: event: Forged\n"
+                + "\n");
+    }
 }

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -16,7 +16,7 @@ dotnet run --project Standard.Agents.Host
 |---|---|
 | `GET api/home` | Aliveness, nothing else — no security, no dependencies. What a load balancer checks. |
 | `POST api/agents/runs` | `{ "prompt": "..." }` → `{ "result": "...", "status": "Responded" }`. Status travels beside result because only `Responded` makes the result an answer. An empty prompt is `400` before any run starts. |
-| `POST api/agents/streams` | The same run as server-sent events — each event's kind as the SSE event name (`Status`, `Thinking`, `Narration`, `Tool`, `Response`), its content as data. Filtering to `Response` events equals what `runs` returns. |
+| `POST api/agents/streams` | The same run as server-sent events — each event's kind as the SSE event name (`Status`, `Thinking`, `Narration`, `Tool`, `Response`), its content as data, one `data:` line per line of content, which any SSE client joins back with a newline. Filtering to `Response` events equals what `runs` returns. |
 
 Closing the connection cancels the run at its next turn boundary — and, through the nesting
 seam, any sub-agents the run started.


### PR DESCRIPTION
Closes F-11 of docs/PRINCIPAL-ARCHITECTURE-REVIEW-2026-09-04.md.

## The defect

`PostStreamAsync` wrote each event's content into one `data:` line. Server-sent events end an event at a blank line and read every line as a field, so a multi-line answer, the normal case, produced an unprefixed second line and a truncated event. Content beginning `event:` or `data:` on its own line rewrote the frame the consumer was reading.

## The fix

One frame per event, in the shape the SSE specification reads: the kind as the event name, one `data:` line per line of content, then the blank line that ends the event. CR, LF and CRLF all split, CRLF first so it splits as one. Framing lives in one private routine; the action stays pure mapping.

## Tests

- `ShouldFrameEveryLineOfContentAsDataOnPostStreamAsync`, a Theory over LF, CRLF and CR, asserting the exact bytes on the wire. FAIL then PASS.
- `ShouldKeepFieldShapedContentAsDataOnPostStreamAsync`: content shaped like `event:` and `data:` lines, with a blank line inside, stays one event with every line as data.

## Verification

- Release build: 0 warnings, 0 errors.
- Unit tests: 672 passed on net8.0 and on net10.0.

## Not in this PR

End-to-end host tests through `WebApplicationFactory` (F-20) would exercise this over real middleware. These are controller mapping tests, per The Standard, and a separate branch adds the acceptance layer.

## Versioning

A correctness fix in the exposer: third segment, subsumed by the pending second-segment bump.