### PR TITLE
MINOR CLIENTS: An Endpoint Base Is Validated At Composition, And hosting.md Names A Real One

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
@@ -128,6 +128,40 @@ public class StandardAgentFromJsonTests
             .BeEquivalentTo(expectedInvalidAgentConfigurationException);
     }
 
+    // The document reaches the same verb code does, so the same URL shape is refused — and the
+    // refusal names the entry, because the author is looking at a JSON file, not a stack trace.
+    [Fact]
+    public void ShouldThrowInvalidAgentConfigurationExceptionOnFromJsonIfBrainApiUrlIsInvalid()
+    {
+        // given
+        var invalidAgentApiUrlException =
+            new InvalidAgentApiUrlException(
+                message:
+                    "Invalid agent API URL. An endpoint is the base the route is appended to: an "
+                        + "absolute http(s) URL ending with '/', such as "
+                        + "https://api.peerllm.com/v1/, that does not name chat/completions "
+                        + "itself.");
+
+        var expectedInvalidAgentConfigurationException =
+            new InvalidAgentConfigurationException(
+                message:
+                    "The 'brain' entry's 'apiUrl' is not an endpoint base the route can be "
+                        + "appended to. " + invalidAgentApiUrlException.Message,
+                innerException: invalidAgentApiUrlException);
+
+        // when
+        Action composeAction = () =>
+            StandardAgent.FromJson(
+                """{ "brain": { "apiUrl": "http://localhost:11434/v1/chat/completions", "apiKey": "k", "model": "m" } }""");
+
+        InvalidAgentConfigurationException actualInvalidAgentConfigurationException =
+            Assert.Throws<InvalidAgentConfigurationException>(composeAction);
+
+        // then
+        actualInvalidAgentConfigurationException.Should()
+            .BeEquivalentTo(expectedInvalidAgentConfigurationException);
+    }
+
     [Fact]
     public void ShouldRejectMalformedConfigurationJson()
     {

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Validations.ApiUrl.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.Validations.ApiUrl.cs
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Standard.Agents.Models.Clients.Agents.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+public partial class StandardAgentTests
+{
+    // Found in the 2026-09-04 principal review (F-12): hosting.md taught an endpoint that
+    // already named chat/completions, and the broker appends that route to whatever base it is
+    // given, so the copied example reached v1/chat/chat/completions. The neighbouring mistake is
+    // as silent: a base without its trailing slash resolves the route against the parent, so
+    // 'https://host/v1' reaches 'https://host/chat/completions'. Both fail at the first prompt
+    // with a 404 that blames the provider. The shape is refused at composition instead.
+    public static TheoryData<string> InvalidApiUrls =>
+        new()
+        {
+            "invalid-url",
+            "https://api.peerllm.com/v1",
+            "http://localhost:11434/v1/chat/completions",
+            "https://api.peerllm.com/v1/chat/completions/"
+        };
+
+    private const string InvalidApiUrlMessage =
+        "Invalid agent API URL. An endpoint is the base the route is appended to: an absolute "
+            + "http(s) URL ending with '/', such as https://api.peerllm.com/v1/, that does not "
+            + "name chat/completions itself.";
+
+    [Theory]
+    [MemberData(nameof(InvalidApiUrls))]
+    public void ShouldThrowInvalidAgentApiUrlExceptionOnBrainIfApiUrlIsInvalid(string invalidApiUrl)
+    {
+        // given
+        var expectedInvalidAgentApiUrlException =
+            new InvalidAgentApiUrlException(message: InvalidApiUrlMessage);
+
+        // when
+        Action brainAction = () =>
+            new StandardAgent().Brain(apiUrl: invalidApiUrl, apiKey: "key", model: "model");
+
+        InvalidAgentApiUrlException actualInvalidAgentApiUrlException =
+            Assert.Throws<InvalidAgentApiUrlException>(brainAction);
+
+        // then
+        actualInvalidAgentApiUrlException.Should()
+            .BeEquivalentTo(expectedInvalidAgentApiUrlException);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidApiUrls))]
+    public void ShouldThrowInvalidAgentApiUrlExceptionOnNativeBrainIfApiUrlIsInvalid(
+        string invalidApiUrl)
+    {
+        // given
+        var expectedInvalidAgentApiUrlException =
+            new InvalidAgentApiUrlException(message: InvalidApiUrlMessage);
+
+        // when
+        Action nativeBrainAction = () =>
+            new StandardAgent().NativeBrain(apiUrl: invalidApiUrl, apiKey: "key", model: "model");
+
+        InvalidAgentApiUrlException actualInvalidAgentApiUrlException =
+            Assert.Throws<InvalidAgentApiUrlException>(nativeBrainAction);
+
+        // then
+        actualInvalidAgentApiUrlException.Should()
+            .BeEquivalentTo(expectedInvalidAgentApiUrlException);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidApiUrls))]
+    public void ShouldThrowInvalidAgentApiUrlExceptionOnGateIfApiUrlIsInvalid(string invalidApiUrl)
+    {
+        // given
+        var expectedInvalidAgentApiUrlException =
+            new InvalidAgentApiUrlException(message: InvalidApiUrlMessage);
+
+        // when
+        Action gateAction = () =>
+            new StandardAgent().Gate(apiUrl: invalidApiUrl, apiKey: "key", model: "model");
+
+        InvalidAgentApiUrlException actualInvalidAgentApiUrlException =
+            Assert.Throws<InvalidAgentApiUrlException>(gateAction);
+
+        // then
+        actualInvalidAgentApiUrlException.Should()
+            .BeEquivalentTo(expectedInvalidAgentApiUrlException);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidApiUrls))]
+    public void ShouldThrowInvalidAgentApiUrlExceptionOnJudgeIfApiUrlIsInvalid(string invalidApiUrl)
+    {
+        // given
+        var expectedInvalidAgentApiUrlException =
+            new InvalidAgentApiUrlException(message: InvalidApiUrlMessage);
+
+        // when
+        Action judgeAction = () =>
+            new StandardAgent().Judge(apiUrl: invalidApiUrl, apiKey: "key", model: "model");
+
+        InvalidAgentApiUrlException actualInvalidAgentApiUrlException =
+            Assert.Throws<InvalidAgentApiUrlException>(judgeAction);
+
+        // then
+        actualInvalidAgentApiUrlException.Should()
+            .BeEquivalentTo(expectedInvalidAgentApiUrlException);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.cs
@@ -87,7 +87,7 @@ public partial class StandardAgentTests
         var memory = new Mock<IMemoryBroker>();
         memory.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
 
-        var agent = new StandardAgent(apiUrl: "invalid-url", apiKey: "key", model: "model")
+        var agent = new StandardAgent(apiUrl: "https://api.peerllm.invalid/v1/", apiKey: "key", model: "model")
             .UseSkills(skillBroker.Object)
             .UseMemory(memory.Object)
             .UseKnowledge(EmptyKnowledgeBroker());

--- a/Standard.Agents.Tests.Unit/Packaging/DocumentedApiUrlTests.cs
+++ b/Standard.Agents.Tests.Unit/Packaging/DocumentedApiUrlTests.cs
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Packaging;
+
+// An endpoint written in the documentation is an endpoint someone will paste. hosting.md carried
+// a base that already named chat/completions for several releases, and a copied example reached
+// v1/chat/chat/completions (principal review 2026-09-04, F-12). The docs are copied next to the
+// assembly so every documented endpoint is composed through the real verb: a documented URL the
+// builder refuses is a documentation bug, caught here rather than by the next reader.
+public class DocumentedApiUrlTests
+{
+    private static readonly string[] documentedFiles =
+    [
+        "README.md",
+        Path.Combine("docs", "hosting.md"),
+        Path.Combine("docs", "how-to.md")
+    ];
+
+    // The three shapes an endpoint takes in the docs: a C# argument, a JSON agent document, and
+    // the host's appsettings entry.
+    private static readonly Regex documentedApiUrl = new(
+        "(?:\"?apiUrl\"?|\"Url\")\\s*:\\s*\"(?<url>https?://[^\"]+)\"",
+        RegexOptions.Compiled);
+
+    public static TheoryData<string, string> DocumentedApiUrls()
+    {
+        var documentedApiUrls = new TheoryData<string, string>();
+
+        foreach (string documentedFile in documentedFiles)
+        {
+            string documentation =
+                File.ReadAllText(Path.Combine(AppContext.BaseDirectory, documentedFile));
+
+            foreach (Match match in documentedApiUrl.Matches(documentation))
+            {
+                documentedApiUrls.Add(documentedFile, match.Groups["url"].Value);
+            }
+        }
+
+        return documentedApiUrls;
+    }
+
+    [Theory]
+    [MemberData(nameof(DocumentedApiUrls))]
+    public void ShouldComposeEveryDocumentedApiUrl(string documentedFile, string documentedApiUrl)
+    {
+        // given . when
+        Action brainAction = () =>
+            new StandardAgent().Brain(apiUrl: documentedApiUrl, apiKey: "key", model: "model");
+
+        // then
+        brainAction.Should().NotThrow(
+            because: $"{documentedFile} teaches this endpoint, and a copied example must compose");
+    }
+}

--- a/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
+++ b/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
@@ -33,6 +33,11 @@
          just documentation. Copied next to the assembly so PackageReadmeTests can read the same
          bytes that get packed. -->
     <None Include="..\README.md" Link="README.md" CopyToOutputDirectory="PreserveNewest" />
+
+    <!-- The endpoints these documents teach are composed through the real builder by
+         DocumentedApiUrlTests, so a documented URL the builder refuses fails here. -->
+    <None Include="..\docs\hosting.md" Link="docs\hosting.md" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\docs\how-to.md" Link="docs\how-to.md" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/Standard.Agents/Models/Clients/Agents/Exceptions/InvalidAgentApiUrlException.cs
+++ b/Standard.Agents/Models/Clients/Agents/Exceptions/InvalidAgentApiUrlException.cs
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Xeptions;
+
+namespace Standard.Agents.Models.Clients.Agents.Exceptions;
+
+/// <summary>
+/// An endpoint the agent cannot honestly call. The API URL is the base a route is appended to,
+/// so its shape is load-bearing: without a trailing slash the route resolves against the parent,
+/// and a base that already names the route reaches it twice. Either fails at the first prompt
+/// with a 404 that blames the provider, so the contradiction is refused at composition instead.
+/// </summary>
+public class InvalidAgentApiUrlException : Xeption
+{
+    public InvalidAgentApiUrlException(string message)
+        : base(message)
+    { }
+}

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@
 Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentBudgetException
 Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentBudgetException.InvalidAgentBudgetException(string! message) -> void
 Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentConfigurationException.InvalidAgentConfigurationException(string! message, System.Exception! innerException) -> void
+Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentApiUrlException
+Standard.Agents.Models.Clients.Agents.Exceptions.InvalidAgentApiUrlException.InvalidAgentApiUrlException(string! message) -> void

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -32,10 +32,29 @@ public partial class StandardAgent
 
         foreach ((string key, JsonNode? value) in document)
         {
-            Apply(agent, key, value);
+            ApplyEntry(agent, key, value);
         }
 
         return agent;
+    }
+
+    // The document reaches the same verbs code does, so a verb's refusal is rewrapped into the
+    // document's own exception naming the entry the author must fix — they are looking at a JSON
+    // file, not a stack trace — with the verb's refusal preserved beneath it.
+    private static void ApplyEntry(StandardAgent agent, string key, JsonNode? value)
+    {
+        try
+        {
+            Apply(agent, key, value);
+        }
+        catch (InvalidAgentApiUrlException invalidAgentApiUrlException)
+        {
+            throw new InvalidAgentConfigurationException(
+                message:
+                    $"The '{key}' entry's 'apiUrl' is not an endpoint base the route can be "
+                        + "appended to. " + invalidAgentApiUrlException.Message,
+                innerException: invalidAgentApiUrlException);
+        }
     }
 
     /// <summary>Reads <paramref name="path"/> and composes the agent from its JSON.</summary>

