### PR TITLE
MEDIUM BROKERS: MCP Tools Keep Their Schema And Receive Their Arguments As Written

### DIFF
--- a/Standard.Agents.Conformance/Brokers/NotConfiguredMcpBroker.cs
+++ b/Standard.Agents.Conformance/Brokers/NotConfiguredMcpBroker.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Conformance;
 
 public sealed class NotConfiguredMcpBroker : IMcpBroker
 {
-    public async ValueTask<string> CallAsync(string name, string input) =>
+    public async ValueTask<string> CallAsync(string name, string argumentsJson) =>
         $"[external '{name}' not configured]";
 
     public async ValueTask<IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool>>

--- a/Standard.Agents.Conformance/Brokers/ScriptedMcpServer.cs
+++ b/Standard.Agents.Conformance/Brokers/ScriptedMcpServer.cs
@@ -14,14 +14,20 @@ namespace Standard.Agents.Conformance;
 public sealed class ScriptedMcpServer : IMcpBroker
 {
     private readonly Dictionary<string, string> tools;
+    private readonly Dictionary<string, string> schemas;
     private int callCount;
 
-    public ScriptedMcpServer(Dictionary<string, string> tools) =>
+    public ScriptedMcpServer(
+        Dictionary<string, string> tools,
+        Dictionary<string, string>? schemas = null)
+    {
         this.tools = tools;
+        this.schemas = schemas ?? [];
+    }
 
     public int CallCount => Volatile.Read(ref this.callCount);
 
-    public async ValueTask<string> CallAsync(string name, string input)
+    public async ValueTask<string> CallAsync(string name, string argumentsJson)
     {
         Interlocked.Increment(ref this.callCount);
 
@@ -30,6 +36,12 @@ public sealed class ScriptedMcpServer : IMcpBroker
             : $"[external '{name}' not configured]";
     }
 
+    // A tool the vector gave a schema advertises it; the rest take an open object, as a real
+    // server that declares none would.
     public async ValueTask<IReadOnlyList<McpTool>> ListToolsAsync() =>
-        [.. this.tools.Keys.Select(name => new McpTool(name, $"scripted tool {name}"))];
+        [.. this.tools.Keys.Select(name =>
+            new McpTool(
+                name,
+                $"scripted tool {name}",
+                this.schemas.TryGetValue(name, out string? schema) ? schema : "{}"))];
 }

--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -123,6 +123,11 @@ public sealed record Vector(
     // contested name. ExtraSkills adds skill sources after the harness's stub, in order,
     // because accumulation is only observable with more than one source.
     List<Dictionary<string, string>>? McpServers = null,
+
+    // What a scripted server declares its tools take, {toolName: inputSchemaJson}. A tool with
+    // no entry takes an open object, as a real server that declares no schema would (SPEC.md
+    // §6.1: what a tool takes is part of what advertises it).
+    Dictionary<string, string>? McpToolSchemas = null,
     List<string>? ExtraSkills = null,
 
     // Composition from data (SPEC.md §4.8 v1.4). When set, the vector certifies composition

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -300,7 +300,8 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
     // Created once per vector so call counts survive instance rebuilds, the way a real
     // server's would.
     List<ScriptedMcpServer> scriptedMcpServers =
-        [.. (vector.McpServers ?? []).Select(catalog => new ScriptedMcpServer(catalog))];
+        [.. (vector.McpServers ?? []).Select(catalog =>
+            new ScriptedMcpServer(catalog, vector.McpToolSchemas))];
 
     // The fleet (SPEC.md §4.8 v1.6): scripted specialists, created once per vector so their
     // scripted brains keep their place across instance rebuilds, exactly as real endpoints

--- a/Standard.Agents.Evals/Brokers/CaseBrokers.cs
+++ b/Standard.Agents.Evals/Brokers/CaseBrokers.cs
@@ -40,7 +40,7 @@ public sealed class CaseMemoryBroker : IMemoryBroker
 
 public sealed class NotConfiguredMcpBroker : IMcpBroker
 {
-    public async ValueTask<string> CallAsync(string name, string input) =>
+    public async ValueTask<string> CallAsync(string name, string argumentsJson) =>
         $"[external '{name}' not configured]";
 
     public async ValueTask<IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool>>

--- a/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Exceptions.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Exceptions.Call.cs
@@ -50,7 +50,7 @@ Exception criticalDependencyException)
                 innerException: failedExternalToolDependencyException);
 
         this.mcpBrokerMock.Setup(broker =>
-            broker.CallAsync(randomName, randomInput))
+            broker.CallAsync(randomName, ExpectedArgumentsJson(randomInput)))
                 .ThrowsAsync(criticalDependencyException);
 
         // when
