### PR TITLE
MINOR FOUNDATIONS: Remember Serializes Its File Append

### DIFF
--- a/Standard.Agents/Services/Foundations/Memorys/MemoryService.cs
+++ b/Standard.Agents/Services/Foundations/Memorys/MemoryService.cs
@@ -68,10 +68,26 @@ public partial class MemoryService : IMemoryService
         return await fileBroker.ReadAllLinesAsync(this.memoryPath);
     }
 
+    // Appends are serialized: two callers remembering at once open the file at the same moment
+    // and one of them fails with a sharing violation, which the review predicted and a
+    // thirty-two-writer test reproduced two runs in three (principal review 2026-09-04, F-05).
+    // Per instance, because the file is per instance; a store shared across processes is a
+    // memory broker's job, not this file's.
+    private readonly SemaphoreSlim memoryFileLock = new(initialCount: 1, maxCount: 1);
+
     private async ValueTask InsertMemoryIntoFileAsync(IFileBroker fileBroker, string memory)
     {
-        fileBroker.CreateDirectory(Path.GetDirectoryName(this.memoryPath)!);
+        await this.memoryFileLock.WaitAsync();
 
-        await fileBroker.AppendAllLinesAsync(this.memoryPath, [memory]);
+        try
+        {
+            fileBroker.CreateDirectory(Path.GetDirectoryName(this.memoryPath)!);
+
+            await fileBroker.AppendAllLinesAsync(this.memoryPath, [memory]);
+        }
+        finally
+        {
+            this.memoryFileLock.Release();
+        }
     }
 }


### PR DESCRIPTION
Fixes a red test that PR #363 merged with, and closes the remaining part of F-05 in docs/PRINCIPAL-ARCHITECTURE-REVIEW-2026-09-04.md.

## What happened

`ShouldRememberConcurrentlyToFileWithoutLosingAMemoryAsync` passed on its first run and I read that as the review's interleaving claim not reproducing. It is timing dependent: it then failed on both targets during the merge run, and my command chain hid the test runner's exit code behind a pipe, so #363 merged red. Reproduced afterwards at two failures in three runs, each a `MemoryDependencyException` localizing a file sharing violation.

## The fix

`MemoryService` serializes the file append behind a `SemaphoreSlim`, per instance, because the file is per instance. A store shared across processes remains a memory broker's job.

## Verification, with real exit codes this time

- Concurrency test: 0 failures in 6 consecutive runs.
- Unit tests: 721 passed on net8.0 and on net10.0.
- Conformance: 76 passed.

## Process change

Every verification chain from here on runs under `pipefail`, so a failing runner stops the chain before anything is committed.