--- a/Standard.Agents/StandardAgent.Validations.cs
+++ b/Standard.Agents/StandardAgent.Validations.cs
@@ -32,6 +32,31 @@ public sealed partial class StandardAgent
     // zero forever and never trips. The framework cannot know what a model costs and so cannot
     // fill the rate in; it can refuse the contradiction of a dollar bound on a model declared
     // free. Token and wall-clock bounds need no price and are not checked here.
+    // An endpoint is the base the route is appended to, so its shape is load-bearing. Without
+    // the trailing '/' .NET resolves the route against the parent ('https://host/v1' reaches
+    // 'https://host/chat/completions'), and a base that already names chat/completions reaches
+    // 'v1/chat/chat/completions' — the URL hosting.md taught (principal review 2026-09-04,
+    // F-12). Both fail at the first prompt with a 404 that blames the provider.
+    private static void ValidateApiUrl(string apiUrl)
+    {
+        bool isAbsoluteHttp =
+            Uri.TryCreate(apiUrl, UriKind.Absolute, out Uri? endpoint)
+                && endpoint.Scheme is "http" or "https";
+
+        bool namesTheRoute =
+            apiUrl.TrimEnd('/').EndsWith("/chat/completions", StringComparison.OrdinalIgnoreCase);
+
+        if (isAbsoluteHttp is false || apiUrl.EndsWith('/') is false || namesTheRoute)
+        {
+            throw new InvalidAgentApiUrlException(
+                message:
+                    "Invalid agent API URL. An endpoint is the base the route is appended to: an "
+                        + "absolute http(s) URL ending with '/', such as "
+                        + "https://api.peerllm.com/v1/, that does not name chat/completions "
+                        + "itself.");
+        }
+    }
+
     private static void ValidateBudget(decimal? maxCostUsd, decimal costPerThousandTokens)
     {
         if (maxCostUsd is not null && costPerThousandTokens <= 0m)

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -229,9 +229,13 @@ public sealed partial class StandardAgent : IAgent
         string model,
         double? temperature = null,
         int? maxTokens = null,
-        int timeoutSeconds = 120) =>
-        Set(() => this.brainSettings =
+        int timeoutSeconds = 120)
+    {
+        ValidateApiUrl(apiUrl);
+
+        return Set(() => this.brainSettings =
             new InferenceSettings(apiUrl, apiKey, model, temperature, maxTokens, timeoutSeconds));
+    }
 
     /// <summary>
     /// Supplies an in-process brain as a delegate, so the agent makes no API calls — the