@@ -66,7 +66,7 @@ Exception criticalDependencyException)
             .BeEquivalentTo(expectedExternalToolDependencyException);
 
         this.mcpBrokerMock.Verify(broker =>
-            broker.CallAsync(randomName, randomInput),
+            broker.CallAsync(randomName, ExpectedArgumentsJson(randomInput)),
                 Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>
@@ -98,7 +98,7 @@ Exception criticalDependencyException)
                 innerException: failedExternalToolDependencyException);
 
         this.mcpBrokerMock.Setup(broker =>
-            broker.CallAsync(randomName, randomInput))
+            broker.CallAsync(randomName, ExpectedArgumentsJson(randomInput)))
                 .ThrowsAsync(dependencyException);
 
         // when
@@ -114,7 +114,7 @@ Exception criticalDependencyException)
             .BeEquivalentTo(expectedExternalToolDependencyException);
 
         this.mcpBrokerMock.Verify(broker =>
-            broker.CallAsync(randomName, randomInput),
+            broker.CallAsync(randomName, ExpectedArgumentsJson(randomInput)),
                 Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>
@@ -144,7 +144,7 @@ Exception criticalDependencyException)
                 innerException: invalidExternalToolException);
 
         this.mcpBrokerMock.Setup(broker =>
-            broker.CallAsync(randomName, randomInput))
+            broker.CallAsync(randomName, ExpectedArgumentsJson(randomInput)))
                 .ThrowsAsync(badRequestException);
 
         // when
@@ -160,7 +160,7 @@ Exception criticalDependencyException)
             .BeEquivalentTo(expectedExternalToolDependencyValidationException);
 
         this.mcpBrokerMock.Verify(broker =>
-            broker.CallAsync(randomName, randomInput),
+            broker.CallAsync(randomName, ExpectedArgumentsJson(randomInput)),
                 Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>
@@ -191,7 +191,7 @@ Exception criticalDependencyException)
                 innerException: failedExternalToolServiceException);
 
         this.mcpBrokerMock.Setup(broker =>
-            broker.CallAsync(randomName, randomInput))
+            broker.CallAsync(randomName, ExpectedArgumentsJson(randomInput)))
                 .ThrowsAsync(serviceException);
 
         // when
@@ -207,7 +207,7 @@ Exception criticalDependencyException)
             .BeEquivalentTo(expectedExternalToolServiceException);
 
         this.mcpBrokerMock.Verify(broker =>
-            broker.CallAsync(randomName, randomInput),
+            broker.CallAsync(randomName, ExpectedArgumentsJson(randomInput)),
                 Times.Once);
 
         this.loggingBrokerMock.Verify(broker =>

--- a/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Logic.Call.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.Logic.Call.cs
@@ -23,7 +23,7 @@ public partial class ExternalToolServiceTests
         string expectedOutput = randomOutput;
 
         this.mcpBrokerMock.Setup(broker =>
-            broker.CallAsync(inputName, inputInput))
+            broker.CallAsync(inputName, ExpectedArgumentsJson(inputInput)))
                 .ReturnsAsync(randomOutput);
 
         // when
@@ -34,7 +34,7 @@ public partial class ExternalToolServiceTests
         actualOutput.Should().BeEquivalentTo(expectedOutput);
 
         this.mcpBrokerMock.Verify(broker =>
-            broker.CallAsync(inputName, inputInput),
+            broker.CallAsync(inputName, ExpectedArgumentsJson(inputInput)),
                 Times.Once);
 
         this.mcpBrokerMock.VerifyNoOtherCalls();
@@ -51,7 +51,7 @@ public partial class ExternalToolServiceTests
         string expectedOutput = toolReportedError;
 
         this.mcpBrokerMock.Setup(broker =>
-            broker.CallAsync(randomName, randomInput))
+            broker.CallAsync(randomName, ExpectedArgumentsJson(randomInput)))
                 .ReturnsAsync(toolReportedError);
 
         // when
