### PR TITLE
MEDIUM CLIENTS: The Request-Rich Run Is IAgent's Contract

### DIFF
--- a/Standard.Agents.Tests.Unit/Clients/AgentContractTests.cs
+++ b/Standard.Agents.Tests.Unit/Clients/AgentContractTests.cs
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+// Found in the 2026-09-04 principal review (F-09): IAgent's primary member was a string in and
+// a string out, and its outcome-reporting members defaulted to "the run answered". An agent
+// that implemented only the string door had every held or refused run reported to a host or an
+// outer agent as an answer. The request-rich members are the contract now; the string members
+// are adapters over them, so an adapter can never fabricate a status.
+public class AgentContractTests
+{
+    private const string HeldResult = "waiting on an authority";
+
+    // An agent written against the contract alone — the two request-rich primaries — whose
+    // runs are held, exactly the case an adapter must not turn into an answer.
+    private sealed class HoldingAgent : IAgent
+    {
+        public async ValueTask<AgentOutcome> RunAsync(
+            PromptRequest request,
+            CancellationToken cancellationToken) =>
+            new AgentOutcome(Result: HeldResult, Status: AgentStatus.AwaitingApproval);
+
+        public async IAsyncEnumerable<AgentStreamEvent> StreamPromptAsync(
+            PromptRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            yield return new AgentStreamEvent(AgentStreamEventType.Status, HeldResult);
+        }
+    }
+
+    [Fact]
+    public async Task ShouldReportAHeldRunTruthfullyThroughTheStringRunAdaptersAsync()
+    {
+        // given
+        IAgent agent = new HoldingAgent();
+
+        var expectedOutcome =
+            new AgentOutcome(Result: HeldResult, Status: AgentStatus.AwaitingApproval);
+
+        // when
+        AgentOutcome actualOutcome = await agent.RunAsync("wire the money");
+
+        AgentOutcome actualStoppableOutcome =
+            await agent.RunAsync("wire the money", CancellationToken.None);
+
+        string actualAnswer = await agent.ProcessPromptAsync("wire the money");
+
+        // then: the adapters carried what the run reported, not what they assumed
+        actualOutcome.Should().BeEquivalentTo(expectedOutcome);
+        actualStoppableOutcome.Should().BeEquivalentTo(expectedOutcome);
+        actualAnswer.Should().Be(HeldResult);
+    }
+
+    [Fact]
+    public async Task ShouldStreamAHeldRunThroughTheStringStreamAdapterAsync()
+    {
+        // given
+        IAgent agent = new HoldingAgent();
+        var streamedEvents = new List<AgentStreamEvent>();
+
+        // when
+        await foreach (AgentStreamEvent streamEvent in agent.StreamPromptAsync("wire the money"))
+        {
+            streamedEvents.Add(streamEvent);
+        }
+
+        // then
+        streamedEvents.Should().ContainSingle(streamEvent =>
+            streamEvent.Type == AgentStreamEventType.Status
+                && streamEvent.Content == HeldResult);
+    }
+}

--- a/Standard.Agents/IAgent.cs
+++ b/Standard.Agents/IAgent.cs
@@ -38,17 +38,15 @@ public interface IAgent
 
     /// <summary>The one-line door: a prompt in, the answer's text out.</summary>
     async ValueTask<string> ProcessPromptAsync(string prompt) =>
-        (await RunAsync(new PromptRequest { Prompt = prompt }, CancellationToken.None)).Result;
+        (await RunAsync(prompt)).Result;
 
     /// <summary>
     /// The same run, reported with <b>how it ended</b> as well as what it produced. A run can end
     /// answered, refused, held on an authority, or out of turns, and only the first makes the
     /// result an answer — a caller given nothing but the string cannot tell them apart.
     /// </summary>
