### PR TITLE
MINOR WIRE: The Real Brokers Against A Scripted Protocol Server

### DIFF
--- a/Standard.Agents.Tests.Unit/Wire/AnthropicWireContractTests.cs
+++ b/Standard.Agents.Tests.Unit/Wire/AnthropicWireContractTests.cs
@@ -1,0 +1,138 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Standard.Agents.Brokers.Generators;
+using Standard.Agents.Models.Brokers.Generators.V1;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Wire;
+
+// The Anthropic Messages wire, read from the bytes the real broker sends (F-21): the route, the
+// version pin, the top-level system, tool_use and tool_result blocks, and the usage names.
+public class AnthropicWireContractTests
+{
+    private static readonly IReadOnlyList<ConversationMessage> conversation =
+    [
+        new() { Role = MessageRole.System, Content = "be brief" },
+        new() { Role = MessageRole.User, Content = "what is owed on 42?" },
+
+        new()
+        {
+            Role = MessageRole.Assistant,
+            ToolCalls = [new ModelToolCall("toolu_1", "lookup", "{\"account\":\"42\"}")]
+        },
+
+        new() { Role = MessageRole.Tool, Content = "owed: 12", ToolCallId = "toolu_1" }
+    ];
+
+    private static readonly IReadOnlyList<ToolDefinition> tools =
+    [
+        new ToolDefinition(
+            Name: "lookup",
+            Description: "looks up an account",
+            ParametersJson: "{\"type\":\"object\",\"properties\":{\"account\":{\"type\":\"string\"}}}")
+    ];
+
+    private static AnthropicGeneratorBrokerV1 CreateBroker(ScriptedServerHandler server) =>
+        new(
+            server,
+            apiKey: "key-1",
+            model: "claude-x",
+            temperature: 0.2,
+            maxTokens: 64,
+            timeoutSeconds: 30,
+            apiUrl: "http://anthropic.test/");
+
+    [Fact]
+    public async Task ShouldPostMessagesInTheAnthropicShapeAsync()
+    {
+        // given — a server answering with a text block, a tool_use block and usage
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            "{\"content\":[{\"type\":\"text\",\"text\":\"checking \"},"
+                + "{\"type\":\"tool_use\",\"id\":\"toolu_2\",\"name\":\"lookup\",\"input\":{\"account\":\"7\"}}],"
+                + "\"usage\":{\"input_tokens\":21,\"output_tokens\":8}}");
+
+        AnthropicGeneratorBrokerV1 broker = CreateBroker(server);
+
+        var expectedResult = new GenerationResult
+        {
+            Content = "checking ",
+            ToolCalls = [new ModelToolCall("toolu_2", "lookup", "{\"account\":\"7\"}")],
+            PromptTokens = 21,
+            CompletionTokens = 8
+        };
+
+        // when
+        GenerationResult actualResult = await broker.GenerateAsync(conversation, tools);
+
+        // then — the route and the two headers the API refuses a request without
+        HttpRequestMessage request = server.Requests.Should().ContainSingle().Subject;
+        request.RequestUri.Should().Be(new Uri("http://anthropic.test/v1/messages"));
+        request.Headers.GetValues("x-api-key").Should().ContainSingle("key-1");
+        request.Headers.GetValues("anthropic-version").Should().ContainSingle("2023-06-01");
+
+        // and the body: system at the top level, never as a message role
+        JsonNode body = JsonNode.Parse(server.Bodies[0])!;
+        body["model"]!.GetValue<string>().Should().Be("claude-x");
+        body["max_tokens"]!.GetValue<int>().Should().Be(64);
+        body["system"]!.GetValue<string>().Should().Be("be brief");
+
+        JsonArray messages = body["messages"]!.AsArray();
+        messages.Select(message => message!["role"]!.GetValue<string>()).Should().NotContain("system");
+        messages.Select(message => message!["role"]!.GetValue<string>()).Should().NotContain("tool");
+
+        // the assistant's call as a tool_use block, the answer as a tool_result block in a USER turn
+        string rendered = server.Bodies[0];
+        rendered.Should().Contain("\"type\":\"tool_use\"").And.Contain("\"id\":\"toolu_1\"");
+        rendered.Should().Contain("\"type\":\"tool_result\"").And.Contain("\"tool_use_id\":\"toolu_1\"");
+
+        JsonNode tool = body["tools"]![0]!;
+        tool["name"]!.GetValue<string>().Should().Be("lookup");
+        tool["input_schema"]!["type"]!.GetValue<string>().Should().Be("object");
+
+        // and the response, read back whole
+        actualResult.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    public async Task ShouldThrowHttpRequestExceptionOnAFailedStatusAsync(HttpStatusCode statusCode)
+    {
+        // given
+        ScriptedServerHandler server = ScriptedServerHandler.AnsweringWith(
+            statusCode,
+            "{\"type\":\"error\",\"error\":{\"type\":\"rate_limit_error\"}}");
+
+        AnthropicGeneratorBrokerV1 broker = CreateBroker(server);
+
+        // when
+        Func<Task> generateAsync = async () => await broker.GenerateAsync(conversation, tools);
+
+        // then
+        (await generateAsync.Should().ThrowAsync<HttpRequestException>())
+            .Which.StatusCode.Should().Be(statusCode);
+    }
+
+    [Fact]
+    public async Task ShouldReadAnAnswerWithNoBlocksAsEmptyAsync()
+    {
+        // given — a stop with nothing in it
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            "{\"content\":[],\"stop_reason\":\"end_turn\"}");
+
+        AnthropicGeneratorBrokerV1 broker = CreateBroker(server);
+        var expectedResult = new GenerationResult();
+
+        // when
+        GenerationResult actualResult = await broker.GenerateAsync(conversation, tools);
+
+        // then
+        actualResult.Should().BeEquivalentTo(expectedResult);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Wire/McpWireContractTests.cs
+++ b/Standard.Agents.Tests.Unit/Wire/McpWireContractTests.cs
@@ -1,0 +1,146 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Standard.Agents.Brokers.Mcps;
+using Standard.Agents.Models.Brokers.Mcps;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Wire;
+
+// The MCP JSON-RPC wire, read from the bytes the real broker sends (F-21): tools/list and
+// tools/call as the protocol shapes them, ids that increase, schemas that survive untouched,
+// arguments that arrive as an object, errors that surface, and a token asked for per request.
+public class McpWireContractTests
+{
+    private static McpBroker CreateBroker(
+        ScriptedServerHandler server,
+        string? bearerToken = null,
+        string? apiKey = null,
+        Func<ValueTask<string>>? bearerTokenProvider = null) =>
+        new(
+            server,
+            endpointUrl: "http://mcp.test/",
+            relativeUrl: "rpc",
+            timeoutSeconds: 30,
+            bearerToken,
+            apiKey,
+            apiKeyHeader: "X-Api-Key",
+            bearerTokenProvider);
+
+    [Fact]
+    public async Task ShouldPostToolsListAsJsonRpcAndKeepSchemasWholeAsync()
+    {
+        // given — a server listing one tool with a typed schema
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"lookup\","
+                + "\"description\":\"looks up an account\","
+                + "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"account\":{\"type\":\"string\"}},"
+                + "\"required\":[\"account\"]}}]}}");
+
+        McpBroker broker = CreateBroker(server, apiKey: "mcp-key");
+
+        var expectedTools = new List<McpTool>
+        {
+            new(
+                Name: "lookup",
+                Description: "looks up an account",
+                InputSchemaJson:
+                    "{\"type\":\"object\",\"properties\":{\"account\":{\"type\":\"string\"}},"
+                        + "\"required\":[\"account\"]}")
+        };
+
+        // when
+        IReadOnlyList<McpTool> actualTools = await broker.ListToolsAsync();
+
+        // then — the route, the credential header, the envelope
+        HttpRequestMessage request = server.Requests.Should().ContainSingle().Subject;
+        request.RequestUri.Should().Be(new Uri("http://mcp.test/rpc"));
+        request.Headers.GetValues("X-Api-Key").Should().ContainSingle("mcp-key");
+
+        JsonNode body = JsonNode.Parse(server.Bodies[0])!;
+        body["jsonrpc"]!.GetValue<string>().Should().Be("2.0");
+        body["method"]!.GetValue<string>().Should().Be("tools/list");
+        body["id"]!.GetValue<int>().Should().Be(1);
+
+        // and the schema, verbatim (F-03)
+        actualTools.Should().BeEquivalentTo(expectedTools);
+    }
+
+    [Fact]
+    public async Task ShouldPostToolsCallWithArgumentsAsAnObjectAndIncreasingIdsAsync()
+    {
+        // given — a call after a list on the same broker
+        var server = new ScriptedServerHandler((_, body) =>
+            body.Contains("tools/list")
+                ? ScriptedServerHandler.Json(
+                    HttpStatusCode.OK,
+                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}")
+                : ScriptedServerHandler.Json(
+                    HttpStatusCode.OK,
+                    "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"content\":"
+                        + "[{\"type\":\"text\",\"text\":\"owed: \"},{\"type\":\"text\",\"text\":\"12\"}]}}"));
+
+        McpBroker broker = CreateBroker(server, bearerToken: "static-token");
+
+        // when
+        await broker.ListToolsAsync();
+        string actualText = await broker.CallAsync("lookup", "{\"account\":\"42\",\"deep\":{\"n\":1}}");
+
+        // then — params as the protocol reads them, id advanced, text blocks joined
+        JsonNode call = JsonNode.Parse(server.Bodies[1])!;
+        call["method"]!.GetValue<string>().Should().Be("tools/call");
+        call["id"]!.GetValue<int>().Should().Be(2);
+        call["params"]!["name"]!.GetValue<string>().Should().Be("lookup");
+        call["params"]!["arguments"]!["account"]!.GetValue<string>().Should().Be("42");
+        call["params"]!["arguments"]!["deep"]!["n"]!.GetValue<int>().Should().Be(1);
+
+        server.Requests[1].Headers.Authorization?.Scheme.Should().Be("Bearer");
+        server.Requests[1].Headers.Authorization?.Parameter.Should().Be("static-token");
+        actualText.Should().Be("owed: 12");
+    }
+
+    [Fact]
+    public async Task ShouldThrowHttpRequestExceptionOnAJsonRpcErrorAsync()
+    {
+        // given — a well-formed 200 carrying a protocol error
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32601,\"message\":\"unknown tool\"}}");
+
+        McpBroker broker = CreateBroker(server);
+
+        // when
+        Func<Task> callAsync = async () => await broker.CallAsync("nope", "{}");
+
+        // then — the server's own words, as a native exception for the foundation to localize
+        (await callAsync.Should().ThrowAsync<HttpRequestException>())
+            .WithMessage("unknown tool");
+    }
+
+    [Fact]
+    public async Task ShouldAskTheTokenProviderOnEveryRequestAsync()
+    {
+        // given — an access token that changes between calls, as an OAuth token does
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}");
+
+        int issued = 0;
+
+        McpBroker broker = CreateBroker(
+            server,
+            bearerToken: "stale-static-token",
+            bearerTokenProvider: async () => $"token-{++issued}");
+
+        // when
+        await broker.ListToolsAsync();
+        await broker.ListToolsAsync();
+
+        // then — the provider wins over the static token, and every request asked again
+        server.Requests[0].Headers.Authorization?.Parameter.Should().Be("token-1");
+        server.Requests[1].Headers.Authorization?.Parameter.Should().Be("token-2");
+    }
+}

