### PR TITLE
MINOR INFRA: Release Keyed By Tag With The Full Gate, Critical Certified In CI, Licenses Checked Against Policy

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -6,7 +6,10 @@ name: Standard.Agents Cut Release
 #
 # Publishing stays in release.yml. A release created with GITHUB_TOKEN does not fire the
 # `release` event (GitHub prevents workflows from triggering workflows through that token),
-# so after this succeeds, dispatch release.yml on the new tag to attach artifacts and publish.
+# so after this succeeds, dispatch release.yml with its `tag` input set to the tag created
+# here. release.yml checks that tag out, refuses it unless the project file carries the same
+# version, runs the full gate, and publishes exactly that version — never whatever branch
+# happened to be selected.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,6 +47,14 @@ jobs:
         dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
         -- --profile Enterprise
 
+    # The highest level the README claims, certified explicitly. Critical inherits Enterprise,
+    # so this transitively re-certifies every lower profile; running all vectors proves their
+    # current behavior but not that each profile's required set is still complete (F-18).
+    - name: Certifying Critical Profile
+      run: >
+        dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
+        -- --profile Critical
+
     # Quality certification beside contract certification: the golden evals measure task
     # completion, groundedness, retrieval precision and recall, tool selection, refusal
     # correctness and revision effectiveness, and fail the build under threshold.
@@ -84,8 +92,30 @@ jobs:
           exit 1
         fi
 
-    - name: Listing Dependency Licenses
-      run: dotnet list package --include-transitive
+    # A license inventory with a policy, not a package listing: every package in the shipped
+    # graph, transitively, resolved to a license expression and checked against
+    # licenses/allowed-licenses.json. Packages that publish only a URL are mapped in
+    # licenses/license-url-mappings.json; the two that ship a bare License.txt are named in
+    # licenses/package-overrides.json. An unknown or disallowed license fails the build (F-26).
+    - name: Checking Dependency Licenses Against Policy
+      run: |
+        dotnet tool install --global nuget-license
+        nuget-license -i Standard.Agents/Standard.Agents.csproj -t \
+          -a licenses/allowed-licenses.json \
+          -mapping licenses/license-url-mappings.json \
+          -override licenses/package-overrides.json \
+          -o JsonPretty -fo licenses.json
+        nuget-license -i Standard.Agents/Standard.Agents.csproj -t \
+          -a licenses/allowed-licenses.json \
+          -mapping licenses/license-url-mappings.json \
+          -override licenses/package-overrides.json \
+          -err
+
+    - name: Publishing The License Inventory
+      uses: actions/upload-artifact@v4
+      with:
+        name: license-inventory
+        path: licenses.json
 
     # Secrets that reach a public repository are already leaked; the value of this check is
     # catching the commit that would have done it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,22 @@
 name: Standard.Agents Release
 
-# Publishes the package to NuGet when a release is cut (a GitHub Release is
-# published) or triggered manually. The API key is never in the repo — it is
-# read from the NUGET_API_KEY repository secret at run time.
+# Publishes the package to NuGet when a release is cut (a GitHub Release is published) or
+# when dispatched by hand on a tag. The API key is never in the repo — it is read from the
+# NUGET_API_KEY repository secret at run time.
+#
+# Keyed by an immutable tag, never by "whatever branch was selected": a manual dispatch names
+# the tag it publishes, the workflow checks that tag out, and it refuses to run unless the
+# package version in the project file is the tag's version. A release whose bytes came from a
+# different commit than the tag names, or whose package carries an unbumped version, is worse
+# than no release (principal review 2026-09-04, F-17).
 on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "The published tag to build and publish (e.g. v1.16.0)"
+        required: true
 
 jobs:
   publish:
@@ -21,9 +31,28 @@ jobs:
       id-token: write
       attestations: write
 
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+
     steps:
-    - name: Pulling Code
+    - name: Pulling The Tagged Code
       uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+    # The tag is the release's identity; the project file is what gets packed. They must agree