-    async ValueTask<AgentOutcome> RunAsync(string prompt) =>
-        new AgentOutcome(
-            Result: await ProcessPromptAsync(prompt),
-            Status: AgentStatus.Responded);
+    ValueTask<AgentOutcome> RunAsync(string prompt) =>
+        RunAsync(new PromptRequest { Prompt = prompt }, CancellationToken.None);
 
     /// <summary>
     /// The same run, stoppable: cancellation stops it at the next turn boundary, so no effect
@@ -56,7 +54,7 @@ public interface IAgent
     /// the outer run's token here, so cancelling an outer run stops the whole tree.
     /// </summary>
     ValueTask<AgentOutcome> RunAsync(string prompt, CancellationToken cancellationToken) =>
-        RunAsync(prompt);
+        RunAsync(new PromptRequest { Prompt = prompt }, cancellationToken);
 
     /// <summary>The streamed run for a bare prompt, riding the request-rich stream.</summary>
     IAsyncEnumerable<AgentStreamEvent> StreamPromptAsync(

--- a/Standard.Agents/IAgent.cs
+++ b/Standard.Agents/IAgent.cs
@@ -8,23 +8,43 @@ using Standard.Agents.Models.Orchestrations.Agents;
 
 namespace Standard.Agents;
 
+/// <summary>
+/// An agent, as a host or a nested agent sees it. The request-rich members are the contract:
+/// a run carries a session, a caller-owned transcript, caller tools, resumed tool exchanges and
+/// inference controls, and ends with a structured outcome that says HOW it ended. The
+/// string members are convenience adapters over them, so an adapter can never report a held
+/// or refused run as an answer (principal review 2026-09-04, F-09).
+/// </summary>
 public interface IAgent
 {
-    ValueTask<string> ProcessPromptAsync(string prompt);
+    /// <summary>
+    /// The run, in full: everything about the request that is data, and an outcome that says
+    /// how the run ended — answered, refused, held on an authority, waiting on the caller, or
+    /// out of turns. Only <see cref="AgentStatus.Responded"/> makes the result an answer.
+    /// Cancellation stops it at the next turn boundary, so no effect is left half-recorded
+    /// (SPEC.md §4.10).
+    /// </summary>
+    ValueTask<AgentOutcome> RunAsync(
+        PromptRequest request,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The same run, streamed (SPEC.md §4.14): every event as it happens, for a request
+    /// carrying everything <see cref="RunAsync(PromptRequest, CancellationToken)"/> accepts.
+    /// </summary>
+    IAsyncEnumerable<AgentStreamEvent> StreamPromptAsync(
+        PromptRequest request,
+        CancellationToken cancellationToken);
+
+    /// <summary>The one-line door: a prompt in, the answer's text out.</summary>
+    async ValueTask<string> ProcessPromptAsync(string prompt) =>
+        (await RunAsync(new PromptRequest { Prompt = prompt }, CancellationToken.None)).Result;
 
     /// <summary>
     /// The same run, reported with <b>how it ended</b> as well as what it produced. A run can end
     /// answered, refused, held on an authority, or out of turns, and only the first makes the
     /// result an answer — a caller given nothing but the string cannot tell them apart.
     /// </summary>
-    /// <remarks>
-    /// The default assumes the run answered, which is exactly what a caller of
-    /// <see cref="ProcessPromptAsync"/> already assumes, so an existing implementation keeps
-    /// working and is no less accurate than it was. An implementation that knows better — and
-    /// every implementation that runs the loop does — should override it. Nesting reads this
-    /// (<c>AgentTool</c>), so an agent that leaves the default will have its held runs reported to
-    /// an outer agent as answers.
-    /// </remarks>
     async ValueTask<AgentOutcome> RunAsync(string prompt) =>
         new AgentOutcome(
             Result: await ProcessPromptAsync(prompt),
@@ -35,16 +55,14 @@ public interface IAgent
     /// is left half-recorded (SPEC.md §4.10). Nesting reads this — <c>AgentTool</c> forwards
     /// the outer run's token here, so cancelling an outer run stops the whole tree.
     /// </summary>
-    /// <remarks>
-    /// The default ignores the token, which is no less accurate than an implementation that
-    /// cannot stop mid-run was before. An implementation that runs the loop should override it.
-    /// </remarks>
     ValueTask<AgentOutcome> RunAsync(string prompt, CancellationToken cancellationToken) =>
         RunAsync(prompt);
 
+    /// <summary>The streamed run for a bare prompt, riding the request-rich stream.</summary>
     IAsyncEnumerable<AgentStreamEvent> StreamPromptAsync(
         string prompt,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default) =>
+        StreamPromptAsync(new PromptRequest { Prompt = prompt }, cancellationToken);
 
     /// <summary>
     /// The streamed run (SPEC.md §4.14): every event live, and — once the enumeration
@@ -53,11 +71,10 @@ public interface IAgent
     /// run's story.
     /// </summary>
     /// <remarks>
-    /// The default adapts <see cref="StreamPromptAsync"/> and assumes the run answered —
-    /// exactly the assumption <see cref="RunAsync(string)"/>'s default documents, and no less
-    /// accurate than it was. It cannot know a pending effect or a refusal from the events
-    /// alone, so an implementation that runs the loop — and every implementation that runs the
-    /// loop knows how its run ended — should override it.
+    /// The default adapts <see cref="StreamPromptAsync(string, CancellationToken)"/> and
+    /// assumes the run answered, because it cannot know a pending effect or a refusal from the
+    /// events alone. An implementation that runs the loop — and every implementation that runs
+    /// the loop knows how its run ended — overrides it; <c>StandardAgent</c> does.
     /// </remarks>
     AgentRunStream RunStreamAsync(
         string prompt,

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -59,3 +59,5 @@ Standard.Agents.Services.Managements.RunManagementService.RunManagementService(S
 Standard.Agents.Models.Coordinations.Agents.PrincipalResolver
 Standard.Agents.Models.Coordinations.Agents.PrincipalResolver.PrincipalResolver(System.Func<Standard.Agents.Models.Orchestrations.Effects.AgentPrincipal?>! resolve) -> void
 Standard.Agents.Models.Coordinations.Agents.PrincipalResolver.Resolve() -> Standard.Agents.Models.Orchestrations.Effects.AgentPrincipal?
+Standard.Agents.IAgent.RunAsync(Standard.Agents.Models.Clients.Agents.PromptRequest! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<Standard.Agents.Models.Clients.Agents.AgentOutcome!>
+Standard.Agents.IAgent.StreamPromptAsync(Standard.Agents.Models.Clients.Agents.PromptRequest! request, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<Standard.Agents.Models.Clients.Agents.AgentStreamEvent!>!


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-09. `IAgent`'s only abstract member was `ProcessPromptAsync(string)`: a string in, a string out. Every outcome-reporting member (`RunAsync`, `RunStreamAsync`) was a default that fabricated `AgentStatus.Responded`, so an agent written against the contract alone had every held or refused run reported to a host or an outer agent as an answer.

## Change

- `IAgent` now has two abstract members, both request-rich: `RunAsync(PromptRequest, CancellationToken)` and `StreamPromptAsync(PromptRequest, CancellationToken)`. A run carries its session, caller transcript, caller tools, resumed tool exchanges and inference controls, and ends with an outcome that says how it ended.
- The string members are adapters over those primaries. `RunAsync(string)`, `RunAsync(string, ct)` and `ProcessPromptAsync(string)` all ride the request-rich run, so no default can invent a status.
- `StandardAgent` already implemented every member; nothing changes for the built-in agent or for callers.

## Tests

- `AgentContractTests`: an agent that implements only the two primaries and holds every run is reported as held through every string adapter, and streams through the string stream adapter.
- Unit 726 passed on net8.0 and net10.0; conformance 77 passed; Core, Reliable, Enterprise and Critical certified; evals 6 passed.

## Versioning

`IAgent` gained two abstract members. The next release stays on the 1.x line (v1.17.0.0), a routine bump on the second segment.
