### PR TITLE
MINOR CLIENTS: The Document Refuses By Name At Any Depth (Semantic Validation)

### DIFF
--- a/Standard.Agents.Host/Program.cs
+++ b/Standard.Agents.Host/Program.cs
@@ -13,8 +13,33 @@ using OpenTelemetry.Trace;
 using Standard.Agents;
 using Standard.Agents.Brokers.Telemetries;
 using Standard.Agents.Host.Security;
+using Standard.Agents.Models.Clients.Agents.Exceptions;
 
 const string AgentHttpClientName = "standard-agent";
+
+// A validate-only run: `--validate [path]` composes the document and says whether it composes,
+// naming the entry when it does not, without standing the host up - the check a deployment
+// pipeline runs before a green heartbeat could mislead it (principal review 2026-09-04, F-24).
+if (args.Contains("--validate"))
+{
+    string documentPath =
+        args.SkipWhile(argument => argument != "--validate").Skip(1).FirstOrDefault()
+            ?? Path.Combine(AppContext.BaseDirectory, "agent.json");
+
+    try
+    {
+        StandardAgent.FromJson(File.ReadAllText(documentPath));
+        Console.WriteLine($"{documentPath} composes.");
+
+        return 0;
+    }
+    catch (Exception exception) when (exception is InvalidAgentConfigurationException or IOException)
+    {
+        Console.Error.WriteLine($"{documentPath} does not compose: {exception.Message}");
+
+        return 1;
+    }
+}
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -167,6 +192,8 @@ app.Use(async (context, next) =>
 app.MapControllers();
 
 app.Run();
+
+return 0;
 
 // Top-level statements compile to an internal Program; the acceptance tests stand the host up
 // through WebApplicationFactory<Program>, which needs to see it (F-20).

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.Semantics.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.Semantics.cs
@@ -1,0 +1,139 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Standard.Agents.Models.Clients.Agents.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+// Found in the 2026-09-04 principal review (F-24): a top-level typo was refused, but a document
+// could still look valid and be ineffective. A nested typo was ignored, a wrong-typed value
+// surfaced as a raw runtime exception or fell back to a default, a zero limit composed as if it
+// were set, a section given the wrong shape collapsed into defaults, and a control that listed
+// nothing read as on. Every one of those is now refused, by name, before an agent composes.
+public partial class StandardAgentFromJsonTests
+{
+    private static void ShouldRefuse(string json, string expectedMessage)
+    {
+        // given
+        var expectedInvalidAgentConfigurationException =
+            new InvalidAgentConfigurationException(message: expectedMessage);
+
+        // when
+        Action composeAction = () => StandardAgent.FromJson(json);
+
+        InvalidAgentConfigurationException actualInvalidAgentConfigurationException =
+            Assert.Throws<InvalidAgentConfigurationException>(composeAction);
+
+        // then
+        actualInvalidAgentConfigurationException.Should()
+            .BeEquivalentTo(expectedInvalidAgentConfigurationException);
+    }
+
+    [Theory]
+    [InlineData(
+        """{ "brain": { "apiUrl": "http://b.test/v1/", "model": "m", "temprature": 0.1 } }""",
+        "'brain' does not accept 'temprature'. It accepts: apiUrl, apiKey, model, temperature, "
+            + "maxTokens, timeoutSeconds.")]
+    [InlineData(
+        """{ "knowledge": { "path": "Knowledge", "maxResult": 5 } }""",
+        "'knowledge' does not accept 'maxResult'. It accepts: path, pattern, maxResults, minScore.")]
+    [InlineData(
+        """{ "sessions": { "path": "Sessions", "maxHistory": 5 } }""",
+        "'sessions' does not accept 'maxHistory'. It accepts: path, maxHistoryTurns.")]
+    [InlineData(
+        """{ "budget": { "maxTokens": 100, "maxCost": 1 } }""",
+        "'budget' does not accept 'maxCost'. It accepts: maxTokens, maxCostUsd, "
+            + "maxWallClockSeconds, costPerThousandTokens.")]
+    [InlineData(
+        """{ "mcp": { "endpointUrl": "http://mcp.test/", "token": "t" } }""",
+        "'mcp' does not accept 'token'. It accepts: endpointUrl, relativeUrl, timeoutSeconds, "
+            + "bearerToken, apiKey, apiKeyHeader.")]
+    [InlineData(
+        """{ "redact": { "rules": [ { "label": "SSN", "regex": "\\d+" } ] } }""",
+        "'redact.rules' does not accept 'regex'. It accepts: label, pattern.")]
+    public void ShouldThrowInvalidAgentConfigurationExceptionOnFromJsonIfANestedKeyIsUnknown(
+        string json,
+        string expectedMessage) =>
+        ShouldRefuse(json, expectedMessage);
+
+    [Theory]
+    [InlineData(
+        """{ "brain": { "apiUrl": "http://b.test/v1/", "model": "m", "maxTokens": "lots" } }""",
+        "'brain.maxTokens' must be a number.")]
+    [InlineData(
+        """{ "knowledge": { "path": "Knowledge", "minScore": "high" } }""",
+        "'knowledge.minScore' must be a number.")]
+    [InlineData(
+        """{ "budget": { "maxCostUsd": "cheap" } }""",
+        "'budget.maxCostUsd' must be a number.")]
+    [InlineData(
+        """{ "usage": { "charactersPerToken": true } }""",
+        "'usage.charactersPerToken' must be a number.")]
+    public void ShouldThrowInvalidAgentConfigurationExceptionOnFromJsonIfANumberIsNotANumber(
+        string json,
+        string expectedMessage) =>
+        ShouldRefuse(json, expectedMessage);
+
+    [Theory]
+    [InlineData("""{ "maxTurns": 0 }""", "'maxTurns' must be a positive number.")]
+    [InlineData("""{ "resilience": -1 }""", "'resilience' must be zero or a positive number.")]
+    [InlineData(
+        """{ "brain": { "apiUrl": "http://b.test/v1/", "model": "m", "timeoutSeconds": 0 } }""",
+        "'brain.timeoutSeconds' must be a positive number.")]
+    [InlineData(
+        """{ "brain": { "apiUrl": "http://b.test/v1/", "model": "m", "maxTokens": -5 } }""",
+        "'brain.maxTokens' must be a positive number.")]
+    [InlineData(
+        """{ "knowledge": { "path": "Knowledge", "maxResults": 0 } }""",
+        "'knowledge.maxResults' must be a positive number.")]
+    [InlineData(
+        """{ "sessions": { "path": "Sessions", "maxHistoryTurns": 0 } }""",
+        "'sessions.maxHistoryTurns' must be a positive number.")]
+    [InlineData(
+        """{ "usage": { "charactersPerToken": 0 } }""",
+        "'usage.charactersPerToken' must be a positive number.")]
+    [InlineData(
+        """{ "budget": { "maxTokens": 0 } }""",
+        "'budget.maxTokens' must be a positive number.")]
+    [InlineData(
+        """{ "budget": { "maxWallClockSeconds": -1 } }""",
+        "'budget.maxWallClockSeconds' must be a positive number.")]
+    [InlineData(
+        """{ "mcp": { "endpointUrl": "http://mcp.test/", "timeoutSeconds": 0 } }""",
+        "'mcp.timeoutSeconds' must be a positive number.")]
+    public void ShouldThrowInvalidAgentConfigurationExceptionOnFromJsonIfALimitIsNotPositive(
+        string json,
+        string expectedMessage) =>
+        ShouldRefuse(json, expectedMessage);
+
+    [Theory]
+    [InlineData("""{ "usage": "fast" }""", "'usage' must be an object.")]
+    [InlineData("""{ "budget": 5 }""", "'budget' must be an object.")]
+    [InlineData("""{ "brain": "http://b.test/v1/" }""", "'brain' must be an object.")]
+    [InlineData("""{ "risk": [ "wire" ] }""", "'risk' must be an object.")]
+    public void ShouldThrowInvalidAgentConfigurationExceptionOnFromJsonIfASectionHasTheWrongShape(
+        string json,
+        string expectedMessage) =>
+        ShouldRefuse(json, expectedMessage);
+
+    [Theory]
+    [InlineData("""{ "ruleGate": [] }""", "ruleGate")]
+    [InlineData("""{ "ruleJudge": [] }""", "ruleJudge")]
+    [InlineData("""{ "requireApproval": [] }""", "requireApproval")]
+    [InlineData("""{ "redact": { "rules": [] } }""", "redact.rules")]
+    [InlineData("""{ "risk": {} }""", "risk")]
+    [InlineData("""{ "skills": [] }""", "skills")]
+    [InlineData("""{ "mcp": [] }""", "mcp")]
+    [InlineData("""{ "agents": [] }""", "agents")]
+    public void ShouldThrowInvalidAgentConfigurationExceptionOnFromJsonIfAControlListsNothing(
+        string json,
+        string key) =>
+        ShouldRefuse(
+            json,
+            $"'{key}' lists nothing. A control that lists nothing is not a control: remove the "
+                + "key, or list what it should hold.");
+}

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.cs
@@ -12,7 +12,7 @@ namespace Standard.Agents.Tests.Unit.Clients;
 // The whole configurable surface as data (SPEC.md §4.8's three verbs, reached a fourth way):
 // one JSON key per capability, the same names as the builder verbs, composing the same agent
 // the fluent code composes. Tools and delegates stay code; JSON reaches everything that is data.
-public class StandardAgentFromJsonTests
+public partial class StandardAgentFromJsonTests
 {
     [Fact]
     public async Task ShouldComposeAnAgentFromJsonAsync()

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -102,37 +102,43 @@ public partial class StandardAgent
                 break;
 
             case "brain":
+                Shaped(value, key, "apiUrl", "apiKey", "model", "temperature", "maxTokens", "timeoutSeconds");
+
                 agent.Brain(
                     Text(value, key, "apiUrl"),
                     Text(value, key, "apiKey", fallback: string.Empty),
                     Text(value, key, "model"),
-                    Number(value, "temperature", fallback: 0.7),
-                    Whole(value, "maxTokens", fallback: 1024),
-                    Whole(value, "timeoutSeconds", fallback: 120));
+                    Number(value, key, "temperature", fallback: 0.7),
+                    PositiveWhole(value, key, "maxTokens", fallback: 1024),
+                    PositiveWhole(value, key, "timeoutSeconds", fallback: 120));
 
                 break;
 
             case "nativeBrain":
+                Shaped(value, key, "apiUrl", "apiKey", "model", "temperature", "maxTokens");
+
                 agent.NativeBrain(
                     Text(value, key, "apiUrl"),
                     Text(value, key, "apiKey", fallback: string.Empty),
                     Text(value, key, "model"),
-                    Number(value, "temperature", fallback: 0.7),
-                    Whole(value, "maxTokens", fallback: 1024));
+                    Number(value, key, "temperature", fallback: 0.7),
+                    PositiveWhole(value, key, "maxTokens", fallback: 1024));
 
                 break;
 
             case "nativeBrainAnthropic":