--- a/Standard.Agents.Tests.Unit/Wire/OpenAiWireContractTests.cs
+++ b/Standard.Agents.Tests.Unit/Wire/OpenAiWireContractTests.cs
@@ -1,0 +1,196 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Standard.Agents.Brokers.Generators;
+using Standard.Agents.Models.Brokers.Generators.V1;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Wire;
+
+// Found in the 2026-09-04 principal review (F-21): the native OpenAI-compatible broker was only
+// ever exercised through scripted doubles, so the route, the headers, the request shape, the
+// response variants and the failure modes of the real wire could drift unseen. These run the
+// real broker against a scripted protocol server and read the bytes.
+public class OpenAiWireContractTests
+{
+    private const string BaseUrl = "http://provider.test/v1/";
+
+    private static readonly IReadOnlyList<ConversationMessage> conversation =
+    [
+        new() { Role = MessageRole.System, Content = "be brief" },
+        new() { Role = MessageRole.User, Content = "what is owed on 42?" },
+
+        new()
+        {
+            Role = MessageRole.Assistant,
+            ToolCalls = [new ModelToolCall("call_1", "lookup", "{\"account\":\"42\"}")]
+        },
+
+        new() { Role = MessageRole.Tool, Content = "owed: 12", ToolCallId = "call_1" }
+    ];
+
+    private static readonly IReadOnlyList<ToolDefinition> tools =
+    [
+        new ToolDefinition(
+            Name: "lookup",
+            Description: "looks up an account",
+            ParametersJson: "{\"type\":\"object\",\"properties\":{\"account\":{\"type\":\"string\"}}}")
+    ];
+
+    private static GeneratorBrokerV1 CreateBroker(ScriptedServerHandler server, int timeoutSeconds = 30) =>
+        new(server, BaseUrl, "key-1", "model-1", temperature: 0.2, maxTokens: 64, timeoutSeconds);
+
+    [Fact]
+    public async Task ShouldPostAChatCompletionInTheOpenAiShapeAsync()
+    {
+        // given — a server answering with a tool call and usage
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":null,"
+                + "\"tool_calls\":[{\"id\":\"call_2\",\"type\":\"function\","
+                + "\"function\":{\"name\":\"lookup\",\"arguments\":\"{\\\"account\\\":\\\"7\\\"}\"}}]}}],"
+                + "\"usage\":{\"prompt_tokens\":21,\"completion_tokens\":8}}");
+
+        GeneratorBrokerV1 broker = CreateBroker(server);
+
+        var expectedResult = new GenerationResult
+        {
+            Content = "",
+            ToolCalls = [new ModelToolCall("call_2", "lookup", "{\"account\":\"7\"}")],
+            PromptTokens = 21,
+            CompletionTokens = 8
+        };
+
+        // when
+        GenerationResult actualResult = await broker.GenerateAsync(conversation, tools);
+
+        // then — the route, the credential, the media type
+        HttpRequestMessage request = server.Requests.Should().ContainSingle().Subject;
+        request.Method.Should().Be(HttpMethod.Post);
+        request.RequestUri.Should().Be(new Uri("http://provider.test/v1/chat/completions"));
+        request.Headers.Authorization?.Scheme.Should().Be("Bearer");
+        request.Headers.Authorization?.Parameter.Should().Be("key-1");
+        request.Content?.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        // and the request body, as the provider reads it
+        JsonNode body = JsonNode.Parse(server.Bodies[0])!;
+        body["model"]!.GetValue<string>().Should().Be("model-1");
+        body["temperature"]!.GetValue<double>().Should().Be(0.2);
+        body["max_tokens"]!.GetValue<int>().Should().Be(64);
+
+        JsonArray messages = body["messages"]!.AsArray();
+        messages.Count.Should().Be(4);
+        messages[0]!["role"]!.GetValue<string>().Should().Be("system");
+        messages[1]!["role"]!.GetValue<string>().Should().Be("user");
+        messages[2]!["role"]!.GetValue<string>().Should().Be("assistant");
+        messages[2]!["tool_calls"]![0]!["id"]!.GetValue<string>().Should().Be("call_1");
+        messages[2]!["tool_calls"]![0]!["type"]!.GetValue<string>().Should().Be("function");
+
+        messages[2]!["tool_calls"]![0]!["function"]!["arguments"]!.GetValue<string>()
+            .Should().Be("{\"account\":\"42\"}");
+
+        messages[3]!["role"]!.GetValue<string>().Should().Be("tool");
+        messages[3]!["tool_call_id"]!.GetValue<string>().Should().Be("call_1");
+
+        JsonNode tool = body["tools"]![0]!;
+        tool["type"]!.GetValue<string>().Should().Be("function");
+        tool["function"]!["name"]!.GetValue<string>().Should().Be("lookup");
+        tool["function"]!["parameters"]!["type"]!.GetValue<string>().Should().Be("object");
+
+        // and the response, read back whole
+        actualResult.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Fact]
+    public async Task ShouldNotAdvertiseAnEmptyToolListAsync()
+    {
+        // given — no tools; some providers treat "tools": [] as a different request
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"12\"}}]}");
+
+        GeneratorBrokerV1 broker = CreateBroker(server);
+
+        // when
+        GenerationResult actualResult = await broker.GenerateAsync(conversation, tools: []);
+
+        // then
+        JsonNode body = JsonNode.Parse(server.Bodies[0])!;
+        body["tools"].Should().BeNull();
+        actualResult.Content.Should().Be("12");
+    }
+
+    [Fact]
+    public async Task ShouldReadAnAnswerWithoutUsageAsZeroTokensAsync()
+    {
+        // given — a partial answer: no usage block, no tool calls, content only
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"12\"}}]}");
+
+        GeneratorBrokerV1 broker = CreateBroker(server);
+
+        var expectedResult = new GenerationResult { Content = "12" };
+
+        // when
+        GenerationResult actualResult = await broker.GenerateAsync(conversation, tools);
+
+        // then — reported, not estimated: zero says "the provider did not say"
+        actualResult.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    public async Task ShouldThrowHttpRequestExceptionOnAFailedStatusAsync(HttpStatusCode statusCode)
+    {
+        // given — the provider refusing, throttling or failing
+        ScriptedServerHandler server = ScriptedServerHandler.AnsweringWith(
+            statusCode,
+            "{\"error\":{\"message\":\"no\"}}");
+
+        GeneratorBrokerV1 broker = CreateBroker(server);
+
+        // when
+        Func<Task> generateAsync = async () => await broker.GenerateAsync(conversation, tools);
+
+        // then — a native exception, for the foundation above to localize
+        (await generateAsync.Should().ThrowAsync<HttpRequestException>())
+            .Which.StatusCode.Should().Be(statusCode);
+    }
+
+    [Fact]
+    public async Task ShouldThrowJsonExceptionOnAMalformedBodyAsync()
+    {
+        // given — a 200 that is not JSON (a proxy's HTML page, a truncated stream)
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            "<html>bad gateway</html>",
+            mediaType: "text/html");
+
+        GeneratorBrokerV1 broker = CreateBroker(server);
+
+        // when
+        Func<Task> generateAsync = async () => await broker.GenerateAsync(conversation, tools);
+
+        // then
+        await generateAsync.Should().ThrowAsync<JsonException>();
+    }
+
+    [Fact]
+    public async Task ShouldTimeOutWhenTheProviderNeverAnswersAsync()
+    {
+        // given — a server that holds the connection past the broker's timeout
+        ScriptedServerHandler server = ScriptedServerHandler.Hanging();
+        GeneratorBrokerV1 broker = CreateBroker(server, timeoutSeconds: 1);
+
+        // when
+        Func<Task> generateAsync = async () => await broker.GenerateAsync(conversation, tools);
+
+        // then — the timeout is the broker's, so a hung provider cannot hang the run
+        await generateAsync.Should().ThrowAsync<TaskCanceledException>();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Wire/ScriptedServerHandler.cs
+++ b/Standard.Agents.Tests.Unit/Wire/ScriptedServerHandler.cs
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net;
+using System.Text;
+
+namespace Standard.Agents.Tests.Unit.Wire;
+
+// A protocol server in a handler: records every request the broker sends, byte for byte, and
+// answers from a script. Deterministic, in-process, no port - the wire-contract tests run the
+// real brokers against it (principal review 2026-09-04, F-21).
+internal sealed class ScriptedServerHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, string, CancellationToken, Task<HttpResponseMessage>>
+        respondAsync;
+
+    public ScriptedServerHandler(Func<HttpRequestMessage, string, HttpResponseMessage> respond)
+        : this(async (request, body, _) => respond(request, body))
+    {
+    }
+
+    public ScriptedServerHandler(
+        Func<HttpRequestMessage, string, CancellationToken, Task<HttpResponseMessage>> respondAsync) =>
+        this.respondAsync = respondAsync;
+
+    public List<HttpRequestMessage> Requests { get; } = [];
+    public List<string> Bodies { get; } = [];
+
+    public static ScriptedServerHandler Answering(string body, string mediaType = "application/json") =>
+        new((_, _) => Json(HttpStatusCode.OK, body, mediaType));
+
+    public static ScriptedServerHandler AnsweringWith(HttpStatusCode statusCode, string body = "") =>
+        new((_, _) => Json(statusCode, body));
+
+    // Holds the connection open until the caller gives up - a provider that never answers.
+    public static ScriptedServerHandler Hanging() =>
+        new(async (_, _, cancellationToken) =>
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+
+            return Json(HttpStatusCode.OK, "{}");
+        });
+
+    public static HttpResponseMessage Json(
+        HttpStatusCode statusCode,
+        string body,
+        string mediaType = "application/json") =>
+        new(statusCode)
+        {
+            Content = new StringContent(body, Encoding.UTF8, mediaType)
+        };
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        string body = request.Content is null
+            ? string.Empty
+            : await request.Content.ReadAsStringAsync(cancellationToken);
+
+        this.Requests.Add(request);
+        this.Bodies.Add(body);
+
+        return await this.respondAsync(request, body, cancellationToken);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Wire/TextProtocolWireContractTests.cs
+++ b/Standard.Agents.Tests.Unit/Wire/TextProtocolWireContractTests.cs
@@ -1,0 +1,147 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using RESTFulSense.Exceptions;
+using Standard.Agents.Brokers.Generators;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Wire;
+
+// The text-protocol brain over the OpenAI-compatible wire, batched and streamed, read from the
+// bytes the real broker sends and parsed from the bytes a server sends back (F-21). The stream
+// is where wire contracts drift most: frame boundaries, comments, blank lines, the sentinel.
+public class TextProtocolWireContractTests
+{
+    private const string BaseUrl = "http://provider.test/v1/";
+
+    private static GeneratorBroker CreateBroker(ScriptedServerHandler server) =>
+        new(server, BaseUrl, "key-1", "model-1", temperature: 0.2, maxTokens: 64, timeoutSeconds: 30);
+
+    [Fact]
+    public async Task ShouldPostAChatCompletionAndReadTheAnswerAsync()
+    {
+        // given
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"FINAL: 12\"}}]}");
+
+        GeneratorBroker broker = CreateBroker(server);
+
+        // when
+        string actualAnswer = await broker.GenerateAsync("be brief", "what is owed?");
+
+        // then — the route, the credential, and the two-message body
+        HttpRequestMessage request = server.Requests.Should().ContainSingle().Subject;
+        request.RequestUri.Should().Be(new Uri("http://provider.test/v1/chat/completions"));
+        request.Headers.Authorization?.Parameter.Should().Be("key-1");
+
+        JsonNode body = JsonNode.Parse(server.Bodies[0])!;
+        body["model"]!.GetValue<string>().Should().Be("model-1");
+        body["stream"]?.GetValue<bool>().Should().NotBe(true);
+
+        JsonArray messages = body["messages"]!.AsArray();
+        messages[0]!["role"]!.GetValue<string>().Should().Be("system");
+        messages[0]!["content"]!.GetValue<string>().Should().Be("be brief");
+        messages[1]!["role"]!.GetValue<string>().Should().Be("user");
+        messages[1]!["content"]!.GetValue<string>().Should().Be("what is owed?");
+
+        actualAnswer.Should().Be("FINAL: 12");
+    }
+
+    [Fact]
+    public async Task ShouldStreamDataFramesUntilTheDoneSentinelAsync()
+    {
+        // given — an SSE body with a comment, a non-data field, blank lines, an empty delta,
+        // the sentinel, and a frame after the sentinel that must never be read
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            ": keep-alive\n"
+                + "event: message\n"
+                + "data: {\"choices\":[{\"delta\":{\"content\":\"FIN\"}}]}\n\n"
+                + "data: {\"choices\":[{\"delta\":{\"content\":\"AL: \"}}]}\n\n"
+                + "data: {\"choices\":[{\"delta\":{}}]}\n\n"
+                + "data: {\"choices\":[{\"delta\":{\"content\":\"12\"}}]}\n\n"
+                + "data: [DONE]\n\n"
+                + "data: {\"choices\":[{\"delta\":{\"content\":\"NOT READ\"}}]}\n\n",
+            mediaType: "text/event-stream");
+
+        GeneratorBroker broker = CreateBroker(server);
+        var streamed = new List<string>();
+
+        // when
+        await foreach (string chunk in broker.GenerateStreamAsync("be brief", "what is owed?"))
+        {
+            streamed.Add(chunk);
+        }
+
+        // then — the request asked to stream; only content deltas came out, in order, then stop
+        JsonNode body = JsonNode.Parse(server.Bodies[0])!;
+        body["stream"]!.GetValue<bool>().Should().BeTrue();
+        streamed.Should().Equal("FIN", "AL: ", "12");
+    }
+
+    [Fact]
+    public async Task ShouldEndTheStreamWhenTheConnectionEndsWithoutASentinelAsync()
+    {
+        // given — a provider that drops the connection mid-stream
+        ScriptedServerHandler server = ScriptedServerHandler.Answering(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"FINAL: 1\"}}]}\n\n"
+                + "data: {\"choices\":[{\"delta\":{\"content\":\"2\"}}]}\n\n",
+            mediaType: "text/event-stream");
+
+        GeneratorBroker broker = CreateBroker(server);
+        var streamed = new List<string>();
+
+        // when
+        await foreach (string chunk in broker.GenerateStreamAsync("be brief", "what is owed?"))
+        {
+            streamed.Add(chunk);
+        }
+
+        // then — what arrived is delivered; the enumeration completes rather than hangs
+        streamed.Should().Equal("FINAL: 1", "2");
+    }
+
+    [Fact]
+    public async Task ShouldThrowOnAThrottledStreamBeforeReadingAnyFrameAsync()
+    {
+        // given
+        ScriptedServerHandler server = ScriptedServerHandler.AnsweringWith(
+            HttpStatusCode.TooManyRequests,
+            "{\"error\":{\"message\":\"slow down\"}}");
+
+        GeneratorBroker broker = CreateBroker(server);
+
+        // when
+        Func<Task> streamAsync = async () =>
+        {
+            await foreach (string _ in broker.GenerateStreamAsync("be brief", "what is owed?"))
+            {
+            }
+        };
+
+        // then
+        (await streamAsync.Should().ThrowAsync<HttpRequestException>())
+            .Which.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+    }
+
+    [Fact]
+    public async Task ShouldThrowTheTypedRestExceptionOnAThrottledCompletionAsync()
+    {
+        // given — the batched door rides RESTFulSense, which types the status
+        ScriptedServerHandler server = ScriptedServerHandler.AnsweringWith(
+            HttpStatusCode.TooManyRequests,
+            "{\"error\":{\"message\":\"slow down\"}}");
+
+        GeneratorBroker broker = CreateBroker(server);
+
+        // when
+        Func<Task> generateAsync = async () => await broker.GenerateAsync("be brief", "what is owed?");
+
+        // then
+        await generateAsync.Should().ThrowAsync<HttpResponseTooManyRequestsException>();
+    }
+}


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-21. The conformance suite substitutes scripted brokers by design, and unit tests covered request-building logic, so nothing exercised the real HTTP brokers against the wire: routes, headers, request shapes, response variants, streaming frame boundaries, throttling, timeouts and protocol errors could drift unseen. The wrong documented URL (F-12) and the dropped MCP schemas (F-03) were the examples the suite did not catch.

