### PR TITLE
MEDIUM EXPOSERS: The Whole Run Over The Wire (api/V1/agents)

### DIFF
--- a/Standard.Agents.Host/Controllers/V1/AgentsV1Controller.cs
+++ b/Standard.Agents.Host/Controllers/V1/AgentsV1Controller.cs
@@ -3,29 +3,152 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Standard.Agents.Host.Models.V1;
+using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Effects;
 
 namespace Standard.Agents.Host.Controllers.V1;
 
 // The agent, exposed in full: version 1 of the host's wire contract carries everything a run
 // is — session, transcript, caller tools, resumed exchanges, inference controls — and reports
 // everything a run ends with, the pending act included. Pure duplex mapping over ONE service
-// dependency (IAgent); the prompt-only api/agents routes stay as the convenience door.
+// dependency (IAgent); the prompt-only api/agents routes stay as the convenience door
+// (principal review 2026-09-04, F-10).
 [ApiController]
 [Route("api/V1/agents")]
 public class AgentsV1Controller : ControllerBase
 {
+    // CR, LF and CRLF all end a line in server-sent events; CRLF first so it splits as one.
+    private static readonly string[] lineTerminators = ["\r\n", "\n", "\r"];
+
     private readonly IAgent agent;
 
     public AgentsV1Controller(IAgent agent) =>
         this.agent = agent;
 
     [HttpPost("runs")]
-    public ValueTask<ActionResult<AgentRunResponseV1>> PostRunAsync(AgentRunRequestV1 request) =>
-        throw new NotImplementedException();
+    public async ValueTask<ActionResult<AgentRunResponseV1>> PostRunAsync(
+        AgentRunRequestV1 request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Prompt))
+        {
+            return BadRequest("prompt is required");
+        }
 
+        // The caller closing the connection cancels the run at its next turn boundary - and,
+        // through the nesting seam, any sub-agents the run started.
+        AgentOutcome outcome =
+            await this.agent.RunAsync(ToPromptRequest(request), HttpContext.RequestAborted);
+
+        return Ok(ToResponse(outcome));
+    }
+
+    // The streamed door, as server-sent events: the kind as the event name, the content as
+    // data, one "data:" line per line of content. Filtering the stream to Response events
+    // equals what the batched door returns.
     [HttpPost("streams")]