+                Shaped(value, key, "apiKey", "model", "temperature", "maxTokens");
+
                 agent.NativeBrainAnthropic(
                     Text(value, key, "apiKey"),
                     Text(value, key, "model"),
-                    Number(value, "temperature", fallback: 0.7),
-                    Whole(value, "maxTokens", fallback: 1024));
+                    Number(value, key, "temperature", fallback: 0.7),
+                    PositiveWhole(value, key, "maxTokens", fallback: 1024));
 
                 break;
 
-            case "skills" when value is JsonArray sources:
-                foreach (JsonNode? source in sources)
+            case "skills" when value is JsonArray:
+                foreach (JsonNode? source in Listed(value, key))
                 {
                     agent.Skills(Text(source, key));
                 }
@@ -145,11 +151,13 @@ public partial class StandardAgent
                 break;
 
             case "knowledge" when value is JsonObject:
+                Shaped(value, key, "path", "pattern", "maxResults", "minScore");
+
                 agent.Knowledge(
                     Text(value, key, "path"),
                     Text(value, key, "pattern", fallback: "*.md"),
-                    Whole(value, "maxResults", fallback: 3),
-                    Number(value, "minScore", fallback: 0.0));
+                    PositiveWhole(value, key, "maxResults", fallback: 3),
+                    Number(value, key, "minScore", fallback: 0.0));
 
                 break;
 