## Change

A scripted protocol server in a handler (`ScriptedServerHandler`), and the real brokers run against it through the handler seam from F-23. Deterministic, in-process, no port, mandatory in CI. Twenty tests, reading the bytes:

- **OpenAI-compatible native brain**: route `chat/completions` under the base, Bearer credential, media type, the model and inference fields, lowercase roles, `tool_calls` with `type: function` and string arguments, `tool_call_id` on tool messages, tools rendered as functions with object schemas, no `tools` field when there are none; a tool call and usage read back whole; an answer without usage reads as zero tokens; 429, 500 and 401 surface as `HttpRequestException` carrying the status; a non-JSON 200 throws `JsonException`; a provider that never answers times out on the broker's own clock.
- **Anthropic Messages**: route `v1/messages`, `x-api-key` and `anthropic-version` headers, system at the top level and never as a role, `tool_use` and `tool_result` blocks with the model's ids, `input_schema` on tools; text plus tool_use plus usage read back whole; empty content reads as empty; 429 and 500 surface with the status.
- **Text-protocol brain**: the batched completion and its two-message body; the stream honours comments, non-data fields, blank lines and empty deltas, stops at `[DONE]` and never reads past it; a connection dropped without the sentinel delivers what arrived and completes; a throttled stream throws before any frame; the batched door throws RESTFulSense's typed exception.
- **MCP JSON-RPC**: `tools/list` and `tools/call` envelopes, ids that increase across calls, `inputSchema` kept verbatim, arguments sent as a JSON object (nested included), text blocks joined, a protocol error surfacing with the server's own message, and a token provider asked on every request over a stale static token.

No defect surfaced; the brokers behave as the contract says, and now the suite says so too.

## Verified

Unit 764 passed on net8.0 and net10.0 (20 new). The timeout test passed on three consecutive runs.

## Not in this PR

Live-provider tests stay optional and outside CI, as the review recommends.