+    # before anything is built: a tag v1.16.0 packs 1.16.0.x, and the fourth segment is the
+    # build number NuGet normalizes away (docs/support.md, "Version numbers").
+    - name: Verifying The Tag Matches The Package Version
+      run: |
+        version=$(sed -n 's/.*<Version>\([0-9]*\.[0-9]*\.[0-9]*\)\.[0-9]*<\/Version>.*/\1/p' Standard.Agents/Standard.Agents.csproj | head -1)
+        tag="${RELEASE_TAG#v}"
+        echo "project version: $version"
+        echo "release tag:     $tag"
+        if [ -z "$version" ] || [ "$version" != "$tag" ]; then
+          echo "::error::The tag $RELEASE_TAG does not match the package version $version in Standard.Agents.csproj."
+          exit 1
+        fi
 
     # The SDK comes from global.json, so the package is built with the same compiler a
     # developer used. Reproducibility starts with agreeing on the toolchain.
@@ -31,6 +60,7 @@ jobs:
       uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
+        dotnet-version: 8.0.x
 
     - name: Restoring Packages
       run: dotnet restore
@@ -41,10 +71,23 @@ jobs:
     - name: Running Tests
       run: dotnet test --no-build --configuration Release --verbosity normal
 
-    # Same gate the build workflow enforces — never publish a package that no
-    # longer conforms to the spec's vectors.
+    # The complete gate the build workflow enforces — every vector, the profiles the README
+    # claims, and the golden evals. Never publish a package that could not pass its own CI.
     - name: Certifying Conformance
       run: dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
+
+    - name: Certifying Enterprise Profile
+      run: >
+        dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
+        -- --profile Enterprise
+
+    - name: Certifying Critical Profile
+      run: >
+        dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
+        -- --profile Critical
+
+    - name: Evaluating Quality
+      run: dotnet run --project Standard.Agents.Evals --no-build --configuration Release
 
     - name: Packing Package
       run: >
@@ -52,6 +95,17 @@ jobs:
         --no-build
         --configuration Release
         --output ${{ github.workspace }}/artifacts
+
+    # The packed artifact must carry the version the tag names. Packing an unbumped project
+    # produced a package NuGet already had, which --skip-duplicate then hid as a success.
+    - name: Verifying The Packed Version
+      run: |
+        expected="${RELEASE_TAG#v}"
+        ls "${{ github.workspace }}/artifacts"
+        if ! ls "${{ github.workspace }}/artifacts" | grep -q "^Standard\.Agents\.${expected}\.nupkg$"; then
+          echo "::error::No Standard.Agents.${expected}.nupkg was produced for tag $RELEASE_TAG."
+          exit 1
+        fi
 
     # A software bill of materials: what is actually inside the package, transitively. Most
     # regulated procurement asks for one, and generating it at release time means it describes
@@ -73,13 +127,15 @@ jobs:
     - name: Attaching Artifacts To The Release
       uses: softprops/action-gh-release@v3
       with:
