### PR TITLE
MINOR CLIENTS: Memory Is An Explicit Choice For A Hosted Agent

### DIFF
--- a/Standard.Agents.Host/Program.cs
+++ b/Standard.Agents.Host/Program.cs
@@ -61,6 +61,19 @@ builder.Services.AddSingleton<IAgent>(provider =>
         string agentJson = File.ReadAllText(agentJsonPath);
         StandardAgent configured = StandardAgent.FromJson(agentJson);
 
+        // One instance serves every caller, so a memory would be one memory for all of them:
+        // one caller's facts in another caller's context. The document must name a memory to
+        // get one; otherwise the agent recalls nothing and offers no way to store
+        // (principal review 2026-09-04, F-05).
+        bool namesMemory =
+            System.Text.Json.Nodes.JsonNode.Parse(agentJson) is System.Text.Json.Nodes.JsonObject memoryDocument
+                && memoryDocument.ContainsKey("memory");
+
+        if (namesMemory is false)
+        {
+            configured.WithoutMemory();
+        }
+
         // The same zero-config grace the classic path has: a document with no brain still
         // stands, heartbeats, and answers with what to add — never a 500 at the first prompt.
         bool hasBrain =
@@ -95,6 +108,19 @@ builder.Services.AddSingleton<IAgent>(provider =>
     if (string.IsNullOrWhiteSpace(skillsPath) is false)
     {
         agent.Skills(skillsPath);
+    }
+
+    // The same rule as the document: a hosted memory is shared by every caller, so it exists
+    // only when the configuration names it (Agent:Memory).
+    string? memoryPath = configuration["Agent:Memory"];
+
+    if (string.IsNullOrWhiteSpace(memoryPath))
+    {
+        agent.WithoutMemory();
+    }
+    else
+    {
+        agent.Memory(memoryPath);
     }
 
     // Always on: the spans exist only when something listens, so this line is free on a

--- a/Standard.Agents.Tests.Unit/Acceptance/MemoryOptOutTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/MemoryOptOutTests.cs
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Models.Foundations.Skills;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// Found in the 2026-09-04 principal review (F-05): every instance composed memory by default and
+// always registered the remember tool, so a host serving many callers from one singleton let
+// one caller's remembered facts reach another caller's model, and let one caller poison memory
+// for everyone after. Memory stays the convenient default for a one-user agent; a deployment
+// that serves strangers says so, and the agent then recalls nothing and offers no way to store.
+public class MemoryOptOutTests
+{
+    private const string RememberedFact = "the user is Ada";
+
+    private static IMemoryBroker MemoryHolding(string fact, out Mock<IMemoryBroker> memoryBroker)
+    {
+        memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([fact]);
+
+        return memoryBroker.Object;
+    }
+
+    private static IKnowledgeBroker EmptyKnowledge()
+    {
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return knowledgeBroker.Object;
+    }
+
+    [Fact]
+    public async Task ShouldNotAdvertiseOrRecallMemoryWhenComposedWithoutMemoryAsync()
+    {
+        // given
+        IMemoryBroker memory = MemoryHolding(RememberedFact, out Mock<IMemoryBroker> memoryBroker);
+        string seenByBrain = string.Empty;
+
+        StandardAgent agent = new StandardAgent()
+            .UseKnowledge(EmptyKnowledge())
+            .OnSkills(async () =>
+                [new Skill { Name = "persona", Content = "Your tools:\n{{tools}}" }])
+            .UseMemory(memory)
+            .WithoutMemory()
+            .OnBrain(async (systemPrompt, userPrompt) =>
+            {
+                seenByBrain = systemPrompt + "\n" + userPrompt;
+
+                return "FINAL: done";
+            });
+
+        // when
+        await agent.ProcessPromptAsync("hello");
+
+        // then: nothing recalled, nothing offered, the store never asked
+        seenByBrain.Should().NotContain(RememberedFact);
+        seenByBrain.Should().NotContain("remember");
+        memoryBroker.Verify(broker => broker.SelectMemoriesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task ShouldAdvertiseAndRecallMemoryByDefaultAsync()
+    {
+        // given: the unamended one-user default
+        IMemoryBroker memory = MemoryHolding(RememberedFact, out Mock<IMemoryBroker> memoryBroker);
+        string seenByBrain = string.Empty;
+
+        StandardAgent agent = new StandardAgent()
+            .UseKnowledge(EmptyKnowledge())
+            .OnSkills(async () =>
+                [new Skill { Name = "persona", Content = "Your tools:\n{{tools}}" }])
+            .UseMemory(memory)
+            .OnBrain(async (systemPrompt, userPrompt) =>
+            {
+                seenByBrain = systemPrompt + "\n" + userPrompt;
+
+                return "FINAL: done";
+            });
+
+        // when
+        await agent.ProcessPromptAsync("hello");
+
+        // then
+        seenByBrain.Should().Contain(RememberedFact);
+        seenByBrain.Should().Contain("remember");
+        memoryBroker.Verify(broker => broker.SelectMemoriesAsync(), Times.Once);
+    }
+
+    // The document says it the same way code does: a document is the whole truth of a hosted
+    // agent, and a hosted agent that wants no memory needs one key to say so.
+    [Fact]
+    public async Task ShouldComposeWithoutMemoryFromJsonWhenTheDocumentSaysFalseAsync()
+    {
+        // given
+        IMemoryBroker memory = MemoryHolding(RememberedFact, out Mock<IMemoryBroker> memoryBroker);
+        string seenByBrain = string.Empty;
+
+        StandardAgent agent = StandardAgent.FromJson("""{ "memory": false }""")
+            .UseKnowledge(EmptyKnowledge())
+            .OnSkills(async () =>
+                [new Skill { Name = "persona", Content = "Your tools:\n{{tools}}" }])
+            .UseMemory(memory)
+            .OnBrain(async (systemPrompt, userPrompt) =>
+            {
+                seenByBrain = systemPrompt + "\n" + userPrompt;
+
+                return "FINAL: done";
+            });
+
+        // when
+        await agent.ProcessPromptAsync("hello");
+
+        // then
+        seenByBrain.Should().NotContain(RememberedFact);
+        seenByBrain.Should().NotContain("remember");
+        memoryBroker.Verify(broker => broker.SelectMemoriesAsync(), Times.Never);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Logic.RememberToFileConcurrently.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Memorys/MemoryServiceTests.Logic.RememberToFileConcurrently.cs
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Standard.Agents.Brokers.Files;
+using Standard.Agents.Services.Foundations.Memorys;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Services.Foundations.Memorys;
+
+public partial class MemoryServiceTests
+{
+    // Found in the 2026-09-04 principal review (F-05): the file append was not serialized, so
+    // simultaneous remembers — the shape a hosted singleton meets when several callers store a
+    // fact at once — could collide on the file and fail, or interleave. Every fact stored must
+    // be in the file afterwards, whole and once.
+    [Fact]
+    public async Task ShouldRememberConcurrentlyToFileWithoutLosingAMemoryAsync()
+    {
+        // given
+        string memoryPath =
+            Path.Combine(Path.GetTempPath(), $"standard-agent-memory-{Guid.NewGuid():N}.txt");
+
+        var fileMemoryService = new MemoryService(
+            fileBroker: new FileBroker(),
+            memoryPath: memoryPath,
+            loggingBroker: this.loggingBrokerMock.Object);
+
+        IReadOnlyList<string> memories =
+            [.. Enumerable.Range(0, 32).Select(index => $"fact number {index}")];
+
+        try
+        {
+            // when
+            await Task.WhenAll(memories.Select(memory =>
+                fileMemoryService.RememberAsync(memory).AsTask()));
+
+            // then
+            string[] rememberedMemories = await File.ReadAllLinesAsync(memoryPath);
+            rememberedMemories.Should().BeEquivalentTo(memories);
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+        }
+        finally
+        {
+            File.Delete(memoryPath);
+        }
+    }
+}

--- a/Standard.Agents/Brokers/Memorys/NotConfiguredMemoryBroker.cs
+++ b/Standard.Agents/Brokers/Memorys/NotConfiguredMemoryBroker.cs
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Brokers.Memorys;
+
+// No memory at all: nothing to recall, nowhere to store. What an agent composed without memory
+// reads from, so the foundation keeps one shape rather than growing a nullable dependency.
+public sealed class NotConfiguredMemoryBroker : IMemoryBroker
+{
+    public async ValueTask<IReadOnlyList<string>> SelectMemoriesAsync() =>
+        [];
+
+    public async ValueTask InsertMemoryAsync(string memory)
+    {
+    }
+}

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -41,3 +41,8 @@ Standard.Agents.Services.Coordinations.Data.IDataCoordinationService.RetrieveRem
 Standard.Agents.Services.Coordinations.Data.DataCoordinationService.RetrieveRemoteToolsAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!>
 Standard.Agents.Models.Loggings.AgentRun.RemoteTools.get -> System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Brokers.Mcps.McpTool!>!
 Standard.Agents.Models.Loggings.AgentRun.RemoteTools.set -> void
+Standard.Agents.StandardAgent.WithoutMemory() -> Standard.Agents.StandardAgent!
+Standard.Agents.Brokers.Memorys.NotConfiguredMemoryBroker
+Standard.Agents.Brokers.Memorys.NotConfiguredMemoryBroker.NotConfiguredMemoryBroker() -> void
+Standard.Agents.Brokers.Memorys.NotConfiguredMemoryBroker.SelectMemoriesAsync() -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<string!>!>
+Standard.Agents.Brokers.Memorys.NotConfiguredMemoryBroker.InsertMemoryAsync(string! memory) -> System.Threading.Tasks.ValueTask

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -158,6 +158,17 @@ public partial class StandardAgent
 
                 break;
 
+            // A document that wants no memory says so with one key: a hosted agent is the
+            // whole document, and a hosted memory is one memory for every caller.
+            case "memory" when value is JsonValue memoryFlag
+                && memoryFlag.TryGetValue(out bool memoryEnabled):
+                if (memoryEnabled is false)
+                {
+                    agent.WithoutMemory();
+                }
+
+                break;
+
             case "memory":
                 agent.Memory(Text(value, key));
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -444,6 +444,19 @@ public sealed partial class StandardAgent : IAgent
         Set(() => this.memoryPath = path);
 
     /// <summary>
+    /// Composes the agent with <b>no memory</b>: nothing is recalled, and the built-in
+    /// <c>remember</c> tool is not registered, so the model is never offered a way to store.
+    /// The explicit opt-out for a deployment where one instance serves many callers — a shared
+    /// memory would let one caller's facts reach another caller's model, and let one caller
+    /// poison memory for everyone after (principal review 2026-09-04, F-05). Wins over
+    /// <see cref="Memory"/>, <see cref="UseMemory"/> and <see cref="OnMemory"/> whatever order
+    /// they were called in. The one-user default keeps its memory file.
+    /// </summary>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent WithoutMemory() =>
+        Set(() => this.memoryBroker = new NotConfiguredMemoryBroker());
+
+    /// <summary>
     /// Gives the agent a knowledge base — a folder of reference files searched each turn, with the
     /// most relevant matches seeded into the turn's observations for the brain to draw on.
     /// </summary>

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -454,7 +454,11 @@ public sealed partial class StandardAgent : IAgent
     /// </summary>
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent WithoutMemory() =>
-        Set(() => this.memoryBroker = new NotConfiguredMemoryBroker());
+        Set(() => this.memoryDisabled = true);
+
+    // Whether memory is composed at all, held until composition. A flag rather than a broker
+    // swap so the opt-out wins whatever order the memory verbs were called in.
+    private bool memoryDisabled;
 
     /// <summary>
     /// Gives the agent a knowledge base — a folder of reference files searched each turn, with the
@@ -1697,11 +1701,18 @@ public sealed partial class StandardAgent : IAgent
                         brain.MaxTokens ?? ResolvedInference.DefaultMaxTokens,
                         brain.TimeoutSeconds));
 
-        IMemoryService memoryService = this.memoryBroker is null
-            ? new MemoryService(file, Path.GetFullPath(this.memoryPath), logging)
-            : new MemoryService(this.memoryBroker, logging);
+        // Without memory there is nothing to recall and no way to store: the foundation reads a
+        // not-configured broker, and the remember tool is never registered, so the model is not
+        // offered it (principal review 2026-09-04, F-05).
+        IMemoryService memoryService = this.memoryDisabled
+            ? new MemoryService(new NotConfiguredMemoryBroker(), logging)
+            : this.memoryBroker is null
+                ? new MemoryService(file, Path.GetFullPath(this.memoryPath), logging)
+                : new MemoryService(this.memoryBroker, logging);
 
-        List<ITool> allTools = [.. this.tools, new RememberTool(memoryService.RememberAsync)];
+        List<ITool> allTools = this.memoryDisabled
+            ? [.. this.tools]
+            : [.. this.tools, new RememberTool(memoryService.RememberAsync)];
 
         // The fleet materializes as tools — which is the whole design: a handoff is an act, so
         // the advertisement opt-in, the perimeter, the audit and cancellation across the seam

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -71,6 +71,13 @@ with no brain key still stands and heartbeats, and answers every run with exactl
 rather than failing at startup or at the first prompt. No document means the classic
 `Agent:Url` configuration above, unchanged.
 
+**Memory is off in the host unless you turn it on.** One instance serves every caller, so a
+memory file would be one memory for all of them: one caller's remembered facts in another
+caller's context, and one caller able to poison memory for everyone after. The host composes
+the agent without memory unless the document carries a `memory` key, or `Agent:Memory` names a
+path in the classic configuration. Without one, the agent recalls nothing and never offers the
+`remember` tool. Turning it on is a deliberate choice that every caller of that host shares.
+
 ## Locking the door
 
 An agent endpoint carries approval and budget semantics, so the front door is worth a thought.

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -728,6 +728,12 @@ grows, and all of it rides along each turn). Want it somewhere other than a flat
 a per-user store? Implement `IMemoryBroker` and pass it to `.UseMemory(...)`. Calling `.Memory(path)`
 a second time **replaces** the path rather than adding a second one.
 
+**No memory at all.** `.WithoutMemory()` composes the agent with nothing to recall and no
+`remember` tool offered, and it wins whatever order the memory verbs were called in; in a JSON
+document the key is `"memory": false`. It is what a host serving many callers from one instance
+should use unless a shared memory is a deliberate choice, because one instance's memory is one
+memory for every caller. The one-user default keeps its memory file.
+
 ### Memory in Redis
 
 For a shared, multi-tenant memory — one store, many users — the


### PR DESCRIPTION
Closes F-05 of docs/PRINCIPAL-ARCHITECTURE-REVIEW-2026-09-04.md.

## The defect

Every instance composed memory by default and always registered the `remember` tool. The host serves every caller from one singleton, so one caller's remembered facts reached another caller's model, and one caller could poison memory for everyone after.

## The fix

- `WithoutMemory()` composes the agent with no memory: nothing recalled, no `remember` tool offered. It is a flag, not a broker swap, so it wins whatever order the memory verbs were called in. A new `NotConfiguredMemoryBroker` keeps the foundation's shape.
- `"memory": false` says the same in a document.
- The host composes without memory unless the document carries a `memory` key, or `Agent:Memory` names a path in the classic configuration. Turning it on is a deliberate, documented choice every caller of that host shares.
- The one-user default is unchanged: a bare `new StandardAgent()` keeps its memory file.

## Tests, FAIL then PASS

- `ShouldNotAdvertiseOrRecallMemoryWhenComposedWithoutMemoryAsync`: the store is never asked, the fact never reaches the model, and the tool is not in the catalog, with the opt-out called after `UseMemory`.
- `ShouldAdvertiseAndRecallMemoryByDefaultAsync` pins the unamended default.
- `ShouldComposeWithoutMemoryFromJsonWhenTheDocumentSaysFalseAsync`.
- `ShouldRememberConcurrentlyToFileWithoutLosingAMemoryAsync`: thirty-two simultaneous remembers through the real file broker all land whole. This one passed before any change, so the review's interleaving claim did not reproduce here; no serialization was added for a failure that could not be shown, and the test stands as the contract.

## Verification

- Release build: 0 warnings, 0 errors.
- Unit tests: 721 passed on net8.0 and on net10.0.
- Conformance: 76 passed. Reliable, Enterprise and Critical certified.

## Not in this PR

Tenant and principal namespaces for a shared memory, authorization on reads and writes, encryption and retention are the rest of F-05's recommendation and a design of their own.

## Versioning

A new public verb and a new public broker: second segment, subsumed by the first-segment bump already flagged.