### PR TITLE
MINOR ACCEPTANCE: The Host Under Test Through Real HTTP

### DIFF
--- a/Standard.Agents.Host/Program.cs
+++ b/Standard.Agents.Host/Program.cs
@@ -156,3 +156,7 @@ app.Use(async (context, next) =>
 app.MapControllers();
 
 app.Run();
+
+// Top-level statements compile to an internal Program; the acceptance tests stand the host up
+// through WebApplicationFactory<Program>, which needs to see it (F-20).
+public partial class Program { }

--- a/Standard.Agents.Tests.Unit/Acceptance/Host/HostAcceptanceTests.Security.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/Host/HostAcceptanceTests.Security.cs
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Moq;
+using Standard.Agents.Host.Models.V1;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance.Host;
+
+public partial class HostAcceptanceTests
+{
+    // The same host, with the door locked by the one configuration line hosting.md documents.
+    private WebApplicationFactory<Program> CreateLockedHost() =>
+        this.hostFactory.WithWebHostBuilder(builder =>
+            builder.UseSetting("Host:ApiKey", "psk-test"));
+
+    [Fact]
+    public async Task ShouldRefuseAgentRoutesWithoutTheApiKeyThroughHttpAsync()
+    {
+        // given
+        using WebApplicationFactory<Program> lockedHost = CreateLockedHost();
+        using HttpClient client = lockedHost.CreateClient();
+
+        // when
+        using HttpResponseMessage runResponse = await client.PostAsJsonAsync(
+            "api/V1/agents/runs",
+            new AgentRunRequestV1 { Prompt = "what is owed" },
+            wireOptions);
+
+        using HttpResponseMessage heartbeat = await client.GetAsync("api/home");
+
+        // then — the agent route is 401 before any run starts; the heartbeat stays open
+        runResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        heartbeat.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        this.agentMock.Verify(agent =>
+            agent.RunAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+    }
+
+    [Fact]
+    public async Task ShouldAdmitAgentRoutesWithTheApiKeyThroughHttpAsync()
+    {
+        // given
+        this.agentMock.Setup(agent =>
+            agent.RunAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new AgentOutcome("the answer", AgentStatus.Responded));
+
+        using WebApplicationFactory<Program> lockedHost = CreateLockedHost();
+        using HttpClient client = lockedHost.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Api-Key", "psk-test");
+
+        // when
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            "api/V1/agents/runs",
+            new AgentRunRequestV1 { Prompt = "what is owed" },
+            wireOptions);
+
+        // then
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Acceptance/Host/HostAcceptanceTests.Streams.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/Host/HostAcceptanceTests.Streams.cs
@@ -1,0 +1,79 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Host.Models.V1;
+using Standard.Agents.Models.Clients.Agents;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance.Host;
+
+public partial class HostAcceptanceTests
+{
+    private static async IAsyncEnumerable<AgentStreamEvent> TwoLineResponse()
+    {
+        await Task.CompletedTask;
+
+        yield return new AgentStreamEvent(AgentStreamEventType.Thinking, "considering");
+        yield return new AgentStreamEvent(AgentStreamEventType.Response, "line one\nline two");
+    }
+
+    [Fact]
+    public async Task ShouldStreamServerSentEventsThroughHttpAsync()
+    {
+        // given — the V1 request on the streamed door
+        AgentRunRequestV1 request = CreateFullRequest();
+        PromptRequest expectedPromptRequest = CreateExpectedPromptRequest();
+        PromptRequest? actualPromptRequest = null;
+
+        this.agentMock.Setup(agent =>
+            agent.StreamPromptAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<PromptRequest, CancellationToken>((promptRequest, _) =>
+                    actualPromptRequest = promptRequest)
+                .Returns(TwoLineResponse());
+
+        using HttpClient client = this.hostFactory.CreateClient();
+
+        // when
+        using HttpResponseMessage response =
+            await client.PostAsJsonAsync("api/V1/agents/streams", request, wireOptions);
+
+        string streamed = await response.Content.ReadAsStringAsync();
+
+        // then — the SSE content type on the wire, one frame per event, one data line per
+        // content line (F-11), and the whole request reached the contract
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("text/event-stream");
+
+        streamed.Should().Be(
+            "event: Thinking\ndata: considering\n\n"
+                + "event: Response\ndata: line one\ndata: line two\n\n");
+
+        actualPromptRequest.Should().BeEquivalentTo(expectedPromptRequest);
+    }
+
+    [Fact]
+    public async Task ShouldRefuseAnEmptyPromptOnTheStreamedDoorThroughHttpAsync()
+    {
+        // given
+        using HttpClient client = this.hostFactory.CreateClient();
+
+        // when
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            "api/V1/agents/streams",
+            new AgentRunRequestV1 { Prompt = "" },
+            wireOptions);
+
+        // then
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        this.agentMock.Verify(agent =>
+            agent.StreamPromptAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Acceptance/Host/HostAcceptanceTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/Host/HostAcceptanceTests.cs
@@ -1,0 +1,270 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Standard.Agents.Host.Models;
+using Standard.Agents.Host.Models.V1;
+using Standard.Agents.Models.Brokers.Generators.V1;
+using Standard.Agents.Models.Brokers.Sessions;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+using Standard.Agents.Models.Orchestrations.Effects;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance.Host;
+
+// Found in the 2026-09-04 principal review (F-20): every host test called a controller by hand
+// with a DefaultHttpContext, so routing, JSON binding, the API-key middleware, content types
+// and the SSE wire could all regress while the suite stayed green. These stand the real host
+// up in memory and speak HTTP to it. The agent behind the door is a double: the host is the
+// unit here, and the loop has its own suite.
+public partial class HostAcceptanceTests : IDisposable
+{
+    private static readonly JsonSerializerOptions wireOptions =
+        new(JsonSerializerDefaults.Web);
+
+    private readonly Mock<IAgent> agentMock;
+    private readonly WebApplicationFactory<Program> hostFactory;
+
+    public HostAcceptanceTests()
+    {
+        this.agentMock = new Mock<IAgent>();
+
+        this.hostFactory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+                services.AddSingleton(this.agentMock.Object)));
+    }
+
+    public void Dispose() =>
+        this.hostFactory.Dispose();
+
+    private static AgentRunRequestV1 CreateFullRequest() =>
+        new()
+        {
+            Prompt = "wire the money",
+            SessionId = "trip-3",
+            History = [new AgentTurnV1(Prompt: "hello", Answer: "hi")],
+
+            ToolExchanges =
+            [
+                new ToolExchangeV1(
+                    CallId: "call-1",
+                    ToolName: "lookup",
+                    ArgumentsJson: "{\"account\":\"42\"}",
+                    Result: "owed: 12")
+            ],
+
+            CallerTools =
+            [
+                new CallerToolV1(
+                    Name: "lookup",
+                    Description: "looks up an account",
+                    ParametersJson: "{\"type\":\"object\"}")
+            ],
+
+            ResponseSchemaJson = "{\"type\":\"object\"}",
+            Temperature = 0.2,
+            MaxTokens = 256,
+            Seed = 7,
+            Stop = ["END"],
+            ProviderOptionsJson = "{\"thinking\":true}"
+        };
+
+    private static PromptRequest CreateExpectedPromptRequest() =>
+        new()
+        {
+            Prompt = "wire the money",
+            SessionId = "trip-3",
+            History = [new AgentTurn(Prompt: "hello", Answer: "hi")],
+
+            ToolExchanges =
+            [
+                new ToolExchange(
+                    CallId: "call-1",
+                    ToolName: "lookup",
+                    ArgumentsJson: "{\"account\":\"42\"}",
+                    Result: "owed: 12")
+            ],
+
+            ResponseSchemaJson = "{\"type\":\"object\"}",
+            Temperature = 0.2,
+            MaxTokens = 256,
+            Seed = 7,
+            Stop = ["END"],
+
+            CallerTools =
+            [
+                new ToolDefinition(
+                    Name: "lookup",
+                    Description: "looks up an account",
+                    ParametersJson: "{\"type\":\"object\"}")
+            ],
+
+            ProviderOptionsJson = "{\"thinking\":true}"
+        };
+
+    private static AgentEffect CreateHeldEffect() =>
+        AgentEffect.For(
+            runId: "run-9",
+            toolName: "wire",
+            arguments: "{\"amount\":100}",
+            riskLevel: RiskLevel.Irreversible,
+            approvalRequired: true,
+            principal: new AgentPrincipal { Id = "hassan", TenantId = "peerllm" },
+            scope: "account:42") with
+        { CallId = "call-7" };
+
+    [Fact]
+    public async Task ShouldRoundTripAHeldRunThroughHttpAsync()
+    {
+        // given — the full V1 request in, a run held on an authority out
+        AgentRunRequestV1 request = CreateFullRequest();
+        PromptRequest expectedPromptRequest = CreateExpectedPromptRequest();
+        AgentEffect heldEffect = CreateHeldEffect();
+        PromptRequest? actualPromptRequest = null;
+
+        this.agentMock.Setup(agent =>
+            agent.RunAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<PromptRequest, CancellationToken>((promptRequest, _) =>
+                    actualPromptRequest = promptRequest)
+                .ReturnsAsync(new AgentOutcome(
+                    Result: "waiting on an authority",
+                    Status: AgentStatus.AwaitingApproval,
+                    PendingEffect: heldEffect));
+
+        var expectedResponse = new AgentRunResponseV1(
+            Result: "waiting on an authority",
+            Status: "AwaitingApproval",
+            PendingEffect: new PendingEffectV1(
+                RunId: "run-9",
+                CallId: "call-7",
+                ToolName: "wire",
+                Arguments: "{\"amount\":100}",
+                Scope: "account:42",
+                RiskLevel: "Irreversible",
+                ApprovalRequired: true,
+                IdempotencyKey: heldEffect.IdempotencyKey,
+                Principal: "hassan"));
+
+        using HttpClient client = this.hostFactory.CreateClient();
+
+        // when
+        using HttpResponseMessage response =
+            await client.PostAsJsonAsync("api/V1/agents/runs", request, wireOptions);
+
+        AgentRunResponseV1? actualResponse =
+            await response.Content.ReadFromJsonAsync<AgentRunResponseV1>(wireOptions);
+
+        // then — every field survived the JSON wire in both directions, the pending act included
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+        actualResponse.Should().BeEquivalentTo(expectedResponse);
+        actualPromptRequest.Should().BeEquivalentTo(expectedPromptRequest);
+    }
+
+    [Fact]
+    public async Task ShouldBindAPromptOnlyDocumentWithEmptyListsThroughHttpAsync()
+    {
+        // given — the smallest V1 document a caller can post
+        PromptRequest? actualPromptRequest = null;
+
+        this.agentMock.Setup(agent =>
+            agent.RunAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<PromptRequest, CancellationToken>((promptRequest, _) =>
+                    actualPromptRequest = promptRequest)
+                .ReturnsAsync(new AgentOutcome("the answer", AgentStatus.Responded));
+
+        var expectedPromptRequest = new PromptRequest { Prompt = "what is owed" };
+        using HttpClient client = this.hostFactory.CreateClient();
+
+        // when
+        using HttpResponseMessage response = await client.PostAsync(
+            "api/V1/agents/runs",
+            new StringContent(
+                "{\"prompt\":\"what is owed\"}",
+                System.Text.Encoding.UTF8,
+                "application/json"));
+
+        // then — an absent list is an empty one, and an absent option is unset
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        actualPromptRequest.Should().BeEquivalentTo(expectedPromptRequest);
+    }
+
+    [Fact]
+    public async Task ShouldRefuseANullFieldNamingItThroughHttpAsync()
+    {
+        // given — a list set to null, which the contract does not allow
+        using HttpClient client = this.hostFactory.CreateClient();
+
+        // when
+        using HttpResponseMessage response = await client.PostAsync(
+            "api/V1/agents/runs",
+            new StringContent(
+                "{\"prompt\":\"what is owed\",\"history\":null}",
+                System.Text.Encoding.UTF8,
+                "application/json"));
+
+        string body = await response.Content.ReadAsStringAsync();
+
+        // then — 400, naming the field, before any run starts
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().Contain("History");
+
+        this.agentMock.Verify(agent =>
+            agent.RunAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+    }
+
+    [Fact]
+    public async Task ShouldRefuseAnEmptyPromptThroughHttpAsync()
+    {
+        // given
+        using HttpClient client = this.hostFactory.CreateClient();
+
+        // when
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            "api/V1/agents/runs",
+            new AgentRunRequestV1 { Prompt = "   " },
+            wireOptions);
+
+        // then
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        this.agentMock.Verify(agent =>
+            agent.RunAsync(It.IsAny<PromptRequest>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+    }
+
+    [Fact]
+    public async Task ShouldPostAPromptOnlyRunThroughTheConvenienceDoorAsync()
+    {
+        // given — V0 of the wire, untouched by V1; its controller rides the string door
+        this.agentMock.Setup(agent =>
+            agent.RunAsync("what is owed", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new AgentOutcome("the answer", AgentStatus.Responded));
+
+        var expectedResponse = new AgentRunResponse(Result: "the answer", Status: "Responded");
+        using HttpClient client = this.hostFactory.CreateClient();
+
+        // when
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            "api/agents/runs",
+            new AgentRunRequest(Prompt: "what is owed"),
+            wireOptions);
+
+        AgentRunResponse? actualResponse =
+            await response.Content.ReadFromJsonAsync<AgentRunResponse>(wireOptions);
+
+        // then
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        actualResponse.Should().BeEquivalentTo(expectedResponse);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
+++ b/Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj
@@ -19,6 +19,12 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
     <PackageReference Include="Xeption" Version="2.9.0" />
+    <!-- The host under test through real HTTP: routing, JSON binding, the API-key middleware
+         and the SSE wire, not a controller called by hand (principal review 2026-09-04, F-20).
+         One line per target, because the testing host must match the ASP.NET Core runtime it
+         exercises. -->
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.30" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-20. Every host test called a controller by hand with a `DefaultHttpContext`, so routing, JSON binding, the API-key middleware, content types, dependency registration and the SSE wire could all regress while the suite stayed green.

## Change

- `HostAcceptanceTests` stand the real host up in memory through `WebApplicationFactory<Program>` and speak HTTP to it, with a test double behind `IAgent` (the host is the unit; the loop has its own suite).
- `Microsoft.AspNetCore.Mvc.Testing` added to the test project, one version per target so the testing host matches the ASP.NET Core runtime it exercises (8.0.30 on net8.0, 10.0.11 on net10.0; MIT).
- `public partial class Program { }` at the end of the host's Program.cs, so the factory can see the top-level-statement entry point.

## Covered through real HTTP

- A held run round-trips through `api/V1/agents/runs`: every request field reaches `PromptRequest`, and the outcome with its pending effect (call id, key, scope, risk, principal) comes back as JSON. This is the review's required case 12.
- A prompt-only V1 document binds with empty lists and unset options; a field set to `null` is refused with a 400 naming it; an empty prompt is 400 on both doors before any run starts.
- `api/V1/agents/streams` answers `text/event-stream` with one frame per event and one data line per content line (F-11 through the wire).
- The convenience door `api/agents/runs` is unchanged.
- With `Host:ApiKey` configured, agent routes are 401 without `X-Api-Key` and 200 with it, and the heartbeat stays open.

## Verified

Unit 740 passed on net8.0 and net10.0 (9 new). One host defect surfaced and was not a defect: the V0 controller rides the string door, which a loose double intercepts rather than defaulting through, so the V0 test sets that member up.