@@ -371,9 +375,13 @@ public sealed partial class StandardAgent : IAgent
         string model,
         double temperature = 0.0,
         int maxTokens = 16,
-        int timeoutSeconds = 30) =>
-        Set(() => this.gateSettings =
+        int timeoutSeconds = 30)
+    {
+        ValidateApiUrl(apiUrl);
+
+        return Set(() => this.gateSettings =
             new InferenceSettings(apiUrl, apiKey, model, temperature, maxTokens, timeoutSeconds));
+    }
 
     /// <summary>
     /// Turns on the Judge: an opt-in guardian that scores the brain's draft answer and sends it
@@ -394,9 +402,13 @@ public sealed partial class StandardAgent : IAgent
         string model,
         double temperature = 0.0,
         int maxTokens = 16,
-        int timeoutSeconds = 30) =>
-        Set(() => this.judgeSettings =
+        int timeoutSeconds = 30)
+    {
+        ValidateApiUrl(apiUrl);
+
+        return Set(() => this.judgeSettings =
             new InferenceSettings(apiUrl, apiKey, model, temperature, maxTokens, timeoutSeconds));
+    }
 
     /// <summary>
     /// Turns on a <b>deterministic</b> Gate: a guardian backed by a rule, not a model. It refuses
@@ -918,9 +930,13 @@ public sealed partial class StandardAgent : IAgent
         string apiKey,
         string model,
         double temperature = 0.7,
