### PR TITLE
MEDIUM MANAGEMENTS: Remote Tools Reach Selection, Native Definitions, And Enforcement

### DIFF
--- a/Standard.Agents.Conformance/Models/Vector.cs
+++ b/Standard.Agents.Conformance/Models/Vector.cs
@@ -172,6 +172,10 @@ public sealed record Vector(
     // the advertisement opt-in (§6.1) — so what a run was OFFERED becomes observable in the
     // catalog the Brain reads.
     List<string>? SelectTools = null,
+
+    // Whether the offering BINDS at the Direction perimeter (SPEC.md §4.15, enforced): an act
+    // naming an advertised tool the run was not offered is denied rather than reachable.
+    bool EnforceSelection = false,
     Dictionary<string, string>? ToolDescriptions = null);
 
 /// <summary>A stub tool's declared narration templates, as a vector writes them.</summary>

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -432,6 +432,11 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
         // Selection (SPEC.md §4.15): a scripted selector returning the vector's fixed set,
         // whatever the task — how the harness certifies that a run is offered only what a
         // selector named, with an empty list as the valid offered-nothing case.
+        if (vector.EnforceSelection)
+        {
+            agent.EnforceSelection();
+        }
+
         if (vector.SelectTools is not null)
         {
             agent.OnSelectTools((task, described) =>

--- a/Standard.Agents.Tests.Unit/Acceptance/NativeToolCallTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/NativeToolCallTests.cs
@@ -6,9 +6,11 @@
 using FluentAssertions;
 using Moq;
 using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Brokers.Mcps;
 using Standard.Agents.Models.Foundations.Skills;
 using Standard.Agents.Tools;
 using Xunit;
@@ -254,5 +256,61 @@ public class NativeToolCallTests
 
         // then — reported usage is what the budget measures, not an estimate
         actualResult.Should().Contain("token budget");
+    }
+
+    // Found in the 2026-09-04 principal review (F-03): native tool definitions were built from
+    // local tools only, so a native brain was never told a remote tool existed. A described
+    // remote tool is advertised as a native definition carrying its schema, and a native call
+    // naming it routes to its server with the arguments as written.
+    [Fact]
+    public async Task ShouldAdvertiseDescribedRemoteToolsNativelyAndRouteTheCallAsync()
+    {
+        // given
+        string weatherSchema = """{"type":"object","properties":{"city":{"type":"string"}}}""";
+        string weatherArguments = """{"city":"Seattle"}""";
+        var server = new Mock<IMcpBroker>();
+
+        server.Setup(broker => broker.ListToolsAsync())
+            .ReturnsAsync([new McpTool("weather", "answers weather questions", weatherSchema)]);
+
+        server.Setup(broker => broker.CallAsync("weather", weatherArguments))
+            .ReturnsAsync("sunny");
+
+        IReadOnlyList<ToolDefinition> offeredDefinitions = [];
+        var tool = new CalculatorTool();
+
+        StandardAgent agent = AgentWith(tool, (tools, call) =>
+            {
+                offeredDefinitions = tools;
+
+                return call == 0
+                    ? new GenerationResult
+                    {
+                        ToolCalls =
+                        [
+                            new ModelToolCall(
+                                Id: "call_1",
+                                Name: "weather",
+                                ArgumentsJson: weatherArguments)
+                        ]
+                    }
+                    : new GenerationResult { Content = "It is sunny in Seattle." };
+            })
+            .UseMcp(server.Object);
+
+        // when
+        string actualResult = await agent.ProcessPromptAsync("what is the weather in Seattle?");
+
+        // then: the remote tool was offered natively with its schema, and its call reached it
+        offeredDefinitions.Should().Contain(definition =>
+            definition.Name == "weather"
+                && definition.Description == "answers weather questions"
+                && definition.ParametersJson == weatherSchema);
+
+        server.Verify(broker =>
+            broker.CallAsync("weather", weatherArguments),
+                Times.Once);
+
+        actualResult.Should().Be("It is sunny in Seattle.");
     }
 }

--- a/Standard.Agents.Tests.Unit/Acceptance/SelectionEnforcementTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/SelectionEnforcementTests.cs
@@ -6,10 +6,12 @@
 using FluentAssertions;
 using Moq;
 using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Models.Brokers.Generators.V1;
 using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Brokers.Mcps;
 using Standard.Agents.Models.Foundations.Skills;
 using Standard.Agents.Models.Orchestrations.Agents;
 using Standard.Agents.Tools;
@@ -238,5 +240,49 @@ public class SelectionEnforcementTests
         outcome.Status.Should().Be(AgentStatus.AwaitingInput);
         outcome.PendingEffect.Should().NotBeNull();
         outcome.PendingEffect!.ToolName.Should().Be("send_email");