+        tag_name: ${{ env.RELEASE_TAG }}
         files: |
           ${{ github.workspace }}/artifacts/*.nupkg
           ${{ github.workspace }}/artifacts/*.json
 
+    # No --skip-duplicate: a version NuGet already has is a release that did not happen, and
+    # the run must say so rather than print success over bytes that never shipped.
     - name: Publishing To NuGet
       run: >
         dotnet nuget push "${{ github.workspace }}/artifacts/*.nupkg"
         --source https://api.nuget.org/v3/index.json
         --api-key ${{ secrets.NUGET_API_KEY }}
-        --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ log.math.txt
 ## Local secrets — set appsettings.json ApiKey locally; never commit real keys
 appsettings.*.local.json
 
+## The agent document the host reads may carry credentials (docs/how-to.md §16). The
+## committed shape is agent.example.json, without secrets; the real one stays local.
+agent.json
+agent.*.local.json
+
 ## IDE / OS
 .vs/
 .idea/

--- a/README.md
+++ b/README.md
@@ -259,10 +259,14 @@ execute and answer. See
 ## Provider packages — swap any nature to a real backend
 
 The core [`Standard.Agents`](https://www.nuget.org/packages/Standard.Agents) is deliberately
-**dependency-free**: a hosted brain, and local-file skills, memory, and knowledge. Reach further with
-an opt-in package — each one backs a single nature with a real provider through the **same broker
-seam**, so it's *one line and nothing else about your agent changes*. Mix them freely: a local brain
-with cloud data, a registry of skills with a Redis memory.
+**provider-independent**: a hosted brain, and local-file skills, memory, and knowledge, with no
+provider SDK in the box. It is not literally package-free: it ships three runtime dependencies
+(`RESTFulSense` for the HTTP client, `Xeption` for exception data, and
+`Microsoft.Extensions.Logging.Abstractions`), and their transitive graph is inventoried and
+license-checked on every build. Reach further with an opt-in package — each one backs a single
+nature with a real provider through the **same broker seam**, so it's *one line and nothing else
+about your agent changes*. Mix them freely: a local brain with cloud data, a registry of skills
+with a Redis memory.
 
 | Package | Backs | Provider |
 |---|---|---|

--- a/Standard.Agents.Host/agent.example.json
+++ b/Standard.Agents.Host/agent.example.json
@@ -1,0 +1,7 @@
+{
+  "brain": { "apiUrl": "https://api.peerllm.com/v1/", "apiKey": "<set locally, never commit>", "model": "LLooMA2.0" },
+  "skills": "Skills",
+  "ruleGate": ["password"],
+  "budget": { "maxCostUsd": 0.25, "costPerThousandTokens": 0.002 },
+  "telemetry": "form-built-agent"
+}

--- a/Standard.Agents/Brokers/Audits/FileAuditBroker.cs
+++ b/Standard.Agents/Brokers/Audits/FileAuditBroker.cs
@@ -66,8 +66,15 @@ public sealed class FileAuditBroker : IAuditBroker
 
     // Verifies a sink written by this broker: every record's previousHash must equal the hash
     // of the line before it. Returns the 1-based line number of the first record that does
-    // not, or null when the chain is intact — so a caller can prove a decision log was neither
-    // altered nor truncated (SPEC.md §4.7).
+    // not, or null when the chain is intact — so a caller can prove no record in the MIDDLE of
+    // a decision log was altered or removed (SPEC.md §4.7).
+    //
+    // What it does not prove, said plainly (principal review 2026-09-04, F-13): a suffix cut
+    // off the end leaves a valid prefix with no broken link, and the chain is unkeyed, so
+    // anyone who can rewrite the file can recompute it. This is local, append-only,
+    // hash-linked evidence, not immutable audit storage. A regulated deployment anchors the
+    // terminal hash somewhere it cannot write, or keeps the sink on append-only storage —
+    // docs/support.md says which guarantees are the file's and which are the store's.
     public static int? FindBrokenLink(IEnumerable<string> lines)
     {
         string? expectedHash = null;

--- a/docs/enterprise-plan.md
+++ b/docs/enterprise-plan.md
@@ -331,7 +331,9 @@ audit stream contains both, each record carrying a distinct `runId` and a monoto
 
 - Two consecutive prompts ⇒ **both** runs present in `audit.jsonl`.
 - Every record has `runId`, `sequence`, `timestampUtc`, `previousHash`.
-- Deleting any line from the file is detectable by replaying the chain.
+- Deleting or altering any line before the last is detectable by replaying the chain. A
+  suffix cut off the end is not, and the chain is unkeyed: this is local, append-only,
+  hash-linked evidence, not immutable audit storage (see `docs/support.md`, "Audit sink").
 - `.Audit()` absent ⇒ zero I/O, zero cost. Unchanged for the one-liner user.
 
 ---

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -78,6 +78,12 @@ the agent without memory unless the document carries a `memory` key, or `Agent:M
 path in the classic configuration. Without one, the agent recalls nothing and never offers the
 `remember` tool. Turning it on is a deliberate choice that every caller of that host shares.
 
+**Keep the real document out of the repository.** An `agent.json` may carry an API key, so the
+repository ignores `agent.json` and `agent.*.local.json`, and commits
+`Standard.Agents.Host/agent.example.json` instead, without secrets. Copy the example to
+`agent.json` beside the executable, set the key locally or point `Agent:Config` at a file your
+secret store writes, and the ignore rule keeps a careless `git add .` from shipping it.
+
 ## Locking the door
 
 An agent endpoint carries approval and budget semantics, so the front door is worth a thought.

--- a/docs/support.md
+++ b/docs/support.md
@@ -107,6 +107,29 @@ with the core.
 
 ---
 
+## Version numbers
+
+One release carries three spellings of one version, and they map exactly:
+
+| Where | Shape | Example |
+|---|---|---|
+| `Standard.Agents.csproj` `<Version>` and the assembly version | four segments, the fourth a build number | `1.16.0.0` |
+| The git tag and the release notes file | `v` plus the first three segments | `v1.16.0`, `docs/releases/v1.16.0.md` |
+| The NuGet package | the first three segments; NuGet normalizes a trailing `.0` away | `Standard.Agents.1.16.0.nupkg` |
+
+The release workflow refuses to build a tag whose first three segments differ from the project
+file, and refuses to publish a package whose file name is not the tag's version, so the three
+cannot drift apart on the way out (F-17, F-29).
+
+## Audit sink
+
+`.Audit(path)` writes one JSON record per line, each carrying the SHA-256 of the line before it.
+Replaying the chain proves that no record before the last was altered or removed. It does not
+prove the file was not truncated at the end, and the chain is unkeyed, so anyone who can rewrite
+the file can recompute it. Treat the file as local, append-only, hash-linked evidence. A regulated
+deployment gets immutability from the store, not the file: append-only or WORM storage, a signed
+or keyed record, and the terminal hash anchored somewhere the writer cannot reach.
+
 ## Supply chain
 
 Every change on `main` and every pull request runs:

--- a/licenses/allowed-licenses.json
+++ b/licenses/allowed-licenses.json
@@ -1,0 +1,9 @@
+[
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "0BSD",
+  "MS-PL",
+  "MS-.NET-Library"
+]

--- a/licenses/license-url-mappings.json
+++ b/licenses/license-url-mappings.json
@@ -1,0 +1,5 @@
+{
+  "https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt": "Apache-2.0",
+  "https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT": "MIT",
+  "http://go.microsoft.com/fwlink/?LinkId=329770": "MS-.NET-Library"
+}

--- a/licenses/package-overrides.json
+++ b/licenses/package-overrides.json
@@ -1,0 +1,4 @@
+[
+  { "Id": "RESTFulSense", "Version": "3.2.0", "License": "MIT" },
+  { "Id": "Xeption", "Version": "2.9.0", "License": "MIT" }
+]


### PR DESCRIPTION
Closes F-13, F-17, F-18, F-22, F-25, F-26 and F-29 of docs/PRINCIPAL-ARCHITECTURE-REVIEW-2026-09-04.md, and the CONFORMANCE.md count half of F-30 landed earlier.

## F-18: CI certifies Critical

`dotnet.yml` runs `--profile Critical` after Enterprise. Critical inherits Enterprise, so this re-certifies every lower profile and proves each profile's required set is still complete, which running all vectors alone did not.

## F-17: the release is atomic to its tag

`release.yml` now:
- takes a required `tag` on manual dispatch and checks out that tag, or the published release's tag, never whatever branch was selected;
- refuses to build unless the project file's `<Version>` matches the tag in its first three segments;
- runs the complete gate: all vectors, Enterprise, Critical, and the golden evals, the same gate `dotnet.yml` enforces;
- refuses to publish unless the packed file is `Standard.Agents.<tag>.nupkg`;
- drops `--skip-duplicate`, so a version NuGet already has fails loudly instead of printing success over bytes that never shipped.

`cut-release.yml`'s comment tells the operator to dispatch with the tag. The version regex was tried locally against the project file and yields `1.16.0`.

## F-26: a license policy, not a listing

`nuget-license` resolves every package in the shipped graph, transitively, to a license expression and checks it against `licenses/allowed-licenses.json`. The twenty-eight ASP.NET 2.x packages that publish only a URL are mapped to their SPDX ids in `licenses/license-url-mappings.json`; `RESTFulSense` and `Xeption`, which ship a bare License.txt, are named MIT in `licenses/package-overrides.json`. Tried locally: exit 0 under the policy, exit 2 when a license is not allowed. The inventory is uploaded as a build artifact.

## F-22: honest dependency wording

The README no longer says dependency-free. It says provider-independent, names the three runtime packages, and notes the graph is inventoried and license-checked on every build. Replacing `RESTFulSense` to shed the ASP.NET 2.2 transitive graph is a larger change and is not in this PR.

## F-25: the agent document stays local

`agent.json` and `agent.*.local.json` are ignored; `Standard.Agents.Host/agent.example.json` is committed without secrets; hosting.md says to copy it.

## F-29: version numbers mapped

docs/support.md gains a table mapping the four-segment project version, the three-segment tag and notes file, and the NuGet-normalized package name, and says the release workflow refuses drift between them.

## F-13: the audit chain says what it proves

The broker's verification comment, the enterprise plan's exit criterion, and a new "Audit sink" section in docs/support.md state it plainly: middle integrity is proven, truncation of the suffix is not, the chain is unkeyed, and immutability comes from the store.

## Verification

- Release build: 0 warnings, 0 errors. Unit tests: 724 passed.
- The workflows cannot be exercised locally; their shell steps were run by hand where they could be.