@@ -62,7 +62,41 @@ public partial class ExternalToolServiceTests
         actualOutput.Should().BeEquivalentTo(expectedOutput);
 
         this.mcpBrokerMock.Verify(broker =>
-            broker.CallAsync(randomName, randomInput),
+            broker.CallAsync(randomName, ExpectedArgumentsJson(randomInput)),
+                Times.Once);
+
+        this.mcpBrokerMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // Found in the 2026-09-04 principal review (F-03): every call was forced into one string
+    // argument named "input", so a tool with a typed, multi-property schema could never be
+    // called correctly. Plain text still travels as that one argument — it is what the text
+    // protocol produces and what a schema-less tool understands — but a JSON object, which is
+    // what a native call produces, is handed to the server exactly as the model wrote it.
+    [Fact]
+    public async Task ShouldCallWithTheArgumentsAsGivenOnCallIfInputIsAJsonObjectAsync()
+    {
+        // given
+        string randomName = CreateRandomString();
+        string randomOutput = CreateRandomString();
+        string inputName = randomName;
+        string structuredInput = """{"city":"Seattle","days":3}""";
+        string expectedOutput = randomOutput;
+
+        this.mcpBrokerMock.Setup(broker =>
+            broker.CallAsync(inputName, structuredInput))
+                .ReturnsAsync(randomOutput);
+
+        // when
+        string actualOutput =
+            await this.externalToolService.CallAsync(inputName, structuredInput);
+
+        // then
+        actualOutput.Should().BeEquivalentTo(expectedOutput);
+
+        this.mcpBrokerMock.Verify(broker =>
+            broker.CallAsync(inputName, structuredInput),
                 Times.Once);
 
         this.mcpBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/ExternalTools/ExternalToolServiceTests.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using System.Linq.Expressions;
+using System.Text.Json;
 using Moq;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Mcps;
@@ -31,6 +32,11 @@ public partial class ExternalToolServiceTests
 
     private static string CreateRandomString() =>
         new MnemonicString().GetValue();
+
+    // What the foundation hands the broker for plain text: the text as the one argument a
+    // schema-less tool understands. A JSON object is handed over as given.
+    private static string ExpectedArgumentsJson(string input) =>
+        JsonSerializer.Serialize(new Dictionary<string, string> { ["input"] = input });
 
     private static Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException) =>
         actualException => actualException.SameExceptionAs(expectedException);

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationServiceTests.Logic.RetrieveInstructions.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationServiceTests.Logic.RetrieveInstructions.cs
@@ -25,16 +25,21 @@ public partial class RetrievalOrchestrationServiceTests
         string inputRoute = randomRoute;
         string skillsWithMarker = "Tools you may use:\n{{tools}}";
 
+        string weatherSchema = """{"type":"object","properties":{"city":{"type":"string"}}}""";
+
         IReadOnlyList<McpTool> remoteTools =
         [
-            new McpTool("weather", "answers weather questions"),
+            new McpTool("weather", "answers weather questions", weatherSchema),
             new McpTool("undocumented", "")
         ];
 
+        // What a tool takes is part of what advertises it (SPEC.md §6.1): the schema the server
+        // declared reaches the catalog line, not an empty object (principal review 2026-09-04,
+        // F-03).
         string expectedInstructions =
             "Tools you may use:\n"
                 + LocalToolCatalog + "\n"
-                + "- weather — answers weather questions parameters: {}";
+                + "- weather — answers weather questions parameters: " + weatherSchema;
 
         this.skillServiceMock.Setup(service =>
             service.RetrieveSkillsAsync(inputRoute))

--- a/Standard.Agents/Brokers/Mcps/CompositeMcpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/CompositeMcpBroker.cs
@@ -26,13 +26,13 @@ public sealed class CompositeMcpBroker : IMcpBroker
         this.catalogs = new IReadOnlyList<McpTool>?[this.brokers.Count];
     }
 
-    public async ValueTask<string> CallAsync(string name, string input)
+    public async ValueTask<string> CallAsync(string name, string argumentsJson)
     {
         IMcpBroker? owner = await ResolveAsync(name);
 
         return owner is null
             ? $"[external '{name}' not configured]"
-            : await owner.CallAsync(name, input);
+            : await owner.CallAsync(name, argumentsJson);
     }
 
     public async ValueTask<IReadOnlyList<McpTool>> ListToolsAsync()