-        int maxTokens = 1024) =>
-        Set(() => this.generatorBrokerV1 =
+        int maxTokens = 1024)
+    {
+        ValidateApiUrl(apiUrl);
+
+        return Set(() => this.generatorBrokerV1 =
             new GeneratorBrokerV1(apiUrl, apiKey, model, temperature, maxTokens));
+    }
 
     /// <summary>
     /// Gives the agent a native tool-calling brain on the <b>Anthropic Messages API</b> — the

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -160,7 +160,7 @@ public sealed partial class StandardAgent : IAgent
     /// the same as <c>new StandardAgent().Brain(apiUrl, apiKey, model)</c>. Chain further builder
     /// methods afterward to add skills, tools, guardians, memory or knowledge.
     /// </summary>
-    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint.</param>
+    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint, ending with <c>/</c>; the chat/completions route is appended.</param>
     /// <param name="apiKey">API key for the endpoint (empty string if none is needed).</param>
     /// <param name="model">Model name to request from the endpoint.</param>
     public StandardAgent(string apiUrl, string apiKey, string model) =>
@@ -209,7 +209,7 @@ public sealed partial class StandardAgent : IAgent
     /// agent's reasoning. Required unless you supply an in-process brain via
     /// <see cref="LocalBrain"/> or <see cref="UseGenerator"/>.
     /// </summary>