+    }
+
+    // Found in the 2026-09-04 principal review (F-04): enforcement denied a withheld tool only
+    // when its name was in the LOCAL advertised set, so a disobedient brain could call an
+    // unoffered remote tool freely. A described remote tool is advertised like a local one, and
+    // an enforced offering binds it the same way.
+    [Fact]
+    public async Task ShouldDenyAnUnofferedRemoteToolWhenTheOfferingIsEnforcedAsync()
+    {
+        // given: the run is offered only the calculator, yet the brain names the remote almanac
+        var server = new Mock<IMcpBroker>();
+
+        server.Setup(broker => broker.ListToolsAsync())
+            .ReturnsAsync([new McpTool("almanac", "consults the stars")]);
+
+        server.Setup(broker => broker.CallAsync("almanac", It.IsAny<string>()))
+            .ReturnsAsync("the stars say yes");
+
+        var calculator = new NamedTool("calculator");
+        IReadOnlyList<ConversationMessage> secondTurnMessages = null!;
+
+        StandardAgent agent = AgentWith(
+            CallsThenAnswers(
+                "almanac",
+                "answered among what was offered",
+                messages => secondTurnMessages = messages),
+            calculator)
+            .UseMcp(server.Object)
+            .OnSelectTools((task, described) =>
+                new ValueTask<IReadOnlyList<string>>(new[] { "calculator" }))
+            .EnforceSelection();
+
+        // when
+        string result = await agent.ProcessPromptAsync("when should I plant?");
+
+        // then: the remote act never ran, the denial was told, and the run recovered
+        server.Verify(broker =>
+            broker.CallAsync(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+
+        result.Should().Be("answered among what was offered");
+
+        secondTurnMessages.Should().Contain(message =>
+            message.Content != null && message.Content.Contains("not offered"));
     }
 }

--- a/Standard.Agents.Tests.Unit/Acceptance/SelectionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/SelectionTests.cs
@@ -6,9 +6,11 @@
 using FluentAssertions;
 using Moq;
 using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Mcps;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Skills;
 using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Brokers.Mcps;
 using Standard.Agents.Models.Foundations.Skills;
 using Standard.Agents.Tools;
 using Xunit;
@@ -280,5 +282,50 @@ public class SelectionTests
         answer.Should().Be("hello!");
         shown.Should().Contain(definition => definition.Name == "web_search");
         shown.Should().NotContain(definition => definition.Name == "code_search");
+    }
+
+    // Found in the 2026-09-04 principal review (F-04): the selector judged over the LOCAL
+    // described names and the remote catalog was appended after selection ran, so OnSelectTools
+    // could neither see nor withhold a remote tool, the very case the how-to names as the
+    // motivation for selection: an agent with twenty MCP servers. Remote tools are discovered
+    // before selection and judged with the rest.
+    [Fact]
+    public async Task ShouldOfferTheSelectorRemoteToolsAndWithholdTheUnselectedOnesAsync()
+    {
+        // given: a server offering two described tools; the selector keeps one
+        var server = new Mock<IMcpBroker>();
+
+        server.Setup(broker => broker.ListToolsAsync())
+            .ReturnsAsync(
+            [
+                new McpTool("weather", "answers weather questions"),
+                new McpTool("almanac", "consults the stars")
+            ]);
+
+        IReadOnlyList<string> describedSeenBySelector = [];
+        string capturedSystemPrompt = string.Empty;
+
+        StandardAgent agent = TextAgentWith(async (systemPrompt, userPrompt) =>
+            {
+                capturedSystemPrompt = systemPrompt;
+
+                return "FINAL: done";
+            })
+            .UseMcp(server.Object)
+            .OnSelectTools((task, described) =>
+            {
+                describedSeenBySelector = described;
+
+                return new ValueTask<IReadOnlyList<string>>(new[] { "weather" });
+            });
+
+        // when
+        await agent.ProcessPromptAsync("will it rain in Seattle?");
+
+        // then: the selector saw both remote names, and only the offered line reached the model
+        describedSeenBySelector.Should().Contain("weather");
+        describedSeenBySelector.Should().Contain("almanac");
+        capturedSystemPrompt.Should().Contain("weather — answers weather questions");
+        capturedSystemPrompt.Should().NotContain("almanac");
     }
 }

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DataNature/DataCoordinationServiceTests.Logic.RetrieveRemoteTools.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DataNature/DataCoordinationServiceTests.Logic.RetrieveRemoteTools.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Brokers.Mcps;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Coordinations.DataNature;
+
+public partial class DataCoordinationServiceTests
+{
+    // What the agent HAS includes what its servers offer: the nature hands the loop the remote
+    // tools its retrieval region discovered, so selection can judge them with the local ones
+    // (SPEC.md §4.15; principal review 2026-09-04, F-04).
+    [Fact]
+    public async Task ShouldRetrieveRemoteToolsAsync()
+    {
+        // given
+        IReadOnlyList<McpTool> randomTools =
+        [
+            new McpTool(CreateRandomString(), CreateRandomString())
+        ];
+
+        IReadOnlyList<McpTool> expectedTools = randomTools;
+
+        this.externalToolServiceMock.Setup(service =>
+            service.RetrieveToolsAsync())
+                .ReturnsAsync(randomTools);
+
+        // when
+        IReadOnlyList<McpTool> actualTools =
+            await this.dataCoordinationService.RetrieveRemoteToolsAsync();
+
+        // then
+        actualTools.Should().BeEquivalentTo(expectedTools);
+
+        this.externalToolServiceMock.Verify(service =>
+            service.RetrieveToolsAsync(),
+                Times.Once);
+
+        this.externalToolServiceMock.VerifyNoOtherCalls();
+        this.skillServiceMock.VerifyNoOtherCalls();
+        this.memoryServiceMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationServiceTests.Logic.RetrieveRemoteTools.cs
+++ b/Standard.Agents.Tests.Unit/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationServiceTests.Logic.RetrieveRemoteTools.cs
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Models.Brokers.Mcps;
+using Xeptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Orchestrations.Data.Retrievals;
+
+public partial class RetrievalOrchestrationServiceTests
+{
+    // Found in the 2026-09-04 principal review (F-04): the remote catalog was appended after
+    // selection ran, so a selector could neither see nor withhold a remote tool. Discovery is a
+    // retrieval the loop can ask for BEFORE it decides what a run is offered — every tool the
+    // servers declared, described or not, so the callers apply the opt-in themselves.
+    [Fact]
+    public async Task ShouldRetrieveRemoteToolsAsync()
+    {
+        // given
+        IReadOnlyList<McpTool> randomTools =
+        [
+            new McpTool(CreateRandomString(), CreateRandomString()),
+            new McpTool(CreateRandomString(), "")
+        ];
+
+        IReadOnlyList<McpTool> expectedTools = randomTools;
+
+        this.externalToolServiceMock.Setup(service =>
+            service.RetrieveToolsAsync())
+                .ReturnsAsync(randomTools);
+
+        // when
+        IReadOnlyList<McpTool> actualTools =
+            await this.retrievalOrchestrationService.RetrieveRemoteToolsAsync();
+
+        // then
+        actualTools.Should().BeEquivalentTo(expectedTools);
+
+        this.externalToolServiceMock.Verify(service =>
+            service.RetrieveToolsAsync(),
+                Times.Once);
+
+        this.skillServiceMock.VerifyNoOtherCalls();
+        this.externalToolServiceMock.VerifyNoOtherCalls();
+        this.knowledgeServiceMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+
+    // The same degradation the catalog gets: a server that cannot be asked offers nothing this
+    // turn, and the foundation already logged why.
+    [Theory]
+    [MemberData(nameof(RemoteDiscoveryExceptions))]
+    public async Task ShouldRetrieveNoRemoteToolsWhenDiscoveryFailsAsync(
+        Xeption remoteDiscoveryException)
+    {
+        // given
+        this.externalToolServiceMock.Setup(service =>
+            service.RetrieveToolsAsync())
+                .ThrowsAsync(remoteDiscoveryException);
+
+        // when
+        IReadOnlyList<McpTool> actualTools =
+            await this.retrievalOrchestrationService.RetrieveRemoteToolsAsync();
+
+        // then
+        actualTools.Should().BeEmpty();
+
+        this.externalToolServiceMock.Verify(service =>
+            service.RetrieveToolsAsync(),
+                Times.Once);
+
+        this.skillServiceMock.VerifyNoOtherCalls();
+        this.externalToolServiceMock.VerifyNoOtherCalls();
+        this.knowledgeServiceMock.VerifyNoOtherCalls();
+        this.loggingBrokerMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents/Models/Loggings/AgentRun.cs
+++ b/Standard.Agents/Models/Loggings/AgentRun.cs
@@ -84,6 +84,15 @@ public sealed class AgentRun
     public IReadOnlyList<string>? OfferedTools { get; set; }
 
     /// <summary>
+    /// The remote tools this run discovered on its servers, set by the loop once per run before
+    /// selection and read wherever the offering is rendered or bound: the text catalog, the
+    /// native tool list, and the perimeter's notion of what is advertised. Empty when there are
+    /// none. Riding the run for the same reason the offering does — the readers sit two tiers
+    /// below the loop, and none should gain a parameter for it.
+    /// </summary>
+    public IReadOnlyList<Brokers.Mcps.McpTool> RemoteTools { get; set; } = [];
+
+    /// <summary>
     /// Starts a run on the calling flow and returns the scope that ends it. Call it from the
     /// coordination loop, before anything the run should be credited with.
     /// </summary>

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -35,3 +35,9 @@ Standard.Agents.Models.Brokers.Mcps.McpTool.Deconstruct(out string! Name, out st
 Standard.Agents.Models.Brokers.Mcps.McpTool.McpTool(string! Name, string! Description, string! InputSchemaJson = "{}") -> void
 Standard.Agents.Models.Brokers.Mcps.McpTool.InputSchemaJson.get -> string!
 Standard.Agents.Models.Brokers.Mcps.McpTool.InputSchemaJson.init -> void
+Standard.Agents.Services.Orchestrations.Data.Retrievals.IRetrievalOrchestrationService.RetrieveRemoteToolsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!>
+Standard.Agents.Services.Orchestrations.Data.Retrievals.RetrievalOrchestrationService.RetrieveRemoteToolsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!>
+Standard.Agents.Services.Coordinations.Data.IDataCoordinationService.RetrieveRemoteToolsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!>
+Standard.Agents.Services.Coordinations.Data.DataCoordinationService.RetrieveRemoteToolsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!>
+Standard.Agents.Models.Loggings.AgentRun.RemoteTools.get -> System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!
+Standard.Agents.Models.Loggings.AgentRun.RemoteTools.set -> void

--- a/Standard.Agents/Services/Coordinations/Data/DataCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/Data/DataCoordinationService.cs
@@ -95,4 +95,7 @@ public partial class DataCoordinationService : IDataCoordinationService
 
     public ValueTask RecordSessionAsync(AgentSession session) =>
         this.recollectionService.RecordSessionAsync(session);
+
+    public async ValueTask<IReadOnlyList<Models.Brokers.Mcps.McpTool>> RetrieveRemoteToolsAsync() =>
+        [];
 }

--- a/Standard.Agents/Services/Coordinations/Data/DataCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/Data/DataCoordinationService.cs
@@ -96,6 +96,6 @@ public partial class DataCoordinationService : IDataCoordinationService
     public ValueTask RecordSessionAsync(AgentSession session) =>
         this.recollectionService.RecordSessionAsync(session);
 
-    public async ValueTask<IReadOnlyList<Models.Brokers.Mcps.McpTool>> RetrieveRemoteToolsAsync() =>
-        [];
+    public ValueTask<IReadOnlyList<Models.Brokers.Mcps.McpTool>> RetrieveRemoteToolsAsync() =>
+        this.retrievalService.RetrieveRemoteToolsAsync();
 }

--- a/Standard.Agents/Services/Coordinations/Data/IDataCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/Data/IDataCoordinationService.cs
@@ -18,4 +18,10 @@ public interface IDataCoordinationService
     ValueTask<AgentSession?> RecallSessionAsync(string sessionId);
 
     ValueTask RecordSessionAsync(AgentSession session);
+
+    /// <summary>
+    /// The remote tools the agent's servers offer — part of what the agent HAS, so the loop can
+    /// judge them with the local tools when it decides what a run is offered (SPEC.md §4.15).
+    /// </summary>
+    ValueTask<IReadOnlyList<Models.Brokers.Mcps.McpTool>> RetrieveRemoteToolsAsync();
 }

--- a/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Perimeter.cs
+++ b/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Perimeter.cs
@@ -354,6 +354,15 @@ public partial class DirectionCoordinationService
     private bool DeniedBecauseSelectionWithheldIt(string toolName) =>
         this.enforceSelection
             && AgentRun.Current?.OfferedTools is { } offered
-            && this.advertisedToolNames.Contains(toolName)
+            && IsAdvertised(toolName)
             && offered.Contains(toolName, StringComparer.OrdinalIgnoreCase) is false;
+
+    // Advertised is what selection could have offered: the agent's described tools, and the
+    // described remote tools this run discovered. Enforcement used to check the local set alone,
+    // so an unoffered remote call went through (principal review 2026-09-04, F-04).
+    private bool IsAdvertised(string toolName) =>
+        this.advertisedToolNames.Contains(toolName)
+            || (AgentRun.Current?.RemoteTools ?? []).Any(tool =>
+                string.IsNullOrWhiteSpace(tool.Description) is false
+                    && tool.Name.Equals(toolName, StringComparison.OrdinalIgnoreCase));
 }

--- a/Standard.Agents/Services/Managements/RunManagementService.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.cs
@@ -10,6 +10,7 @@ using Standard.Agents.Brokers.Telemetries;
 using Standard.Agents.Brokers.Times;
 using Standard.Agents.Models.Brokers.Generators;
 using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Brokers.Mcps;
 using Standard.Agents.Models.Brokers.Sessions;
 using Standard.Agents.Models.Coordinations.Agents;
 using Standard.Agents.Models.Clients.Agents;
@@ -106,6 +107,19 @@ public partial class RunManagementService : IRunManagementService
 
         this.toolSelector = toolSelector;
         this.describedToolNames = [.. describedToolNames ?? []];
+    }
+
+    // The described names selection judges over: the agent's own, then its servers' — a
+    // description is the opt-in for both (SPEC.md §6.1), and a remote name the agent already
+    // carries locally is the local tool's: first to claim a name keeps it.
+    private IReadOnlyList<string> DescribedToolNames(IReadOnlyList<McpTool> remoteTools)
+    {
+        IEnumerable<string> remoteDescribedToolNames = remoteTools
+            .Where(tool => string.IsNullOrWhiteSpace(tool.Description) is false)
+            .Select(tool => tool.Name)
+            .Where(name => this.describedToolNames.Contains(name, StringComparer.OrdinalIgnoreCase) is false);
+
+        return [.. this.describedToolNames, .. remoteDescribedToolNames];
     }
 
     // Precedence, per field: configured → request → framework default
@@ -458,14 +472,29 @@ public partial class RunManagementService : IRunManagementService
         // the native tool list), and neither renderer should gain a parameter for it. Recorded,
         // because a review of a run that lacked a capability must see that it was withheld by
         // selection rather than missing from the agent.
+        // What the agent's servers offer, discovered once per composition and carried on the
+        // run: selection judges these with the local tools, the native tool list advertises
+        // them, and the perimeter binds them (SPEC.md §4.15). They used to join the catalog
+        // AFTER selection, so a selector could neither see nor withhold a remote tool
+        // (principal review 2026-09-04, F-04). A double that answered nothing is no servers.
+        IReadOnlyList<McpTool> remoteTools =
+            await this.dataCoordinationService.RetrieveRemoteToolsAsync() ?? [];
+
+        IReadOnlyList<string> describedToolNames = DescribedToolNames(remoteTools);
+
+        if (AgentRun.Current is AgentRun discoveringRun)
+        {
+            discoveringRun.RemoteTools = remoteTools;
+        }
+
         if (this.toolSelector is not null && AgentRun.Current is AgentRun selectingRun)
         {
             IReadOnlyList<string> chosen =
-                await this.toolSelector.SelectAsync(prompt, this.describedToolNames);
+                await this.toolSelector.SelectAsync(prompt, describedToolNames);
 
             // Names the agent does not carry are ignored, and the record below states the
             // TRUTH of the offering — never the selector's claim (SPEC.md §4.15).
-            IReadOnlyList<string> offered = [.. this.describedToolNames
+            IReadOnlyList<string> offered = [.. describedToolNames
                 .Where(name => chosen.Contains(name, StringComparer.OrdinalIgnoreCase))];
 
             selectingRun.OfferedTools = offered;
@@ -473,7 +502,7 @@ public partial class RunManagementService : IRunManagementService
             await this.loggingBroker.LogProcessAsync(
                 "Run",
                 $"Selection → offered [{string.Join(", ", offered)}]; withheld "
-                    + $"[{string.Join(", ", this.describedToolNames.Except(offered, StringComparer.OrdinalIgnoreCase))}]");
+                    + $"[{string.Join(", ", describedToolNames.Except(offered, StringComparer.OrdinalIgnoreCase))}]");
         }
 
         // Precedence resolved once, at the top of the run, and never again below it: a loop

--- a/Standard.Agents/Services/Orchestrations/Data/Retrievals/IRetrievalOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/Retrievals/IRetrievalOrchestrationService.cs
@@ -20,4 +20,11 @@ public interface IRetrievalOrchestrationService
 
     /// <summary>The passages that answer this prompt, best first.</summary>
     ValueTask<IReadOnlyList<string>> RetrieveGroundingAsync(string query);
+
+    /// <summary>
+    /// The remote tools the configured servers offer, discovered once and kept: what a run may
+    /// be offered beyond the tools the agent carries. Empty when there are none, or when their
+    /// server could not be asked — that failure was localized and logged where it happened.
+    /// </summary>
+    ValueTask<IReadOnlyList<Models.Brokers.Mcps.McpTool>> RetrieveRemoteToolsAsync();
 }