-    public ValueTask PostStreamAsync(AgentRunRequestV1 request) =>
-        throw new NotImplementedException();
+    public async ValueTask PostStreamAsync(AgentRunRequestV1 request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Prompt))
+        {
+            Response.StatusCode = StatusCodes.Status400BadRequest;
+
+            return;
+        }
+
+        Response.ContentType = "text/event-stream";
+
+        await foreach (AgentStreamEvent streamEvent in
+            this.agent.StreamPromptAsync(ToPromptRequest(request), HttpContext.RequestAborted))
+        {
+            string frame = ToServerSentEvent(streamEvent);
+
+            await Response.WriteAsync(frame, HttpContext.RequestAborted);
+            await Response.Body.FlushAsync(HttpContext.RequestAborted);
+        }
+    }
+
+    // The wire to the contract, field for field. A list the caller leaves out of the document
+    // is empty; a field the caller sets to null is refused as 400 naming the field, by the
+    // contract the record declares — so nothing here has to guess what null meant.
+    private static PromptRequest ToPromptRequest(AgentRunRequestV1 request)
+    {
+        return new PromptRequest
+        {
+            Prompt = request.Prompt,
+            SessionId = request.SessionId,
+
+            History = [.. request.History.Select(turn =>
+                new AgentTurn(turn.Prompt, turn.Answer))],
+
+            ToolExchanges = [.. request.ToolExchanges.Select(exchange =>
+                new ToolExchange(
+                    exchange.CallId,
+                    exchange.ToolName,
+                    exchange.ArgumentsJson,
+                    exchange.Result))],
+
+            ResponseSchemaJson = request.ResponseSchemaJson,
+            Temperature = request.Temperature,
+            MaxTokens = request.MaxTokens,
+            Seed = request.Seed,
+            Stop = request.Stop,
+
+            CallerTools = [.. request.CallerTools.Select(tool =>
+                new ToolDefinition(tool.Name, tool.Description, tool.ParametersJson))],
+
+            ProviderOptionsJson = request.ProviderOptionsJson
+        };
+    }
+
+    private static AgentRunResponseV1 ToResponse(AgentOutcome outcome)
+    {
+        return new AgentRunResponseV1(
+            Result: outcome.Result,
+            Status: outcome.Status.ToString(),
+            PendingEffect: ToPendingEffect(outcome.PendingEffect));
+    }
+
+    private static PendingEffectV1? ToPendingEffect(AgentEffect? effect)
+    {
+        if (effect is null)
+        {
+            return null;
+        }
+
+        return new PendingEffectV1(
+            RunId: effect.RunId,
+            CallId: effect.CallId,
+            ToolName: effect.ToolName,
+            Arguments: effect.Arguments,
+            Scope: effect.Scope,
+            RiskLevel: effect.RiskLevel.ToString(),
+            ApprovalRequired: effect.ApprovalRequired,
+            IdempotencyKey: effect.IdempotencyKey,
+            Principal: effect.Principal);
+    }
+
+    // One frame per event, in the shape the SSE specification reads (F-11): a content line
+    // left unprefixed is read as a field, and a blank line inside the content ends the event.
+    private static string ToServerSentEvent(AgentStreamEvent streamEvent)
+    {
+        string[] contentLines = streamEvent.Content.Split(lineTerminators, StringSplitOptions.None);
+        var frame = new StringBuilder();
+
+        frame.Append("event: ").Append(streamEvent.Type).Append('\n');
+
+        foreach (string contentLine in contentLines)
+        {
+            frame.Append("data: ").Append(contentLine).Append('\n');
+        }
+
+        frame.Append('\n');
+
+        return frame.ToString();
+    }
 }

--- a/Standard.Agents.Host/Controllers/V1/AgentsV1Controller.cs
+++ b/Standard.Agents.Host/Controllers/V1/AgentsV1Controller.cs
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Standard.Agents.Host.Models.V1;
+
+namespace Standard.Agents.Host.Controllers.V1;
+
+// The agent, exposed in full: version 1 of the host's wire contract carries everything a run
+// is — session, transcript, caller tools, resumed exchanges, inference controls — and reports
+// everything a run ends with, the pending act included. Pure duplex mapping over ONE service
+// dependency (IAgent); the prompt-only api/agents routes stay as the convenience door.
+[ApiController]
+[Route("api/V1/agents")]
+public class AgentsV1Controller : ControllerBase
+{
+    private readonly IAgent agent;
+
+    public AgentsV1Controller(IAgent agent) =>
+        this.agent = agent;
+
+    [HttpPost("runs")]
+    public ValueTask<ActionResult<AgentRunResponseV1>> PostRunAsync(AgentRunRequestV1 request) =>
+        throw new NotImplementedException();
+
+    [HttpPost("streams")]
+    public ValueTask PostStreamAsync(AgentRunRequestV1 request) =>
+        throw new NotImplementedException();
+}