@@ -174,8 +182,8 @@ public partial class StandardAgent
 
                 break;
 
-            case "mcp" when value is JsonArray servers:
-                foreach (JsonNode? server in servers)
+            case "mcp" when value is JsonArray:
+                foreach (JsonNode? server in Listed(value, key))
                 {
                     ApplyMcpServer(agent, server, key);
                 }
@@ -187,8 +195,8 @@ public partial class StandardAgent
 
                 break;
 
-            case "agents" when value is JsonArray fleet:
-                foreach (JsonNode? member in fleet)
+            case "agents" when value is JsonArray:
+                foreach (JsonNode? member in Listed(value, key))
                 {
                     ApplyFleetMember(agent, member, key);
                 }
@@ -201,34 +209,38 @@ public partial class StandardAgent
                 break;
 
             case "gate":
+                Shaped(value, key, "apiUrl", "apiKey", "model", "temperature", "maxTokens", "timeoutSeconds");
+
                 agent.Gate(
                     Text(value, key, "apiUrl"),
                     Text(value, key, "apiKey", fallback: string.Empty),
                     Text(value, key, "model"),
-                    Number(value, "temperature", fallback: 0.0),
-                    Whole(value, "maxTokens", fallback: 16),
-                    Whole(value, "timeoutSeconds", fallback: 30));
+                    Number(value, key, "temperature", fallback: 0.0),
+                    PositiveWhole(value, key, "maxTokens", fallback: 16),
+                    PositiveWhole(value, key, "timeoutSeconds", fallback: 30));
 
                 break;
 
             case "ruleGate":
