### PR TITLE
MINOR EXPOSERS: An Eval Run That Discovers No Cases Fails

### DIFF
--- a/Standard.Agents.Evals/Program.cs
+++ b/Standard.Agents.Evals/Program.cs
@@ -30,8 +30,15 @@ string[] knownMetrics =
     "revisionEffectiveness"
 ];
 
-string goldenPath = args.Length > 0
-    ? args[0]
+// A run that discovers no cases certifies nothing, so by default it fails rather than printing
+// "0 passed, 0 failed" and exiting green - the pass a build reads as coverage (principal review
+// 2026-09-04, F-19). A caller who means an empty set says so.
+const string AllowEmptyFlag = "--allow-empty";
+bool allowEmpty = args.Contains(AllowEmptyFlag, StringComparer.Ordinal);
+string[] pathArguments = [.. args.Where(argument => argument != AllowEmptyFlag)];
+
+string goldenPath = pathArguments.Length > 0
+    ? pathArguments[0]
     : Path.Combine(FindRepositoryRoot(), "evals", "golden");
 
 JsonSerializerOptions jsonOptions = new()
@@ -116,6 +123,15 @@ foreach (string caseFile in
 
 Console.WriteLine();
 Console.WriteLine($"{passed} passed, {failed} failed  [Standard.Agents {frameworkVersion}, set {goldenSetHash}]");
+
+if (passed + failed == 0 && allowEmpty is false)
+{
+    Console.WriteLine(
+        $"No cases discovered in {goldenPath}. A run that certifies nothing is not a pass; "
+            + $"pass {AllowEmptyFlag} to accept an empty set on purpose.");
+
+    return 2;
+}
 
 return failed == 0 ? 0 : 1;
 

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -9,7 +9,10 @@ dotnet run --project Standard.Agents.Evals                     # the framework's
 dotnet run --project Standard.Agents.Evals -- path/to/golden   # your own
 ```
 
-Exit `0` means every threshold in every case is met. Anything else fails the build.
+Exit `0` means every threshold in every case is met. Anything else fails the build: `1` when a
+case misses a threshold, `2` when the run discovered no cases at all. A run that certifies
+nothing is not a pass, so an empty or mistyped golden path fails loudly rather than printing
+`0 passed, 0 failed` in green; pass `--allow-empty` to accept an empty set on purpose.
 
 ## The metrics
 


### PR DESCRIPTION
Closes the Phase 0 item of F-19 in docs/PRINCIPAL-ARCHITECTURE-REVIEW-2026-09-04.md: fail eval runs that discover no cases.

## The defect

The eval runner printed `0 passed, 0 failed` and exited `0` when the golden directory was empty or the path was mistyped. A build read that as coverage while nothing was measured.

## The fix

A run that discovers no cases exits `2` with a message naming the path, unless `--allow-empty` is passed. Exit `1` still means a threshold was missed. The flag is filtered out of the positional arguments, so `dotnet run -- path --allow-empty` and `dotnet run -- --allow-empty path` both work.

## Verification, run by hand since the runner is a top-level program with no test project

| Run | Result |
|---|---|
| empty directory | exit 2, "No cases discovered in ..." |
| empty directory with `--allow-empty` | exit 0 |
| the framework's golden set | 6 passed, 0 failed, exit 0 |

CI's `Evaluating Quality` step runs the golden set and is unaffected.

## Not in this PR

The rest of F-19, splitting deterministic orchestration evals from live model-quality evals, is a design change to the evaluation strategy and is not something to ship unseen.