-    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint.</param>
+    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint, ending with <c>/</c>; the chat/completions route is appended.</param>
     /// <param name="apiKey">API key for the endpoint (empty string if none is needed).</param>
     /// <param name="model">Model name to request from the endpoint.</param>
     /// <param name="temperature">
@@ -362,7 +362,7 @@ public sealed partial class StandardAgent : IAgent
     /// way the Gate is never the brain — it runs its own screening rubric (Data), honouring
     /// SPEC.md invariant 6.
     /// </summary>
-    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint for the Gate.</param>
+    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint for the Gate, ending with <c>/</c>; the chat/completions route is appended.</param>
     /// <param name="apiKey">API key for the endpoint (empty string if none is needed).</param>
     /// <param name="model">Model name to request for screening.</param>
     /// <param name="temperature">Sampling temperature; kept at 0.0 for a deterministic verdict.</param>
@@ -389,7 +389,7 @@ public sealed partial class StandardAgent : IAgent
     /// the brain's endpoint or a different model, and never acts as the brain — it applies its own
     /// evaluation rubric (Data), honouring SPEC.md invariant 6.
     /// </summary>
-    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint for the Judge.</param>
+    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint for the Judge, ending with <c>/</c>; the chat/completions route is appended.</param>
     /// <param name="apiKey">API key for the endpoint (empty string if none is needed).</param>
     /// <param name="model">Model name to request for evaluation.</param>
     /// <param name="temperature">Sampling temperature; kept at 0.0 for a deterministic score.</param>
@@ -919,7 +919,7 @@ public sealed partial class StandardAgent : IAgent
     /// has to imitate. Frontier models are trained on this; the text protocol remains the default
     /// because it works against any endpoint and small local models often do better with it.
     /// </summary>