--- a/Standard.Agents.Host/Models/V1/AgentRunRequestV1.cs
+++ b/Standard.Agents.Host/Models/V1/AgentRunRequestV1.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Host.Models.V1;
+
+/// <summary>
+/// What to run, in full: the wire form of <c>PromptRequest</c>, version 1 of the host's
+/// contract. Everything about a run that is data travels here — the session to continue,
+/// the caller-owned transcript, the tool calls the caller already executed, the tools the
+/// caller will execute, and the caller's inference controls. A hosted agent that composed
+/// sessions, approvals and caller tools could not use any of them over HTTP when the wire
+/// carried a prompt alone (principal review 2026-09-04, F-10).
+/// </summary>
+/// <remarks>
+/// Deliberately absent, as on <c>PromptRequest</c>: executable tools, permissions, budget,
+/// redaction, approvals, principal. The wire has no field in which to ask for them.
+/// <para>Continuing a held run is this same request: post the authority's decision, or the
+/// person's reply, as the prompt on the same session. Completing a caller's tool call is this
+/// same request too: post the exchange, naming the call id the model minted, on the same
+/// session.</para>
+/// </remarks>
+public sealed record AgentRunRequestV1
+{
+    public string Prompt { get; init; } = "";
+    public string SessionId { get; init; } = "";
+    public IReadOnlyList<AgentTurnV1> History { get; init; } = [];
+    public IReadOnlyList<ToolExchangeV1> ToolExchanges { get; init; } = [];
+    public IReadOnlyList<CallerToolV1> CallerTools { get; init; } = [];
+    public string? ResponseSchemaJson { get; init; }
+    public double? Temperature { get; init; }
+    public int? MaxTokens { get; init; }
+    public int? Seed { get; init; }
+    public IReadOnlyList<string> Stop { get; init; } = [];
+    public string? ProviderOptionsJson { get; init; }
+}

--- a/Standard.Agents.Host/Models/V1/AgentRunResponseV1.cs
+++ b/Standard.Agents.Host/Models/V1/AgentRunResponseV1.cs
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Host.Models.V1;
+
+/// <summary>
+/// How the run ended, in protocol form: the wire form of <c>AgentOutcome</c>, version 1.
+/// Status travels beside the result because only <c>Responded</c> makes the result an answer,
+/// and the pending effect travels beside them because a stateless caller that cannot see the
+/// act the run is waiting on cannot perform it, approve it, or answer it.
+/// </summary>
+public sealed record AgentRunResponseV1(
+    string Result,
+    string Status,
+    PendingEffectV1? PendingEffect);

--- a/Standard.Agents.Host/Models/V1/AgentTurnV1.cs
+++ b/Standard.Agents.Host/Models/V1/AgentTurnV1.cs
@@ -1,0 +1,9 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Host.Models.V1;
+
+/// <summary>One past exchange in the caller-owned transcript: what was asked, what was answered.</summary>
+public sealed record AgentTurnV1(string Prompt, string Answer);

--- a/Standard.Agents.Host/Models/V1/CallerToolV1.cs
+++ b/Standard.Agents.Host/Models/V1/CallerToolV1.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Host.Models.V1;
+
+/// <summary>
+/// A tool the CALLER will execute, declared so the model may name it. The agent never runs one:
+/// a returned call naming it ends the run waiting on the caller, with the call as the pending
+/// effect. Parameters are a JSON Schema, as the model reads them.
+/// </summary>
+public sealed record CallerToolV1(string Name, string Description, string ParametersJson);

--- a/Standard.Agents.Host/Models/V1/PendingEffectV1.cs
+++ b/Standard.Agents.Host/Models/V1/PendingEffectV1.cs
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Host.Models.V1;
+
+/// <summary>
+/// The act the run is waiting on: a caller's tool call to execute and answer, or an act held
+/// for an authority's decision. The call id is the model's own, so the caller can answer it;
+/// the idempotency key identifies the act, so a decision names exactly one act.
+/// </summary>
+public sealed record PendingEffectV1(
+    string RunId,
+    string CallId,
+    string ToolName,
+    string Arguments,
+    string Scope,
+    string RiskLevel,
+    bool ApprovalRequired,
+    string IdempotencyKey,
+    string? Principal);

--- a/Standard.Agents.Host/Models/V1/ToolExchangeV1.cs
+++ b/Standard.Agents.Host/Models/V1/ToolExchangeV1.cs
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Host.Models.V1;
+
+/// <summary>
+/// A tool call the caller executed and is answering. The call id is the whole point: the model
+/// that asked for the call expects the result back naming that call, and an id the host invents
+/// is one the model cannot match.
+/// </summary>
+public sealed record ToolExchangeV1(
+    string CallId,
+    string ToolName,
+    string ArgumentsJson,
+    string Result);