--- a/Standard.Agents/Brokers/Mcps/IMcpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/IMcpBroker.cs
@@ -9,7 +9,7 @@ namespace Standard.Agents.Brokers.Mcps;
 
 public interface IMcpBroker
 {
-    ValueTask<string> CallAsync(string name, string input);
+    ValueTask<string> CallAsync(string name, string argumentsJson);
 
     /// <summary>
     /// The server's tool catalog (<c>tools/list</c>). What makes more than one server composable:

--- a/Standard.Agents/Brokers/Mcps/McpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/McpBroker.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using RESTFulSense.Clients;
 using Standard.Agents.Models.Brokers.Mcps;
@@ -16,7 +17,7 @@ public sealed class McpBroker : IMcpBroker
     private const string JsonRpcVersion = "2.0";
     private const string ToolsCallMethod = "tools/call";
     private const string ToolsListMethod = "tools/list";
-    private const string InputArgumentName = "input";
+    private const string OpenObjectSchema = "{}";
 
     private static readonly JsonSerializerOptions jsonOptions = new()
     {
@@ -83,7 +84,7 @@ public sealed class McpBroker : IMcpBroker
         }
     }
 
-    public async ValueTask<string> CallAsync(string name, string input)
+    public async ValueTask<string> CallAsync(string name, string argumentsJson)
     {
         JsonRpcRequest jsonRpcRequest = new(
             JsonRpc: JsonRpcVersion,
@@ -91,10 +92,7 @@ public sealed class McpBroker : IMcpBroker
             Method: ToolsCallMethod,
             Params: new ToolCallParams(
                 Name: name,
-                Arguments: new Dictionary<string, string>
-                {
-                    [InputArgumentName] = input
-                }));
+                Arguments: JsonNode.Parse(argumentsJson)));
 
         JsonRpcResponse jsonRpcResponse =
             await PostAsync<JsonRpcRequest, JsonRpcResponse>(
@@ -123,7 +121,10 @@ public sealed class McpBroker : IMcpBroker
         }
 
         return [.. (jsonRpcResponse.Result?.Tools ?? []).Select(tool =>
-            new McpTool(tool.Name, tool.Description ?? string.Empty))];
+            new McpTool(
+                tool.Name,
+                tool.Description ?? string.Empty,
+                tool.InputSchema?.GetRawText() ?? OpenObjectSchema))];
     }
 
     private static string ToText(JsonRpcResponse jsonRpcResponse)

--- a/Standard.Agents/Brokers/Mcps/NotConfiguredMcpBroker.cs
+++ b/Standard.Agents/Brokers/Mcps/NotConfiguredMcpBroker.cs
@@ -7,7 +7,7 @@ namespace Standard.Agents.Brokers.Mcps;
 
 public sealed class NotConfiguredMcpBroker : IMcpBroker
 {
-    public async ValueTask<string> CallAsync(string name, string input) =>
+    public async ValueTask<string> CallAsync(string name, string argumentsJson) =>
         $"[external '{name}' not configured]";
 
     public async ValueTask<IReadOnlyList<Models.Brokers.Mcps.McpTool>> ListToolsAsync() =>

--- a/Standard.Agents/Models/Brokers/Mcps/McpTool.cs
+++ b/Standard.Agents/Models/Brokers/Mcps/McpTool.cs
@@ -6,7 +6,9 @@
 namespace Standard.Agents.Models.Brokers.Mcps;
 
 /// <summary>
-/// One tool an MCP server offers, as its catalog describes it — the name a call must use, and
-/// the description that would advertise it.
+/// One tool an MCP server offers, as its catalog describes it — the name a call must use, the
+/// description that would advertise it, and the JSON Schema of the arguments it takes. What a
+/// tool takes is part of what advertises it; a server that declares no schema takes an open
+/// object.
 /// </summary>
-public sealed record McpTool(string Name, string Description);
+public sealed record McpTool(string Name, string Description, string InputSchemaJson = "{}");

--- a/Standard.Agents/Models/Brokers/Mcps/ToolCallParams.cs
+++ b/Standard.Agents/Models/Brokers/Mcps/ToolCallParams.cs
@@ -5,6 +5,8 @@
 
 namespace Standard.Agents.Models.Brokers.Mcps;
 
+// Arguments are whatever JSON object the caller shaped — a native call's own arguments, or
+// plain text wrapped upstream — carried as a node so the broker never interprets them.
 internal sealed record ToolCallParams(
     string Name,
-    IReadOnlyDictionary<string, string> Arguments);
+    System.Text.Json.Nodes.JsonNode? Arguments);