-                agent.RuleGate(Texts(value, key));
+                agent.RuleGate(ListedTexts(value, key));
 
                 break;
 
             case "judge":
+                Shaped(value, key, "apiUrl", "apiKey", "model", "temperature", "maxTokens", "timeoutSeconds");
+
                 agent.Judge(
                     Text(value, key, "apiUrl"),
                     Text(value, key, "apiKey", fallback: string.Empty),
                     Text(value, key, "model"),
-                    Number(value, "temperature", fallback: 0.0),
-                    Whole(value, "maxTokens", fallback: 16),
-                    Whole(value, "timeoutSeconds", fallback: 30));
+                    Number(value, key, "temperature", fallback: 0.0),
+                    PositiveWhole(value, key, "maxTokens", fallback: 16),
+                    PositiveWhole(value, key, "timeoutSeconds", fallback: 30));
 
                 break;
 
             case "ruleJudge":
-                agent.RuleJudge(Texts(value, key));
+                agent.RuleJudge(ListedTexts(value, key));
 
                 break;
 
@@ -250,10 +262,12 @@ public partial class StandardAgent
                 break;
 
             case "redact" when value is JsonObject rules:
-                agent.Redact([.. Items(rules["rules"], "redact.rules").Select(rule =>
+                Shaped(rules, key, "rules");
+
+                agent.Redact([.. Listed(rules["rules"], "redact.rules").Select(rule =>
                     new RedactionRule
                     {
-                        Label = Text(rule, "redact.rules", "label"),
+                        Label = Text(Shaped(rule, "redact.rules", "label", "pattern"), "redact.rules", "label"),
                         Pattern = Text(rule, "redact.rules", "pattern")
                     })]);
 
@@ -268,7 +282,7 @@ public partial class StandardAgent
                 break;
 
             case "maxTurns":
-                agent.MaxTurns(Whole(value, key));
+                agent.MaxTurns(Positive(Whole(value, key), key));
 
                 break;
 
@@ -283,7 +297,7 @@ public partial class StandardAgent
                 break;
 
             case "risk":
-                foreach ((string levelName, JsonNode? toolNames) in Entries(value, key))
+                foreach ((string levelName, JsonNode? toolNames) in ListedEntries(value, key))
                 {
                     agent.Risk(NamedText<RiskLevel>(levelName, key), Texts(toolNames, key));
                 }
@@ -291,11 +305,13 @@ public partial class StandardAgent
                 break;
 
             case "requireApproval":
-                agent.RequireApproval(Texts(value, key));
+                agent.RequireApproval(ListedTexts(value, key));
 
                 break;
 
             case "logTo" when value is JsonObject:
+                Shaped(value, key, "path", "verbosity");
+
                 agent.LogTo(
                     Text(value, key, "path"),
                     NamedText<TraceVerbosity>(
@@ -327,9 +343,11 @@ public partial class StandardAgent
                 break;
 
             case "sessions" when value is JsonObject:
+                Shaped(value, key, "path", "maxHistoryTurns");
+
                 agent.Sessions(
                     Text(value, key, "path"),
-                    Whole(value, "maxHistoryTurns", fallback: 20));
+                    PositiveWhole(value, key, "maxHistoryTurns", fallback: 20));
 
                 break;
 
@@ -357,17 +375,25 @@ public partial class StandardAgent
                 break;
 
             case "usage":
-                agent.Usage(Number(value, "charactersPerToken", fallback: 4.0));
+                Shaped(value, key, "charactersPerToken");
+
+                agent.Usage(
+                    PositiveNumber(
+                        Number(value, key, "charactersPerToken", fallback: 4.0),
+                        $"{key}.charactersPerToken"));
 
                 break;
 
             case "resilience" when value is JsonObject:
-                agent.Resilience(Whole(value, "retries", fallback: 3));
+                Shaped(value, key, "retries");
+
+                agent.Resilience(
+                    NonNegative(Whole(value, key, "retries", fallback: 3), $"{key}.retries"));
 
                 break;
 
             case "resilience":
-                agent.Resilience(Whole(value, key));
+                agent.Resilience(NonNegative(Whole(value, key), key));
 
                 break;
 
@@ -393,13 +419,21 @@ public partial class StandardAgent
     // so a cost bound with no rate fails the way a typo'd key does: loudly, and by name.
     private static void ApplyBudget(StandardAgent agent, JsonNode? budgetNode)
     {
+        const string key = "budget";
+
+        Shaped(budgetNode, key, "maxTokens", "maxCostUsd", "maxWallClockSeconds", "costPerThousandTokens");
+
         try
         {
             agent.Budget(
-                maxTokens: OptionalWhole(budgetNode, "maxTokens"),
-                maxCostUsd: OptionalMoney(budgetNode, "maxCostUsd"),
-                maxWallClock: OptionalSeconds(budgetNode, "maxWallClockSeconds"),
-                costPerThousandTokens: OptionalMoney(budgetNode, "costPerThousandTokens") ?? 0m);
+                maxTokens: Positive(OptionalWhole(budgetNode, key, "maxTokens"), $"{key}.maxTokens"),
+                maxCostUsd: Positive(OptionalMoney(budgetNode, key, "maxCostUsd"), $"{key}.maxCostUsd"),
+                maxWallClock: Positive(
+                    OptionalSeconds(budgetNode, key, "maxWallClockSeconds"),
+                    $"{key}.maxWallClockSeconds"),
+                costPerThousandTokens: NonNegative(
+                    OptionalMoney(budgetNode, key, "costPerThousandTokens") ?? 0m,
+                    $"{key}.costPerThousandTokens"));
         }
         catch (InvalidAgentBudgetException invalidAgentBudgetException)
         {
@@ -448,10 +482,20 @@ public partial class StandardAgent
     {
         if (server is JsonObject)
         {
+            Shaped(
+                server,
+                key,
+                "endpointUrl",
+                "relativeUrl",
+                "timeoutSeconds",
+                "bearerToken",
+                "apiKey",
+                "apiKeyHeader");
+
             agent.Mcp(
                 Text(server, key, "endpointUrl"),
                 Text(server, key, "relativeUrl", fallback: string.Empty),
-                Whole(server, "timeoutSeconds", fallback: 30),
+                PositiveWhole(server, key, "timeoutSeconds", fallback: 30),
                 OptionalText(server, "bearerToken"),
                 OptionalText(server, "apiKey"),
                 Text(server, key, "apiKeyHeader", fallback: "X-Api-Key"));
@@ -511,8 +555,122 @@ public partial class StandardAgent
                 $"'{key}' must be true or false.")
         };
 
-    private static double Number(JsonNode? node, string property, double fallback) =>
-        (node as JsonObject)?[property]?.GetValue<double>() ?? fallback;
+    // A section's shape, checked before its values are read (principal review 2026-09-04,
+    // F-24): it must be an object, and every key in it must be one the section accepts. A
+    // nested typo used to be ignored, which is a control the author believes is on and is not,
+    // the same failure the top-level unknown-key refusal exists to prevent.
+    private static JsonObject Shaped(JsonNode? node, string key, params string[] properties)
+    {
+        JsonObject section = node as JsonObject
+            ?? throw new InvalidAgentConfigurationException($"'{key}' must be an object.");
+
+        foreach (string property in section.Select(entry => entry.Key))
+        {
+            if (properties.Contains(property) is false)
+            {
+                throw new InvalidAgentConfigurationException(
+                    $"'{key}' does not accept '{property}'. It accepts: "
+                        + string.Join(", ", properties) + ".");
+            }
+        }
+
+        return section;
+    }
+
+    // A control that lists nothing is not a control: a gate with no rules, an approval list
+    // with no tools, a fleet with no agents all read as on and do nothing.
+    private static IEnumerable<JsonNode?> Listed(JsonNode? node, string key)
+    {
+        JsonArray items = node as JsonArray
+            ?? throw new InvalidAgentConfigurationException($"'{key}' must be an array.");
+
+        if (items.Count is 0)
+        {
+            throw new InvalidAgentConfigurationException(ListsNothing(key));
+        }
+
+        return items;
+    }
+
+    private static string[] ListedTexts(JsonNode? node, string key) =>
+        [.. Listed(node, key).Select(item => Text(item, key))];
+
+    private static IEnumerable<KeyValuePair<string, JsonNode?>> ListedEntries(JsonNode? node, string key)
+    {
+        JsonObject entries = node as JsonObject
+            ?? throw new InvalidAgentConfigurationException($"'{key}' must be an object.");
+
+        if (entries.Count is 0)
+        {
+            throw new InvalidAgentConfigurationException(ListsNothing(key));
+        }
+
+        return entries;
+    }
+
+    private static string ListsNothing(string key) =>
+        $"'{key}' lists nothing. A control that lists nothing is not a control: remove the "
+            + "key, or list what it should hold.";
+
+    // A limit of zero or less composes as if it were set and never binds - or, in MaxTurns'
+    // case, is quietly clamped. The document refuses it by name instead.
+    private static int Positive(int value, string name) =>
+        value > 0
+            ? value
+            : throw new InvalidAgentConfigurationException($"'{name}' must be a positive number.");
+
+    private static int? Positive(int? value, string name) =>
+        value is null ? null : Positive(value.Value, name);
+
+    private static decimal? Positive(decimal? value, string name) =>
+        value is null or > 0
+            ? value
+            : throw new InvalidAgentConfigurationException($"'{name}' must be a positive number.");
+
+    private static TimeSpan? Positive(TimeSpan? value, string name) =>
+        value is null || value > TimeSpan.Zero
+            ? value
+            : throw new InvalidAgentConfigurationException($"'{name}' must be a positive number.");
+
+    private static double PositiveNumber(double value, string name) =>
+        value > 0
+            ? value
+            : throw new InvalidAgentConfigurationException($"'{name}' must be a positive number.");
+
+    private static int NonNegative(int value, string name) =>
+        value >= 0
+            ? value
+            : throw new InvalidAgentConfigurationException(
+                $"'{name}' must be zero or a positive number.");
+
+    private static decimal NonNegative(decimal value, string name) =>
+        value >= 0
+            ? value
+            : throw new InvalidAgentConfigurationException(
+                $"'{name}' must be zero or a positive number.");
+
+    private static int PositiveWhole(JsonNode? node, string key, string property, int fallback) =>
+        Positive(Whole(node, key, property, fallback), $"{key}.{property}");
+
+    // Numbers are read as numbers or refused by name; a string where a number belongs used to
+    // surface as a runtime exception with no entry named, or fall through to a default.
+    private static JsonNode? NumberNode(JsonNode? node, string key, string property)
+    {
+        JsonNode? value = (node as JsonObject)?[property];
+
+        if (value is null)
+        {
+            return null;
+        }
+
+        return value.GetValueKind() is JsonValueKind.Number
+            ? value
+            : throw new InvalidAgentConfigurationException(
+                $"'{key}.{property}' must be a number.");
+    }
+
+    private static double Number(JsonNode? node, string key, string property, double fallback) =>
+        NumberNode(node, key, property)?.GetValue<double>() ?? fallback;
 
     private static int Whole(JsonNode? node, string key) =>
         node?.GetValueKind() is JsonValueKind.Number
@@ -520,17 +678,17 @@ public partial class StandardAgent
             : throw new InvalidAgentConfigurationException(
                 $"'{key}' must be a number.");
 
-    private static int Whole(JsonNode? node, string property, int fallback) =>
-        (node as JsonObject)?[property]?.GetValue<int>() ?? fallback;
+    private static int Whole(JsonNode? node, string key, string property, int fallback) =>
+        NumberNode(node, key, property)?.GetValue<int>() ?? fallback;
 
-    private static int? OptionalWhole(JsonNode? node, string property) =>
-        (node as JsonObject)?[property]?.GetValue<int>();
+    private static int? OptionalWhole(JsonNode? node, string key, string property) =>
+        NumberNode(node, key, property)?.GetValue<int>();
 
-    private static decimal? OptionalMoney(JsonNode? node, string property) =>
-        (node as JsonObject)?[property]?.GetValue<decimal>();
+    private static decimal? OptionalMoney(JsonNode? node, string key, string property) =>
+        NumberNode(node, key, property)?.GetValue<decimal>();
 
-    private static TimeSpan? OptionalSeconds(JsonNode? node, string property) =>
-        (node as JsonObject)?[property] is JsonNode value
+    private static TimeSpan? OptionalSeconds(JsonNode? node, string key, string property) =>
+        NumberNode(node, key, property) is JsonNode value
             ? TimeSpan.FromSeconds(value.GetValue<double>())
             : null;
 

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -126,6 +126,16 @@ A document that refuses to compose (an unknown key, a cost budget with no rate) 
 differently from a missing brain: the agent is composed on the first request, not at startup,
 so the host still stands and heartbeats, and every prompt is a 500 whose log line names the
 offending entry. A green heartbeat is not proof the document composed; the first prompt is.
+So a pipeline asks before it deploys:
+
+```bash
+dotnet run --project Standard.Agents.Host -- --validate path/to/agent.json
+```
+
+Exit `0` and "composes", or exit `1` and the entry that does not: an unknown key at any depth,
+a value of the wrong type, a limit that is not positive, a section of the wrong shape, or a
+control that lists nothing. Every rule the document refuses is the same rule the builder verb
+refuses; the document only names the entry (how-to.md §16).
 
 The agent is registered as a **singleton**, which is the intended shape
 ([support.md](support.md)): one instance serves prompts concurrently, and run state is per

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1262,10 +1262,17 @@ var agent = StandardAgent.FromJson(json);        // or StandardAgent.FromJsonFil
 
 The rules, and each is deliberate:
 
-- **An unknown key refuses to compose**, with the key named. A form that typos `"buget"` must
-  not get an unbounded agent that looks configured — a control you believe is on and is not is
-  worse than an error at composition. Wrong-shaped values refuse the same way, and enum-valued
-  keys name what they accept (`permissions` accepts Open, Ask, Deny).
+- **An unknown key refuses to compose**, with the key named, at any depth. A form that typos
+  `"buget"` must not get an unbounded agent that looks configured — a control you believe is on
+  and is not is worse than an error at composition — and `"brain": { "temprature": 0.1 }` is the
+  same mistake one level down, so a section names what it accepts the same way the top level
+  does. Wrong-shaped values refuse the same way (`'brain.maxTokens' must be a number`,
+  `'usage' must be an object`), enum-valued keys name what they accept (`permissions` accepts
+  Open, Ask, Deny), a limit that is not positive is refused rather than composed as if set
+  (`"maxTurns": 0` used to clamp to one turn silently), and a control that lists nothing
+  (`"ruleGate": []`) is refused, because a control that lists nothing is not a control. The
+  supplied host checks all of this without starting: `--validate path/to/agent.json`
+  ([hosting.md](hosting.md)).
 - **Tools stay code, because they are code** — except `mcp`, where a tool is a URL, which is
   data. Delegates (`On*`) and broker instances (`Use*`) stay code for the same reason.
 - **Data and code compose.** `FromJson` returns the same `StandardAgent`, so keep chaining:


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-24. A top-level typo was refused, but a document could still look valid and be ineffective: a nested typo was ignored, a wrong-typed value surfaced as a raw runtime exception or fell through to a default, a zero limit composed as if set (`maxTurns: 0` clamped silently to one turn), a section of the wrong shape collapsed into defaults (`"usage": "fast"` composed with the default ratio), and a control that listed nothing read as on (`"ruleGate": []`).

## Change

The document refuses each of those, by name, before an agent composes, with the same `InvalidAgentConfigurationException` the top-level refusal uses:

- **Unknown nested keys** in every object section (brain, nativeBrain, nativeBrainAnthropic, gate, judge, knowledge, sessions, logTo, budget, usage, resilience, mcp servers, redact and its rules): `'brain' does not accept 'temprature'. It accepts: apiUrl, apiKey, model, temperature, maxTokens, timeoutSeconds.`
- **Wrong node types**: `'brain.maxTokens' must be a number.`, `'usage' must be an object.`, `'brain' must be an object.`
- **Non-positive limits and rates**: maxTurns, maxTokens, timeoutSeconds, maxResults, maxHistoryTurns, charactersPerToken, budget maxTokens, maxCostUsd, maxWallClockSeconds; retries and costPerThousandTokens must be zero or positive (the budget's rate-with-cost pairing rule stays in the builder verb and is rewrapped as before).
- **Empty control sections**: ruleGate, ruleJudge, requireApproval, redact.rules, risk, skills, mcp, agents. `allowTools: []` stays accepted: an empty allow list is a closed perimeter, which is a meaning, not a mistake.
- **A validate-only host command**: `dotnet run --project Standard.Agents.Host -- --validate path/to/agent.json` composes the document without standing the host up, exit 0 and "composes", or exit 1 naming the entry.
- how-to §16 and hosting.md document the rules and the command.

## Not in this PR

A JSON Schema for editors. A hand-written schema would drift from the switch that is the truth; the review itself warns about documentation that drifts from executable sources. Generating one from the code is a separate piece of work, called out in the closing report.

## Tests

- 32 new cases in `StandardAgentFromJsonTests` (nested unknown key, wrong type, non-positive limit, wrong shape, control listing nothing), each asserting the exact message.
- Unit 796 passed on net8.0 and net10.0; conformance 77 passed; Critical certified; evals 6 passed; the validate command exercised on a bad, a good and a missing document.