--- a/Standard.Agents.Tests.Unit/Controllers/V1/AgentsV1ControllerTests.Streams.cs
+++ b/Standard.Agents.Tests.Unit/Controllers/V1/AgentsV1ControllerTests.Streams.cs
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Standard.Agents.Host.Controllers.V1;
+using Standard.Agents.Host.Models.V1;
+using Standard.Agents.Models.Clients.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Controllers.V1;
+
+public partial class AgentsV1ControllerTests
+{
+    private static async IAsyncEnumerable<AgentStreamEvent> TwoLineResponse()
+    {
+        await Task.CompletedTask;
+
+        yield return new AgentStreamEvent(AgentStreamEventType.Thinking, "considering");
+        yield return new AgentStreamEvent(AgentStreamEventType.Response, "line one\nline two");
+    }
+
+    private AgentsV1Controller CreateStreamingController(MemoryStream responseBody) =>
+        new(this.agentMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    Response = { Body = responseBody }
+                }
+            }
+        };
+
+    [Fact]
+    public async Task ShouldPostStreamAsServerSentEventsAsync()
+    {
+        // given — the full request, streamed; a response body that can be read back
+        using var responseBody = new MemoryStream();
+        AgentsV1Controller streamingController = CreateStreamingController(responseBody);
+        AgentRunRequestV1 request = CreateFullRequest();
+        PromptRequest expectedPromptRequest = CreateExpectedPromptRequest();
+        PromptRequest? actualPromptRequest = null;
+
+        this.agentMock.Setup(agent =>
+            agent.StreamPromptAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<PromptRequest, CancellationToken>((promptRequest, _) =>
+                    actualPromptRequest = promptRequest)
+                .Returns(TwoLineResponse());
+
+        // when
+        await streamingController.PostStreamAsync(request);
+
+        // then — the whole wire reached the contract; each event is one SSE frame, every content
+        // line its own data line (F-11 holds on this door too)
+        streamingController.Response.ContentType.Should().Be("text/event-stream");
+        actualPromptRequest.Should().BeEquivalentTo(expectedPromptRequest);
+
+        string streamed = System.Text.Encoding.UTF8.GetString(responseBody.ToArray());
+
+        streamed.Should().Be(
+            "event: Thinking\ndata: considering\n\n"
+                + "event: Response\ndata: line one\ndata: line two\n\n");
+    }
+
+    [Fact]
+    public async Task ShouldReturnBadRequestOnPostStreamIfPromptIsEmptyAsync()
+    {
+        // given
+        using var responseBody = new MemoryStream();
+        AgentsV1Controller streamingController = CreateStreamingController(responseBody);
+        var request = new AgentRunRequestV1 { Prompt = "", SessionId = "trip-3" };
+
+        // when
+        await streamingController.PostStreamAsync(request);
+
+        // then
+        streamingController.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        responseBody.Length.Should().Be(0);
+
+        this.agentMock.Verify(agent =>
+            agent.StreamPromptAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+
+        this.agentMock.VerifyNoOtherCalls();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Controllers/V1/AgentsV1ControllerTests.cs
+++ b/Standard.Agents.Tests.Unit/Controllers/V1/AgentsV1ControllerTests.cs
@@ -1,0 +1,206 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Standard.Agents.Host.Controllers.V1;
+using Standard.Agents.Host.Models.V1;
+using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Effects;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Controllers.V1;
+
+// Found in the 2026-09-04 principal review (F-10): the host's wire carried a prompt alone and
+// answered with a result and a status alone, so sessions, caller transcripts, caller tools,
+// approval continuation and pending effects could not cross the HTTP boundary. Version 1 of
+// the wire is the whole request and the whole outcome. An exposer is pure mapping over one
+// dependency, so these are mapping tests: the wire in, the contract out; the outcome in, the
+// wire out; invalid in, 400 out.
+public partial class AgentsV1ControllerTests
+{
+    private readonly Mock<IAgent> agentMock;
+    private readonly AgentsV1Controller agentsV1Controller;
+
+    public AgentsV1ControllerTests()
+    {
+        this.agentMock = new Mock<IAgent>();
+
+        this.agentsV1Controller = new AgentsV1Controller(this.agentMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    private static AgentRunRequestV1 CreateFullRequest() =>
+        new()
+        {
+            Prompt = "what is owed",
+            SessionId = "trip-3",
+            History = [new AgentTurnV1(Prompt: "hello", Answer: "hi")],
+
+            ToolExchanges =
+            [
+                new ToolExchangeV1(
+                    CallId: "call-1",
+                    ToolName: "lookup",
+                    ArgumentsJson: "{\"account\":\"42\"}",
+                    Result: "owed: 12")
+            ],
+
+            CallerTools =
+            [
+                new CallerToolV1(
+                    Name: "lookup",
+                    Description: "looks up an account",
+                    ParametersJson: "{\"type\":\"object\"}")
+            ],
+
+            ResponseSchemaJson = "{\"type\":\"object\"}",
+            Temperature = 0.2,
+            MaxTokens = 256,
+            Seed = 7,
+            Stop = ["END"],
+            ProviderOptionsJson = "{\"thinking\":true}"
+        };
+
+    private static PromptRequest CreateExpectedPromptRequest() =>
+        new()
+        {
+            Prompt = "what is owed",
+            SessionId = "trip-3",
+            History = [new AgentTurn(Prompt: "hello", Answer: "hi")],
+
+            ToolExchanges =
+            [
+                new ToolExchange(
+                    CallId: "call-1",
+                    ToolName: "lookup",
+                    ArgumentsJson: "{\"account\":\"42\"}",
+                    Result: "owed: 12")
+            ],
+
+            ResponseSchemaJson = "{\"type\":\"object\"}",
+            Temperature = 0.2,
+            MaxTokens = 256,
+            Seed = 7,
+            Stop = ["END"],
+
+            CallerTools =
+            [
+                new ToolDefinition(
+                    Name: "lookup",
+                    Description: "looks up an account",
+                    ParametersJson: "{\"type\":\"object\"}")
+            ],
+
+            ProviderOptionsJson = "{\"thinking\":true}"
+        };
+
+    [Fact]
+    public async Task ShouldPostRunAsync()
+    {
+        // given
+        AgentRunRequestV1 request = CreateFullRequest();
+        PromptRequest expectedPromptRequest = CreateExpectedPromptRequest();
+        PromptRequest? actualPromptRequest = null;
+
+        this.agentMock.Setup(agent =>
+            agent.RunAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<PromptRequest, CancellationToken>((promptRequest, _) =>
+                    actualPromptRequest = promptRequest)
+                .ReturnsAsync(new AgentOutcome("the answer", AgentStatus.Responded));
+
+        var expectedResponse = new AgentRunResponseV1(
+            Result: "the answer",
+            Status: "Responded",
+            PendingEffect: null);
+
+        // when
+        ActionResult<AgentRunResponseV1> actualResult =
+            await this.agentsV1Controller.PostRunAsync(request);
+
+        // then — every field of the wire reached the contract, and the outcome reached the wire
+        OkObjectResult okResult = actualResult.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.Value.Should().BeEquivalentTo(expectedResponse);
+        actualPromptRequest.Should().BeEquivalentTo(expectedPromptRequest);
+    }
+
+    [Fact]
+    public async Task ShouldPostRunAndCarryThePendingEffectAsync()
+    {
+        // given — a run held on an authority, waiting on the caller's tool call
+        var request = new AgentRunRequestV1 { Prompt = "wire the money", SessionId = "trip-3" };
+
+        var principal = new AgentPrincipal { Id = "hassan", TenantId = "peerllm" };
+
+        AgentEffect heldEffect = AgentEffect.For(
+            runId: "run-9",
+            toolName: "wire",
+            arguments: "{\"amount\":100}",
+            riskLevel: RiskLevel.Irreversible,
+            approvalRequired: true,
+            principal: principal,
+            scope: "account:42") with
+        { CallId = "call-7" };
+
+        this.agentMock.Setup(agent =>
+            agent.RunAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new AgentOutcome(
+                    Result: "waiting on an authority",
+                    Status: AgentStatus.AwaitingApproval,
+                    PendingEffect: heldEffect));
+
+        var expectedResponse = new AgentRunResponseV1(
+            Result: "waiting on an authority",
+            Status: "AwaitingApproval",
+            PendingEffect: new PendingEffectV1(
+                RunId: "run-9",
+                CallId: "call-7",
+                ToolName: "wire",
+                Arguments: "{\"amount\":100}",
+                Scope: "account:42",
+                RiskLevel: "Irreversible",
+                ApprovalRequired: true,
+                IdempotencyKey: heldEffect.IdempotencyKey,
+                Principal: "hassan"));
+
+        // when
+        ActionResult<AgentRunResponseV1> actualResult =
+            await this.agentsV1Controller.PostRunAsync(request);
+
+        // then — the act the run is waiting on crossed the wire whole, key and call id included
+        OkObjectResult okResult = actualResult.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.Value.Should().BeEquivalentTo(expectedResponse);
+    }
+
+    [Fact]
+    public async Task ShouldReturnBadRequestOnPostRunIfPromptIsEmptyAsync()
+    {
+        // given
+        var request = new AgentRunRequestV1 { Prompt = "   ", SessionId = "trip-3" };
+
+        // when
+        ActionResult<AgentRunResponseV1> actualResult =
+            await this.agentsV1Controller.PostRunAsync(request);
+
+        // then — a prompt of nothing is the caller's mistake, told as 400 before any run starts
+        actualResult.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        this.agentMock.Verify(agent =>
+            agent.RunAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+
+        this.agentMock.VerifyNoOtherCalls();
+    }
+}

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -17,9 +17,93 @@ dotnet run --project Standard.Agents.Host
 | `GET api/home` | Aliveness, nothing else — no security, no dependencies. What a load balancer checks. |
 | `POST api/agents/runs` | `{ "prompt": "..." }` → `{ "result": "...", "status": "Responded" }`. Status travels beside result because only `Responded` makes the result an answer. An empty prompt is `400` before any run starts. |
 | `POST api/agents/streams` | The same run as server-sent events — each event's kind as the SSE event name (`Status`, `Thinking`, `Narration`, `Tool`, `Response`), its content as data, one `data:` line per line of content, which any SSE client joins back with a newline. Filtering to `Response` events equals what `runs` returns. |
+| `POST api/V1/agents/runs` | The whole run: version 1 of the wire carries everything `PromptRequest` carries and answers with everything `AgentOutcome` reports, the pending effect included. The enterprise door; see below. |
+| `POST api/V1/agents/streams` | The same V1 request, as server-sent events, framed exactly as `api/agents/streams`. |
 
 Closing the connection cancels the run at its next turn boundary — and, through the nesting
 seam, any sub-agents the run started.
+
+The prompt-only `api/agents` routes are the convenience door and stay as they are: a prompt in,
+a result and a status out. They are V0 of the wire and are not the enterprise API — a caller on
+them cannot name a session, hand back a tool result, or see what a held run is waiting on.
+
+## The whole run over the wire
+
+Version 1 of the wire is `PromptRequest` and `AgentOutcome` in JSON, field for field. Every
+field but `prompt` is optional; a list left out is empty, and a field set to `null` is refused
+as `400` naming the field.
+
+```json
+POST api/V1/agents/runs
+{
+  "prompt": "and how many people live there?",
+  "sessionId": "trip-3",
+  "history": [ { "prompt": "capital of France?", "answer": "Paris." } ],
+  "toolExchanges": [
+    { "callId": "call_8f2", "toolName": "lookup", "argumentsJson": "{\"city\":\"Paris\"}", "result": "2.1M" }
+  ],
+  "callerTools": [
+    { "name": "lookup", "description": "Looks a city up", "parametersJson": "{\"type\":\"object\"}" }
+  ],
+  "responseSchemaJson": null,
+  "temperature": 0.2,
+  "maxTokens": 400,
+  "seed": 7,
+  "stop": [],
+  "providerOptionsJson": null
+}
+```
+
+```json
+{
+  "result": "About 2.1 million.",
+  "status": "Responded",
+  "pendingEffect": null
+}
+```
+
+What each field means is what it means on the contract ([how-to.md §18](how-to.md)): a session
+wins over the caller's `history`; `callerTools` are vocabulary the model may name and never
+capability the agent runs; inference fields the deployment configured win over the caller's.
+Deliberately absent, as on the contract: executable tools, permissions, budget, redaction,
+approvals, principal. The wire has no field in which to ask for them.
+
+**The pending effect.** Only `Responded` makes the result an answer. A run that ends
+`AwaitingApproval` or `AwaitingInput` carries the act it is waiting on, so a stateless caller
+can see it, perform it, approve it, or answer it:
+
+```json
+{
+  "result": "Holding the transfer until an authority answers.",
+  "status": "AwaitingApproval",
+  "pendingEffect": {
+    "runId": "run-9",
+    "callId": "",
+    "toolName": "wire",
+    "arguments": "{\"amount\":100}",
+    "scope": "account:42",
+    "riskLevel": "Irreversible",
+    "approvalRequired": true,
+    "idempotencyKey": "5b1e…",
+    "principal": null
+  }
+}
+```
+
+**Continuing a held run is the same request.** Post the authority's decision, or the person's
+reply, as the `prompt` on the same `sessionId`; the run picks up where it stopped, and an act
+it already performed is recognised by its key and replayed rather than performed twice
+(SPEC.md §4.9, §4.11). **Completing a caller's tool call is the same request too**: the run
+ended `AwaitingInput` with the call as the pending effect, the caller ran it, and the result
+comes back in `toolExchanges` naming the `callId` the model minted. There is no separate resume
+route, because resuming is not a different operation; the session already holds everything.
+
+**Identity is not established by this door.** The `X-Api-Key` gate below authenticates
+possession of one shared secret and nothing more: it does not name a principal or a tenant, and
+the wire carries none. A deployment that needs identity in policy, sessions and audit puts an
+authenticating proxy or an ASP.NET authentication scheme in front of the host and resolves the
+principal where the agent is composed (`.Principal(...)`, [how-to.md §12](how-to.md)); the wire
+is deliberately not a place a caller can claim to be someone.
 
 ## Configuration
 


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-10. The host's wire carried a prompt alone and answered with a result and a status alone. Sessions, caller-supplied history, per-request inference, caller tools, approval continuation and pending effects could not cross the HTTP boundary, so a hosted agent that composed those capabilities could not use them.

## Change

- **Version 1 of the wire**, under `Models/V1` per The Standard's versioning rule: `AgentRunRequestV1` mirrors `PromptRequest` field for field (session, history, tool exchanges, caller tools, response schema, temperature, max tokens, seed, stop, provider options); `AgentRunResponseV1` mirrors `AgentOutcome`, with `PendingEffectV1` carrying the act a held run is waiting on (run id, the model's call id, tool, arguments, scope, risk level, approval flag, idempotency key, principal).
- **`AgentsV1Controller`** at `api/V1/agents/runs` and `api/V1/agents/streams`: pure mapping over `IAgent`, the same SSE framing as the V0 door.
- **The prompt-only `api/agents` routes stay as V0**, the convenience door, untouched.
- **Continuation needs no new route.** Resuming a held run is the same request with the decision as the prompt on the same session; completing a caller's tool call is the same request with the exchange naming the model's call id. Documented in hosting.md.
- **Identity is deliberately not on the wire.** The shared-secret gate cannot establish a principal, and a field the caller fills in would let a caller claim to be someone. hosting.md says where identity belongs (an authentication scheme in front, `.Principal(...)` at composition).

## Verified

- Unit 731 passed on net8.0 and net10.0 (5 new mapping tests: full request in, full contract out; pending effect out; 400 on an empty prompt for both doors; SSE framing on the V1 stream).
- Over real HTTP against the zero-config host: prompt-only document binds with empty lists; the full document binds; explicit `null` fields are refused with a 400 naming the field; the V0 route is unchanged.

## Versioning

The host gained a versioned wire model; the library is unchanged.