--- a/Standard.Agents/Models/Brokers/Mcps/ToolListResult.cs
+++ b/Standard.Agents/Models/Brokers/Mcps/ToolListResult.cs
@@ -8,9 +8,12 @@ namespace Standard.Agents.Models.Brokers.Mcps;
 internal sealed record ToolListResult(
     IReadOnlyList<ToolListEntry> Tools);
 
+// The schema rides as the raw element it arrived as: the broker hands it on as text and never
+// interprets it, so a server's own vocabulary reaches the model unchanged.
 internal sealed record ToolListEntry(
     string Name,
-    string? Description);
+    string? Description,
+    System.Text.Json.JsonElement? InputSchema);
 
 internal sealed record JsonRpcToolListResponse(
     ToolListResult? Result,

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -21,3 +21,17 @@ Standard.Agents.Services.Orchestrations.Data.Retrievals.RetrievalOrchestrationSe
 *REMOVED*override Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.ToString() -> string!
 *REMOVED*static Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.operator !=(Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? left, Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? right) -> bool
 *REMOVED*static Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog.operator ==(Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? left, Standard.Agents.Models.Orchestrations.Retrievals.ExternalToolCatalog? right) -> bool
+*REMOVED*Standard.Agents.Brokers.Mcps.CompositeMcpBroker.CallAsync(string! name, string! input) -> System.Threading.Tasks.ValueTask<string!>
+Standard.Agents.Brokers.Mcps.CompositeMcpBroker.CallAsync(string! name, string! argumentsJson) -> System.Threading.Tasks.ValueTask<string!>
+*REMOVED*Standard.Agents.Brokers.Mcps.IMcpBroker.CallAsync(string! name, string! input) -> System.Threading.Tasks.ValueTask<string!>
+Standard.Agents.Brokers.Mcps.IMcpBroker.CallAsync(string! name, string! argumentsJson) -> System.Threading.Tasks.ValueTask<string!>
+*REMOVED*Standard.Agents.Brokers.Mcps.McpBroker.CallAsync(string! name, string! input) -> System.Threading.Tasks.ValueTask<string!>
+Standard.Agents.Brokers.Mcps.McpBroker.CallAsync(string! name, string! argumentsJson) -> System.Threading.Tasks.ValueTask<string!>
+*REMOVED*Standard.Agents.Brokers.Mcps.NotConfiguredMcpBroker.CallAsync(string! name, string! input) -> System.Threading.Tasks.ValueTask<string!>
+Standard.Agents.Brokers.Mcps.NotConfiguredMcpBroker.CallAsync(string! name, string! argumentsJson) -> System.Threading.Tasks.ValueTask<string!>
+*REMOVED*Standard.Agents.Models.Brokers.Mcps.McpTool.Deconstruct(out string! Name, out string! Description) -> void
+*REMOVED*Standard.Agents.Models.Brokers.Mcps.McpTool.McpTool(string! Name, string! Description) -> void
+Standard.Agents.Models.Brokers.Mcps.McpTool.Deconstruct(out string! Name, out string! Description, out string! InputSchemaJson) -> void
+Standard.Agents.Models.Brokers.Mcps.McpTool.McpTool(string! Name, string! Description, string! InputSchemaJson = "{}") -> void
+Standard.Agents.Models.Brokers.Mcps.McpTool.InputSchemaJson.get -> string!
+Standard.Agents.Models.Brokers.Mcps.McpTool.InputSchemaJson.init -> void

--- a/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.cs
+++ b/Standard.Agents/Services/Foundations/ExternalTools/ExternalToolService.cs
@@ -3,6 +3,8 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Standard.Agents.Brokers.Loggings;
 using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Models.Brokers.Mcps;
@@ -11,6 +13,9 @@ namespace Standard.Agents.Services.Foundations.ExternalTools;
 
 public partial class ExternalToolService : IExternalToolService
 {
+    // The one argument plain text travels as, for a tool that declared no schema of its own.
+    private const string InputArgumentName = "input";
+
     private readonly IMcpBroker mcpBroker;
     private readonly ILoggingBroker loggingBroker;
 
@@ -27,8 +32,35 @@ public partial class ExternalToolService : IExternalToolService
     {
         ValidateName(name);
 
-        return await this.mcpBroker.CallAsync(name, input);
+        return await this.mcpBroker.CallAsync(name, ToArgumentsJson(input));
     });
+
+    // The wire takes a JSON object of arguments. A native call already wrote one, and it goes
+    // over exactly as written; the text protocol produces plain text, which travels as the one
+    // argument a schema-less tool understands. Forcing every call into that one argument was
+    // what left typed, multi-property tools uncallable (principal review 2026-09-04, F-03).
+    private static string ToArgumentsJson(string input)
+    {
+        if (IsJsonObject(input))
+        {
+            return input;
+        }
+
+        return JsonSerializer.Serialize(
+            new Dictionary<string, string> { [InputArgumentName] = input });
+    }
+
+    private static bool IsJsonObject(string input)
+    {
+        try
+        {
+            return JsonNode.Parse(input) is JsonObject;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
 
     public ValueTask<IReadOnlyList<McpTool>> RetrieveToolsAsync() =>
     TryCatch(async () => await this.mcpBroker.ListToolsAsync());

--- a/Standard.Agents/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationService.cs
@@ -144,12 +144,15 @@ public partial class RetrievalOrchestrationService : IRetrievalOrchestrationServ
     }
 
     // The same opt-in rule the local catalog uses (SPEC.md §6.1): a description is what
-    // advertises a tool, so an undescribed remote tool stays callable but unlisted.
+    // advertises a tool, so an undescribed remote tool stays callable but unlisted. What the
+    // tool takes is part of the advertisement, so the schema the server declared rides the line
+    // exactly as a local tool's Parameters do.
     private static string RenderRemoteToolCatalog(IReadOnlyList<McpTool> remoteTools)
     {
         IEnumerable<string> catalogLines = remoteTools
             .Where(tool => string.IsNullOrWhiteSpace(tool.Description) is false)
-            .Select(tool => $"- {tool.Name} — {tool.Description} parameters: {{}}");
+            .Select(tool =>
+                $"- {tool.Name} — {tool.Description} parameters: {tool.InputSchemaJson}");
 
         return string.Join("\n", catalogLines);
     }

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -3,7 +3,7 @@
 A **language-neutral** set of behavioral test vectors that any Standard-Agents
 implementation runs to self-certify against
 [`SPEC.md`](https://github.com/hassanhabib/The-Standard-Agent-Specs/blob/main/SPEC.md).
-Seventy-three vectors, four readiness profiles, every vector proven able to fail.
+Seventy-four vectors, four readiness profiles, every vector proven able to fail.
 
 The vectors are the executable half of the specification. Prose can be read two ways; a vector
 cannot, which is why "conformant" here means *this suite passes* rather than *we believe we
@@ -174,6 +174,7 @@ the deterministic core of the Standard.
 | `a-generous-budget-lets-the-run-finish` | A budget is a bound, not a switch: under it, the run completes |
 | `a-cost-budget-without-a-rate-refuses-to-compose` | A dollar bound with no rate computes zero forever; the document refuses and names the missing rate (§4.10) |
 | `an-endpoint-that-names-the-route-refuses-to-compose` | An apiUrl is the base the route is appended to; one that names the route, or drops its trailing slash, refuses and names apiUrl |
+| `a-remote-tools-schema-reaches-the-catalog` | A server's declared inputSchema rides the catalog line as the tool's parameters; the Brain is told how to call it, not only that it exists (§6.1) |
 | `a-repeat-in-a-session-is-a-new-act` | Run-once is scoped to a run; a repeat in a later run performs (§4.9) |
 | `an-allow-list-can-say-where` | Permission is what **and where**; the tool names the scope (§4.9) |
 | `ask-first-covers-what-nothing-permitted` | A mode answers for the acts no permission mentioned (§4.9) |

--- a/conformance/vectors/74-a-remote-tools-schema-reaches-the-catalog.json
+++ b/conformance/vectors/74-a-remote-tools-schema-reaches-the-catalog.json
@@ -1,0 +1,18 @@
+{
+  "name": "a-remote-tools-schema-reaches-the-catalog",
+  "description": "SPEC.md 6.1 for remote tools: what a tool takes is part of what advertises it. A server declares an inputSchema on tools/list, and the catalog line the Brain reads MUST carry that schema rather than an empty object - otherwise the model is told the tool exists and nothing about how to call it, and a typed, multi-property tool can never be called correctly. The 2026-09-04 principal review (F-03) found discovery discarding the schema and every remote tool advertised as taking nothing.",
+  "mcpServers": [
+    { "weather": "sunny in Seattle" }
+  ],
+  "mcpToolSchemas": {
+    "weather": "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}"
+  },
+  "extraSkills": [ "Your tools:\n{{tools}}" ],
+  "generatorReplies": [ "FINAL: noted" ],
+  "tools": {},
+  "prompt": "what tools do you have",
+  "expect": {
+    "resultContains": "noted",
+    "brainSees": "\"properties\":{\"city\":{\"type\":\"string\"}}"
+  }
+}

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -278,6 +278,12 @@ When the brain names a tool that isn't registered locally, the agent routes the 
 no MCP is configured, an unknown tool returns a graceful "not configured" note and the agent
 recovers on the next turn instead of crashing.
 
+**What a remote tool takes travels with it.** Discovery keeps each tool's `inputSchema`, and the
+`{{tools}}` catalog advertises it as the tool's `parameters`, exactly as a local tool's are. On
+the way out, a native tool call's arguments reach the server as the JSON object the model wrote;
+the text protocol's plain-text payload reaches it as the one argument `{ "input": "..." }`, which
+is what a tool with no schema understands.
+
 **Servers accumulate.** Like `.Tool(...)`, each `.Mcp(...)` call *adds* a server — the agent asks
 each server what it offers (`tools/list`) and routes every call to the server whose catalog owns
 the name. When two servers claim the same name, the **first registered wins** — deterministic,


### PR DESCRIPTION
Closes the schema and arguments half of F-03 in docs/PRINCIPAL-ARCHITECTURE-REVIEW-2026-09-04.md.

## The defect

Discovery kept only a remote tool's name and description and threw its `inputSchema` away, so every remote tool was advertised as taking nothing. Every call was then forced into one string argument named `input`, so a tool with a typed, multi-property schema could never be described or called correctly.

## The fix

- `McpTool` carries `InputSchemaJson`, defaulting to an open object for a server that declares none. Two-argument construction still compiles.
- `McpBroker` passes the schema through from `tools/list` as the raw element it arrived as, and posts `tools/call` with the arguments JSON it is handed, parsed into a node and never interpreted. The broker holds no shaping logic.
- `ExternalToolService` shapes the payload, which is the foundation's mapping job: a JSON object, which is what a native call writes, goes over exactly as written; plain text, which is what the text protocol produces, travels as `{ "input": "..." }`, the one argument a schema-less tool understands.
- The `{{tools}}` catalog advertises each remote tool's schema as its `parameters`, exactly as a local tool's `Parameters` ride the line.
- The `IMcpBroker.CallAsync` parameter is now named `argumentsJson` to say what it carries; every implementation follows.

## Tests, each FAIL then PASS

- Foundation: `ShouldCallWithTheArgumentsAsGivenOnCallIfInputIsAJsonObjectAsync`, and every existing call test now expects the shaped text argument. Eleven cases failed against the old pass-through.
- Orchestration: the remote-tools catalog test expects the declared schema on the line.
- Conformance vector 74 `a-remote-tools-schema-reaches-the-catalog`. Scripted servers can now declare what their tools take (`mcpToolSchemas`). It failed with the schema absent from every Brain input, then passed.

## Verification

- Release build: 0 warnings, 0 errors.
- Unit tests: 709 passed on net8.0 and on net10.0.
- Conformance: 74 passed. Reliable, Enterprise and Critical certified. Evals: 6 passed.

## Versioning

`McpTool` gained a positional property and a public interface's parameter was renamed: model change, first segment, as F-15 already flagged for the next release.

## Not in this PR

The wire itself, a real `tools/call` body carrying structured arguments, is only certified by the foundation's unit tests; the scripted server cannot see the broker's serialization. That is F-21's contract-server work. Remote tools reaching native tool definitions and selection is the other half of F-03 and F-04, next.