### PR TITLE
INFRA: The Same Gate On Windows

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -62,6 +62,43 @@ jobs:
     - name: Evaluating Quality
       run: dotnet run --project Standard.Agents.Evals --no-build --configuration Release
 
+  # The same gate on the other operating system the package is used on. What varies most
+  # across platforms is exactly what the file stores, the session lock, path handling and the
+  # SSE wire exercise, and a suite proven on Ubuntu alone proves it there alone (principal
+  # review 2026-09-04, F-28). Certifying Critical here re-certifies every profile below it.
+  windows:
+    runs-on: windows-latest
+
+    steps:
+    - name: Pulling Code
+      uses: actions/checkout@v7
+
+    - name: Installing .NET
+      uses: actions/setup-dotnet@v6
+      with:
+        global-json-file: global.json
+        dotnet-version: 8.0.x
+
+    - name: Restoring Packages
+      run: dotnet restore
+
+    - name: Building Solution
+      run: dotnet build --no-restore --configuration Release
+
+    - name: Running Tests
+      run: dotnet test --no-build --configuration Release --verbosity normal
+
+    - name: Certifying Conformance
+      run: dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
+
+    - name: Certifying Critical Profile
+      run: >
+        dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
+        -- --profile Critical
+
+    - name: Evaluating Quality
+      run: dotnet run --project Standard.Agents.Evals --no-build --configuration Release
+
   supply-chain:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-28. CI ran on Ubuntu alone, and what varies most across platforms is exactly what the file stores, the session lock, path handling and the SSE wire exercise.

## Change

A second job on windows-latest runs the same gate: restore, build (warnings as errors), the unit suite on net8.0 and net10.0, the conformance vectors, the Critical profile (which re-certifies every profile below it), and the evals.

The load, fault-injection and mutation parts of F-28 are not in this PR; they are called out in the closing report as deferred.