-    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint.</param>
+    /// <param name="apiUrl">Base URL of the OpenAI-compatible endpoint, ending with <c>/</c>; the chat/completions route is appended.</param>
     /// <param name="apiKey">API key for the endpoint (empty string if none is needed).</param>
     /// <param name="model">Model name to request.</param>
     /// <param name="temperature">Sampling temperature. Defaults to 0.7.</param>

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -3,7 +3,7 @@
 A **language-neutral** set of behavioral test vectors that any Standard-Agents
 implementation runs to self-certify against
 [`SPEC.md`](https://github.com/hassanhabib/The-Standard-Agent-Specs/blob/main/SPEC.md).
-Seventy-two vectors, four readiness profiles, every vector proven able to fail.
+Seventy-three vectors, four readiness profiles, every vector proven able to fail.
 
 The vectors are the executable half of the specification. Prose can be read two ways; a vector
 cannot, which is why "conformant" here means *this suite passes* rather than *we believe we
@@ -173,6 +173,7 @@ the deterministic core of the Standard.
 | `a-budget-counts-every-turn` | The bound tracks actual cumulative spend, not turn 1 re-billed (§4.10) |
 | `a-generous-budget-lets-the-run-finish` | A budget is a bound, not a switch: under it, the run completes |
 | `a-cost-budget-without-a-rate-refuses-to-compose` | A dollar bound with no rate computes zero forever; the document refuses and names the missing rate (§4.10) |
+| `an-endpoint-that-names-the-route-refuses-to-compose` | An apiUrl is the base the route is appended to; one that names the route, or drops its trailing slash, refuses and names apiUrl |
 | `a-repeat-in-a-session-is-a-new-act` | Run-once is scoped to a run; a repeat in a later run performs (§4.9) |
 | `an-allow-list-can-say-where` | Permission is what **and where**; the tool names the scope (§4.9) |
 | `ask-first-covers-what-nothing-permitted` | A mode answers for the acts no permission mentioned (§4.9) |

--- a/conformance/vectors/73-an-endpoint-that-names-the-route-refuses-to-compose.json
+++ b/conformance/vectors/73-an-endpoint-that-names-the-route-refuses-to-compose.json
@@ -1,0 +1,10 @@
+{
+  "name": "an-endpoint-that-names-the-route-refuses-to-compose",
+  "description": "Composition from data (SPEC.md 4.8 v1.4): an apiUrl is the base a route is appended to, so a document whose brain names chat/completions itself - or omits the trailing slash that keeps the route under its path - describes an endpoint that fails at the first prompt with a 404 blaming the provider. The document MUST refuse to compose and the refusal MUST name apiUrl. The 2026-09-04 principal review (F-12) found hosting.md teaching exactly this URL. No run happens; the refusal is the certification.",
+  "configurationJson": "{ \"brain\": { \"apiUrl\": \"http://localhost:11434/v1/chat/completions\", \"apiKey\": \"k\", \"model\": \"m\" } }",
+  "generatorReplies": [],
+  "prompt": "",
+  "expect": {
+    "configurationRefusalNames": "apiUrl"
+  }
+}

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -26,7 +26,7 @@ seam, any sub-agents the run started.
 ```json
 {
   "Agent": {
-    "Url": "http://localhost:11434/v1/chat/completions",
+    "Url": "http://localhost:11434/v1/",
     "ApiKey": "",
     "Model": "LLooMA2.0",
     "Skills": "Skills"


### PR DESCRIPTION
Closes F-12 of docs/PRINCIPAL-ARCHITECTURE-REVIEW-2026-09-04.md.

## The defect

hosting.md configured `http://localhost:11434/v1/chat/completions`. The broker posts the relative route `chat/completions` against whatever base it is given, so the copied example reached `v1/chat/chat/completions` and failed at the first prompt with a 404 blaming the provider. The neighbouring mistake is as silent: a base without its trailing slash resolves the route against the parent, so `https://host/v1` reaches `https://host/chat/completions`.

## The fix

- `Brain`, `NativeBrain`, `Gate` and `Judge` validate the endpoint at composition: an absolute http(s) URL ending with `/` that does not name `chat/completions` itself. The refusal is `InvalidAgentApiUrlException` from the client's Validations partial.
- `FromJson` rewraps that refusal as `InvalidAgentConfigurationException` naming the entry, with the verb's refusal preserved as the inner exception.
- hosting.md names `http://localhost:11434/v1/`.
- Every `apiUrl` parameter's XML doc now says the base ends with `/` and the route is appended.

## Tests

- `ShouldThrowInvalidAgentApiUrlExceptionOn{Brain,NativeBrain,Gate,Judge}IfApiUrlIsInvalid`, Theories over a non-URL, a base without its slash, and a base naming the route with and without a trailing slash. FAIL then PASS.
- `ShouldThrowInvalidAgentConfigurationExceptionOnFromJsonIfBrainApiUrlIsInvalid`, asserting the inner exception survived.
- `ShouldComposeEveryDocumentedApiUrl`: README.md, hosting.md and how-to.md are copied to the test output and every endpoint they teach is composed through the real verb. It failed on hosting.md's stale endpoint, then passed once the doc was corrected. A documented URL the builder refuses is now a test failure, not the next reader's afternoon.
- Conformance vector 73 `an-endpoint-that-names-the-route-refuses-to-compose`, a configuration-refusal vector like 47 and 51.
- One existing test used `invalid-url` as a stand-in for an unreachable endpoint; it now uses an unreachable but well-formed one, which keeps its intent.

## Verification

- Release build: 0 warnings, 0 errors.
- Unit tests: 693 passed on net8.0 and on net10.0.
- Conformance: 73 passed.

## Versioning

A call that used to compose can now refuse: a routine behavior change, second segment, already claimed by F-01 for the next release.