### PR TITLE
DOCUMENTATION: Evals - What They Measure And What They Cannot

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -59,7 +59,7 @@ jobs:
     # completion, groundedness, retrieval precision and recall, tool selection, refusal
     # correctness and revision effectiveness, and fail the build under threshold.
     # Deterministic - scripted brains, no keys, no network.
-    - name: Evaluating Quality
+    - name: Evaluating Orchestration Quality (Deterministic)
       run: dotnet run --project Standard.Agents.Evals --no-build --configuration Release
 
   # The same gate on the other operating system the package is used on. What varies most
@@ -96,7 +96,7 @@ jobs:
         dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
         -- --profile Critical
 
-    - name: Evaluating Quality
+    - name: Evaluating Orchestration Quality (Deterministic)
       run: dotnet run --project Standard.Agents.Evals --no-build --configuration Release
 
   supply-chain:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         dotnet run --project Standard.Agents.Conformance --no-build --configuration Release
         -- --profile Critical
 
-    - name: Evaluating Quality
+    - name: Evaluating Orchestration Quality (Deterministic)
       run: dotnet run --project Standard.Agents.Evals --no-build --configuration Release
 
     - name: Packing Package

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -1,8 +1,19 @@
 # Quality Evals
 
-Conformance pins **contracts** — does the framework behave to spec. The evals pin **quality** —
-does the agent do its job. Both certify on every build; both are deterministic, so a red run is
-a finding, never a flake.
+Conformance pins **contracts** — does the framework behave to spec. The evals pin **orchestration
+quality** — given what a Brain said, did the loop do its job: carry the facts, cite only what it
+was shown, retrieve what was relevant, run the tools the task needed, refuse what should be
+refused, and revise when the Judge said so. Both certify on every build; both are deterministic,
+so a red run is a finding, never a flake.
+
+**What they do not measure.** The Brain in these runs is scripted: it returns fixed replies and
+never reads a prompt or a skill. So the evals cannot detect a worse model, a worse prompt, a
+worse skill set, or a drift in a provider's behaviour; they detect the framework treating the
+same replies differently than it did yesterday. Model and skill quality is measured against a
+live provider, with pinned datasets, repeated samples and statistical thresholds, and that is
+opt-in and outside CI by design (principal review 2026-09-04, F-19): it costs money, it is not
+deterministic, and a flake in a required gate is a gate nobody trusts. Provider wire contracts
+are covered separately and deterministically by the wire-contract tests in the unit suite.
 
 ```bash
 dotnet run --project Standard.Agents.Evals                     # the framework's golden set


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-19 (remainder). The evals run against a scripted Brain, so they certify deterministic orchestration quality, not model or skill quality, while the doc and the CI step name suggested otherwise. The empty-run failure (exit 2, --allow-empty) landed in #359.

## Change

- evals.md says precisely what the evals measure and what they cannot, and where model and skill quality is measured (live, opt-in, outside CI by design) and where provider wire contracts are (the deterministic wire-contract tests, #372).
- The CI and release steps are named "Evaluating Orchestration Quality (Deterministic)".

No code change.