--- a/Standard.Agents/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationService.cs
@@ -157,6 +157,14 @@ public partial class RetrievalOrchestrationService : IRetrievalOrchestrationServ
         return string.Join("\n", catalogLines);
     }
 
+    public ValueTask<IReadOnlyList<McpTool>> RetrieveRemoteToolsAsync() =>
+    TryCatch(async () =>
+    {
+        await ValueTask.CompletedTask;
+
+        return (IReadOnlyList<McpTool>)[];
+    });
+
     public ValueTask<IReadOnlyList<string>> RetrieveGroundingAsync(string query) =>
     TryCatch(async () =>
     {

--- a/Standard.Agents/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Data/Retrievals/RetrievalOrchestrationService.cs
@@ -33,9 +33,9 @@ public partial class RetrievalOrchestrationService : IRetrievalOrchestrationServ
     // only source — the pre-selection behavior, byte for byte.
     private readonly IReadOnlyDictionary<string, string>? toolCatalogEntries;
 
-    // The rendered remote catalog, kept after the first successful discovery so a healthy server
-    // is asked once per composition rather than once per prompt.
-    private string? remoteToolCatalog;
+    // The remote tools, kept after the first successful discovery so a healthy server is asked
+    // once per composition rather than once per prompt.
+    private IReadOnlyList<McpTool>? remoteTools;
 
     public RetrievalOrchestrationService(
         ISkillService skillService,
@@ -97,7 +97,7 @@ public partial class RetrievalOrchestrationService : IRetrievalOrchestrationServ
         }
 
         string localCatalog = SelectedToolCatalog();
-        string remoteCatalog = await RetrieveRemoteToolCatalogAsync();
+        string remoteCatalog = RenderRemoteToolCatalog(await DiscoverRemoteToolsAsync());
 
         if (string.IsNullOrEmpty(remoteCatalog))
         {
@@ -111,59 +111,59 @@ public partial class RetrievalOrchestrationService : IRetrievalOrchestrationServ
 
     // Best-effort and cached on success: a server down at discovery hides only its own tools
     // this turn and is asked again on the next. The foundation has already localized and logged
-    // its failure at the severity it earned, so this tier degrades to the local catalog rather
+    // its failure at the severity it earned, so this tier degrades to no remote tools rather
     // than reporting the outage as an empty server or failing the run.
-    private async ValueTask<string> RetrieveRemoteToolCatalogAsync()
+    private async ValueTask<IReadOnlyList<McpTool>> DiscoverRemoteToolsAsync()
     {
-        if (this.remoteToolCatalog is not null)
+        if (this.remoteTools is not null)
         {
-            return this.remoteToolCatalog;
+            return this.remoteTools;
         }
 
         try
         {
-            IReadOnlyList<McpTool> remoteTools =
-                await this.externalToolService.RetrieveToolsAsync();
+            this.remoteTools = await this.externalToolService.RetrieveToolsAsync();
 
-            this.remoteToolCatalog = RenderRemoteToolCatalog(remoteTools);
-
-            return this.remoteToolCatalog;
+            return this.remoteTools;
         }
         catch (ExternalToolDependencyException)
         {
-            return string.Empty;
+            return [];
         }
         catch (ExternalToolDependencyValidationException)
         {
-            return string.Empty;
+            return [];
         }
         catch (ExternalToolServiceException)
         {
-            return string.Empty;
+            return [];
         }
     }
 
-    // The same opt-in rule the local catalog uses (SPEC.md §6.1): a description is what
-    // advertises a tool, so an undescribed remote tool stays callable but unlisted. What the
-    // tool takes is part of the advertisement, so the schema the server declared rides the line
-    // exactly as a local tool's Parameters do.
+    // The same rules the local catalog lives by: a description is the opt-in (SPEC.md §6.1), so
+    // an undescribed remote tool stays callable but unlisted; a run under selection is shown
+    // only what it was offered (SPEC.md §4.15); and what the tool takes is part of the
+    // advertisement, so the schema the server declared rides the line as a local tool's
+    // Parameters do.
     private static string RenderRemoteToolCatalog(IReadOnlyList<McpTool> remoteTools)
     {
+        IReadOnlyList<string>? offered = Models.Loggings.AgentRun.Current?.OfferedTools;
+
         IEnumerable<string> catalogLines = remoteTools
             .Where(tool => string.IsNullOrWhiteSpace(tool.Description) is false)
+            .Where(tool => offered is null
+                || offered.Contains(tool.Name, StringComparer.OrdinalIgnoreCase))
             .Select(tool =>
                 $"- {tool.Name} — {tool.Description} parameters: {tool.InputSchemaJson}");
 
         return string.Join("\n", catalogLines);
     }
 
+    // Every tool the servers declared, described or not, so the callers apply the opt-in
+    // themselves — selection judges described names, the native list advertises described
+    // definitions, and the perimeter binds described names (principal review 2026-09-04, F-04).
     public ValueTask<IReadOnlyList<McpTool>> RetrieveRemoteToolsAsync() =>
-    TryCatch(async () =>
-    {
-        await ValueTask.CompletedTask;
-
-        return (IReadOnlyList<McpTool>)[];
-    });
+    TryCatch(async () => await DiscoverRemoteToolsAsync());
 
     public ValueTask<IReadOnlyList<string>> RetrieveGroundingAsync(string query) =>
     TryCatch(async () =>

--- a/Standard.Agents/Services/Orchestrations/Decision/Inferences/InferenceOrchestrationService.Native.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/Inferences/InferenceOrchestrationService.Native.cs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------
 
 using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Brokers.Mcps;
 using Standard.Agents.Models.Orchestrations.Agents;
 
 namespace Standard.Agents.Services.Orchestrations.Decision.Inferences;
@@ -85,7 +86,8 @@ public partial class InferenceOrchestrationService
     // is safe — and only Direction knows which words are whose.
     private IReadOnlyList<ToolDefinition> MergedTools(AgentContext context)
     {
-        IReadOnlyList<ToolDefinition> configured = this.toolDefinitions;
+        IReadOnlyList<ToolDefinition> configured =
+            [.. this.toolDefinitions, .. RemoteToolDefinitions()];
 
         // Selection (SPEC.md §4.15): the run is offered the selected subset of the agent's own
         // tools. Caller tools are the caller's vocabulary and are never selected away.
@@ -100,5 +102,20 @@ public partial class InferenceOrchestrationService
         return callerTools.Count == 0
             ? configured
             : [.. configured, .. callerTools];
+    }
+
+    // The servers' described tools this run discovered, advertised natively with the schema they
+    // declared, after the agent's own: a remote name the agent already carries is the local
+    // tool's. Native definitions used to be built from local tools alone, so a native brain was
+    // never told a remote tool existed (principal review 2026-09-04, F-03).
+    private IReadOnlyList<ToolDefinition> RemoteToolDefinitions()
+    {
+        IReadOnlyList<McpTool> remoteTools = Models.Loggings.AgentRun.Current?.RemoteTools ?? [];
+
+        return [.. remoteTools
+            .Where(tool => string.IsNullOrWhiteSpace(tool.Description) is false)
+            .Where(tool => this.toolDefinitions.Any(local =>
+                local.Name.Equals(tool.Name, StringComparison.OrdinalIgnoreCase)) is false)
+            .Select(tool => new ToolDefinition(tool.Name, tool.Description, tool.InputSchemaJson))];
     }
 }

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -3,7 +3,7 @@
 A **language-neutral** set of behavioral test vectors that any Standard-Agents
 implementation runs to self-certify against
 [`SPEC.md`](https://github.com/hassanhabib/The-Standard-Agent-Specs/blob/main/SPEC.md).
-Seventy-four vectors, four readiness profiles, every vector proven able to fail.
+Seventy-six vectors, four readiness profiles, every vector proven able to fail.
 
 The vectors are the executable half of the specification. Prose can be read two ways; a vector
 cannot, which is why "conformant" here means *this suite passes* rather than *we believe we
@@ -75,6 +75,8 @@ capability it configures did not exist, which is why the early vectors still des
 | `streamed` | run the request through the streamed loop, which enforces every control the batched one does |
 | `streamedOutcome` | run the request through the third door (§4.14): the enumeration's events AND the structured outcome its completion carries, so `status` / `pendingEffectTool` certify on the streamed door too |
 | `selectTools` | a scripted selector (§4.15) returning this fixed set whatever the task; an empty list is the valid offered-nothing selection |
+| `enforceSelection` | the offering BINDS at the perimeter (§4.15, enforced): an unoffered advertised tool is denied rather than reachable |
+| `mcpToolSchemas` | what a scripted server declares its tools take, `{tool: inputSchemaJson}`; the rest take an open object |
 | `toolDescriptions` | gives stub tools descriptions — the advertisement opt-in (§6.1) — so what a run was OFFERED is observable in the catalog the Brain reads |
 | `toolNarrations` | a stub tool's declared narration templates, `{tool: {starting, observed}}` — `{tool}` and `{payload}` slots interpolate |
 | `gateVerdictOnNarration` | the verdict the scripted Gate returns for model narration — screened text that is neither the prompt nor a tool's output |
@@ -175,6 +177,8 @@ the deterministic core of the Standard.
 | `a-cost-budget-without-a-rate-refuses-to-compose` | A dollar bound with no rate computes zero forever; the document refuses and names the missing rate (§4.10) |
 | `an-endpoint-that-names-the-route-refuses-to-compose` | An apiUrl is the base the route is appended to; one that names the route, or drops its trailing slash, refuses and names apiUrl |
 | `a-remote-tools-schema-reaches-the-catalog` | A server's declared inputSchema rides the catalog line as the tool's parameters; the Brain is told how to call it, not only that it exists (§6.1) |
+| `a-selector-can-withhold-a-remote-tool` | Remote tools are discovered before selection and judged with the local ones; the withheld remote line reaches no model (§4.15) |
+| `an-enforced-offering-binds-a-remote-tool` | With enforcement on, an unoffered remote tool is denied at the perimeter, its server never called, and the run recovers (§4.15) |
 | `a-repeat-in-a-session-is-a-new-act` | Run-once is scoped to a run; a repeat in a later run performs (§4.9) |
 | `an-allow-list-can-say-where` | Permission is what **and where**; the tool names the scope (§4.9) |
 | `ask-first-covers-what-nothing-permitted` | A mode answers for the acts no permission mentioned (§4.9) |

--- a/conformance/vectors/75-a-selector-can-withhold-a-remote-tool.json
+++ b/conformance/vectors/75-a-selector-can-withhold-a-remote-tool.json
@@ -1,0 +1,21 @@
+{
+  "name": "a-selector-can-withhold-a-remote-tool",
+  "description": "SPEC.md 4.15 over remote tools: what an agent carries includes what its servers offer, so selection judges the remote catalog together with the local one. The selector keeps weather and withholds almanac; almanac's catalog line reaches no model, and the offered remote tool works exactly as before. The 2026-09-04 principal review (F-04) found the remote catalog appended AFTER selection ran, so a selector could neither see nor withhold a remote tool - the very case the how-to names as selection's motivation, an agent with twenty MCP servers.",
+  "mcpServers": [
+    { "weather": "sunny in Seattle", "almanac": "plant in spring" }
+  ],
+  "extraSkills": [ "Available tools:\n{{tools}}" ],
+  "generatorReplies": [
+    "ACTION: weather: Seattle",
+    "FINAL: sunny"
+  ],
+  "tools": {},
+  "prompt": "what is the weather in Seattle?",
+  "selectTools": [ "weather" ],
+  "expect": {
+    "resultContains": "sunny",
+    "brainSees": "scripted tool weather",
+    "brainNeverSees": "scripted tool almanac",
+    "mcpServerCalls": [ 1 ]
+  }
+}

--- a/conformance/vectors/76-an-enforced-offering-binds-a-remote-tool.json
+++ b/conformance/vectors/76-an-enforced-offering-binds-a-remote-tool.json
@@ -1,0 +1,21 @@
+{
+  "name": "an-enforced-offering-binds-a-remote-tool",
+  "description": "SPEC.md 4.15, enforced, over remote tools: with enforcement on, an act naming an advertised tool the run was not offered is denied at the Direction perimeter - told, non-terminal, recoverable - and a described remote tool is advertised like a local one, so the offering binds it the same way. A disobedient Brain names the withheld almanac; its server is never called, the denial reaches the Brain, and the run answers among what it was offered. The 2026-09-04 principal review (F-04) found enforcement checking the LOCAL advertised set only, so an unoffered remote call went through.",
+  "mcpServers": [
+    { "weather": "sunny in Seattle", "almanac": "plant in spring" }
+  ],
+  "extraSkills": [ "Available tools:\n{{tools}}" ],
+  "generatorReplies": [
+    "ACTION: almanac: when should I plant?",
+    "FINAL: I could not consult the almanac."
+  ],
+  "tools": {},
+  "prompt": "when should I plant?",
+  "selectTools": [ "weather" ],
+  "enforceSelection": true,
+  "expect": {
+    "resultContains": "could not consult",
+    "brainSees": "not offered to this run",
+    "mcpServerCalls": [ 0 ]
+  }
+}

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -284,6 +284,12 @@ the way out, a native tool call's arguments reach the server as the JSON object 
 the text protocol's plain-text payload reaches it as the one argument `{ "input": "..." }`, which
 is what a tool with no schema understands.
 
+**Remote tools are the agent's tools.** A described remote tool is advertised to a native brain as
+a tool definition carrying its schema, judged by `.OnSelectTools(...)` beside the local names,
+and bound by `.EnforceSelection()` the same way. Discovery happens once per composition, at the
+top of the first run, and a server that is down at that moment offers nothing until the next
+run asks again.
+
 **Servers accumulate.** Like `.Tool(...)`, each `.Mcp(...)` call *adds* a server — the agent asks
 each server what it offers (`tools/list`) and routes every call to the server whose catalog owns
 the name. When two servers claim the same name, the **first registered wins** — deterministic,
@@ -1547,6 +1553,10 @@ Without selection, every described tool reaches every run: an agent with twenty 
 puts twenty catalogs in front of "Hello", the token cost scales with the catalog, and a model
 offered a tool will sometimes act on it because it was shown, not because the task needs it —
 the day narration went live, production watched a greeting run a web search six times.
+
+The described names the selector judges over are the agent's own **and** its servers': remote
+tools are discovered before selection runs, so those twenty catalogs are exactly what a selector
+can withhold, and an enforced offering binds a remote name the same way it binds a local one.
 
 ```csharp
 StandardAgent agent = new StandardAgent()


### PR DESCRIPTION
Closes F-04 and the native-advertisement half of F-03 in docs/PRINCIPAL-ARCHITECTURE-REVIEW-2026-09-04.md.

## The defects

- The selector judged over the local described names only, and the remote catalog was appended after selection ran, so `OnSelectTools` could neither see nor withhold a remote tool: the very case the how-to names as selection's motivation, an agent with twenty MCP servers.
- `EnforceSelection` denied a withheld tool only when its name was in the local advertised set, so a disobedient brain could call an unoffered remote tool freely.
- Native tool definitions were built from local tools only, so a native brain was never told a remote tool existed.

## The fix

One flow, in the order the natures already run:

- **Data** discovers. `IRetrievalOrchestrationService.RetrieveRemoteToolsAsync()` returns every tool the servers declared, cached after the first success, empty on a categorized failure the foundation already logged. `IDataCoordinationService` exposes it. The `{{tools}}` catalog now renders remote tools under the run's offering, as it already did local ones.
- **The loop** asks once per run, before selection, carries the result on `AgentRun.RemoteTools` beside `OfferedTools`, and judges selection over local and remote described names together. A remote name the agent already carries locally is the local tool's.
- **Decision** advertises described remote tools as native definitions carrying their schema, after the agent's own.
- **Direction** treats a described remote tool as advertised, so an enforced offering binds it.

## Tests, FAIL then PASS

- Orchestration: `ShouldRetrieveRemoteToolsAsync`, and a Theory proving each categorized discovery failure yields no remote tools.
- Coordination: `ShouldRetrieveRemoteToolsAsync` through the real retrieval region.
- Acceptance: the selector sees both remote names and only the offered line reaches the model; an enforced offering denies an unoffered remote tool and its server is never called; a native brain is offered a remote tool with its schema and its call routes to the server with the arguments as written.
- Conformance vectors 75 `a-selector-can-withhold-a-remote-tool` and 76 `an-enforced-offering-binds-a-remote-tool`. Vectors can now say `enforceSelection`.

Eight new tests failed against the scaffolded stubs, then all 717 passed.

## Verification

- Release build: 0 warnings, 0 errors.
- Unit tests: 717 passed on net8.0 and on net10.0.
- Conformance: 76 passed. Reliable, Enterprise and Critical certified. Evals: 6 passed.

## Behavior change worth knowing

Discovery now runs at the top of the first run whenever servers are configured, rather than only when a `{{tools}}` marker is present. A native-brain agent with MCP pays one discovery call per composition it did not pay before, and in exchange its brain can see the tools.

## Versioning

New public members on two service interfaces and the run model: second segment, subsumed by the first-segment bump F-15 already flagged.