### PR TITLE
MINOR BROKERS: The Logging Broker Wraps One Resource; The Decision Log Decorates It

### DIFF
--- a/Standard.Agents.Tests.Unit/Architecture/TierDisciplineTests.Brokers.cs
+++ b/Standard.Agents.Tests.Unit/Architecture/TierDisciplineTests.Brokers.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Architecture;
+
+public partial class TierDisciplineTests
+{
+    private static IEnumerable<Type> Brokers() =>
+        agentAssembly.GetTypes()
+            .Where(type => type.IsClass && type.IsAbstract is false)
+            .Where(type => type.Namespace?.Contains(".Brokers.", StringComparison.Ordinal) is true)
+            .Where(type => type.Name.EndsWith("Broker", StringComparison.Ordinal));
+
+    private static IEnumerable<Type> BrokerInterfacesTakenBy(ConstructorInfo constructor) =>
+        constructor.GetParameters()
+            .SelectMany(parameter => TypesReferencedBy(
+                Nullable.GetUnderlyingType(parameter.ParameterType) ?? parameter.ParameterType))
+            .Where(type => type.IsInterface && type.Name.EndsWith("Broker", StringComparison.Ordinal))
+            .Distinct();
+
+    // Found in the 2026-09-04 principal review (F-16): the logging broker held the time broker
+    // and the audit broker, orchestrated both, and the alignment document said no deviation
+    // remained. A broker is one resource, wrapped; brokers cannot call other brokers. The one
+    // shape that may hold a broker is a DECORATOR: a broker that implements the very interface
+    // it takes, so it wraps another broker's call and adds one concern (retry, redaction, audit)
+    // without owning a resource of its own. This reads the constructors, so the dependency FLOW
+    // is what is checked, not the folder a type sits in.
+    [Fact]
+    public void ShouldHoldNoOtherBrokerUnlessDecoratingOne()
+    {
+        // given
+        var offenders = new List<string>();
+
+        // when
+        foreach (Type broker in Brokers())
+        {
+            Type[] implemented = broker.GetInterfaces();
+
+            foreach (ConstructorInfo constructor in broker.GetConstructors())
+            {
+                Type[] taken = [.. BrokerInterfacesTakenBy(constructor)];
+
+                bool decorates = taken.Any(implemented.Contains);
+
+                if (taken.Length > 0 && decorates is false)
+                {
+                    offenders.Add(
+                        $"{broker.Name} takes [{string.Join(", ", taken.Select(type => type.Name))}]");
+                }
+            }
+        }
+
+        // then
+        offenders.Should().BeEmpty(
+            because: "a broker is one resource, wrapped, and brokers cannot call other brokers; "
+                + "the only broker that may hold another is a decorator, which implements the "
+                + "interface it takes and adds one concern to the call it wraps");
+    }
+}

--- a/Standard.Agents.Tests.Unit/Architecture/TierDisciplineTests.cs
+++ b/Standard.Agents.Tests.Unit/Architecture/TierDisciplineTests.cs
@@ -19,7 +19,7 @@ namespace Standard.Agents.Tests.Unit.Architecture;
 // So: a foundation wraps ONE nature broker. Anything above the foundation tier holds no broker at
 // all. Utility brokers are the documented exception, and the list of them is short and named here
 // so that adding a sixth is a reviewed decision rather than an omission nobody sees.
-public class TierDisciplineTests
+public partial class TierDisciplineTests
 {
     // Observability, plus the clock. None backs a nature; none can change what the agent decides.
     // Telemetry earns the same exemption the same way: spans and metrics observe the loop and

--- a/Standard.Agents/Brokers/Audits/AuditingLoggingBroker.cs
+++ b/Standard.Agents/Brokers/Audits/AuditingLoggingBroker.cs
@@ -1,0 +1,123 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Times;
+using Standard.Agents.Models.Brokers.Audits;
+using Standard.Agents.Models.Loggings;
+
+namespace Standard.Agents.Brokers.Audits;
+
+// The decision log, applied by decoration: every event the loop narrates to its log is also
+// written to the audit sink as a durable record, stamped, sequenced and attributed - and the
+// logging broker underneath never learns the audit exists. A decorator implements the very
+// interface it takes, so it adds one concern to the call it wraps and owns no resource of its
+// own; that is the one shape in which a broker may hold another (principal review 2026-09-04,
+// F-16). Composed at the facade only when an audit sink is configured, over whichever logging
+// broker the deployment chose - the built-in one or a host's own.
+public sealed class AuditingLoggingBroker : ILoggingBroker
+{
+    private readonly ILoggingBroker loggingBroker;
+    private readonly IAuditBroker auditBroker;
+    private readonly ITimeBroker timeBroker;
+    private readonly Func<string?>? principal;
+
+    // The run is read from the ambient AgentRun that Coordination begins (SPEC.md §4.4); the
+    // fallback covers a broker driven outside the loop.
+    private readonly AgentRun fallbackRun = AgentRun.Detached();
+
+    private AgentRun Run => AgentRun.Current ?? this.fallbackRun;
+
+    public AuditingLoggingBroker(
+        ILoggingBroker loggingBroker,
+        IAuditBroker auditBroker,
+        ITimeBroker timeBroker,
+        Func<string?>? principal = null)
+    {
+        this.loggingBroker = loggingBroker;
+        this.auditBroker = auditBroker;
+        this.timeBroker = timeBroker;
+        this.principal = principal;
+    }
+
+    public ValueTask LogInformationAsync(string message) =>
+        this.loggingBroker.LogInformationAsync(message);
+
+    public ValueTask LogTraceAsync(string message) =>
+        this.loggingBroker.LogTraceAsync(message);
+
+    public ValueTask LogDebugAsync(string message) =>
+        this.loggingBroker.LogDebugAsync(message);
+
+    public ValueTask LogWarningAsync(string message) =>
+        this.loggingBroker.LogWarningAsync(message);
+
+    public async ValueTask LogErrorAsync(Exception exception)
+    {
+        await AuditAsync(AuditKind.Error, actor: "Agent", message: exception.Message);
+        await this.loggingBroker.LogErrorAsync(exception);
+    }
+
+    public async ValueTask LogCriticalAsync(Exception exception)
+    {
+        await AuditAsync(AuditKind.Error, actor: "Agent", message: exception.Message);
+        await this.loggingBroker.LogCriticalAsync(exception);
+    }
+
+    // The trace underneath resets; the decision log is durable and records the start instead
+    // (SPEC.md §4.7).
+    public async ValueTask LogResetAsync()
+    {
+        await AuditAsync(AuditKind.Run, actor: "Agent", message: "run started");
+        await this.loggingBroker.LogResetAsync();
+    }
+
+    public async ValueTask LogTurnAsync(int turn)
+    {
+        await AuditAsync(AuditKind.Turn, actor: "Agent", message: $"turn {turn}");
+        await this.loggingBroker.LogTurnAsync(turn);
+    }
+
+    public async ValueTask LogOutcomeAsync(string message)
+    {
+        await AuditAsync(AuditKind.Outcome, actor: "Agent", message: message);
+        await this.loggingBroker.LogOutcomeAsync(message);
+    }
+
+    public async ValueTask LogStepAsync(AgentStep step)
+    {
+        await AuditAsync(AuditKind.Step, actor: step.ToString(), message: step.ToString());
+        await this.loggingBroker.LogStepAsync(step);
+    }
+
+    public async ValueTask LogProcessAsync(string actor, string message, bool detail = false)
+    {
+        await AuditAsync(AuditKind.Process, actor, message, detail);
+        await this.loggingBroker.LogProcessAsync(actor, message, detail);
+    }
+
+    private async ValueTask AuditAsync(
+        AuditKind kind,
+        string actor,
+        string message,
+        bool detail = false)
+    {
+        AgentRun run = this.Run;
+
+        var record = new AuditRecord
+        {
+            RunId = run.Id,
+            Sequence = run.NextSequence(),
+            Timestamp = this.timeBroker.GetCurrentDateTimeOffset(),
+            Kind = kind,
+            Actor = actor,
+            Message = message,
+            Detail = detail,
+            Principal = this.principal?.Invoke()
+        };
+
+        await this.auditBroker.WriteAsync(record);
+    }
+}

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -4,24 +4,23 @@
 // ---------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
-using Standard.Agents.Brokers.Audits;
-using Standard.Agents.Brokers.Times;
-using Standard.Agents.Models.Brokers.Audits;
 using Standard.Agents.Models.Loggings;
 
 namespace Standard.Agents.Brokers.Loggings;
 
+// One resource, wrapped: the log. Both of its faces are the same sink - the ILogger the host
+// gave us, and the human-readable trace file that is that log written to disk. Nothing else
+// lives here. The decision log is another resource with another broker, and the two meet only
+// by decoration at composition (AuditingLoggingBroker), never by this broker holding that one
+// (principal review 2026-09-04, F-16).
 public sealed class LoggingBroker : ILoggingBroker
 {
     private readonly ILogger<LoggingBroker> logger;
-    private readonly ITimeBroker timeBroker;
-    private readonly IAuditBroker auditBroker;
     private readonly TraceVerbosity verbosity;
     private readonly string? logPath;
-    private readonly Func<string?>? principal;
 
     // No run state lives here. SPEC.md §4.4: run identity and counters are per invocation,
-    // never per instance — one broker serves every concurrent run, so a field here would let
+    // never per instance - one broker serves every concurrent run, so a field here would let
     // one prompt overwrite another's record. The run is read from the ambient AgentRun that
     // Coordination begins; the fallback run covers a broker driven outside the loop.
     private readonly AgentRun fallbackRun = AgentRun.Detached();
@@ -31,18 +30,12 @@ public sealed class LoggingBroker : ILoggingBroker
 
     public LoggingBroker(
         ILogger<LoggingBroker> logger,
-        ITimeBroker timeBroker,
         TraceVerbosity verbosity = TraceVerbosity.Full,
-        string? logPath = null,
-        IAuditBroker? auditBroker = null,
-        Func<string?>? principal = null)
+        string? logPath = null)
     {
         this.logger = logger;
-        this.timeBroker = timeBroker;
-        this.auditBroker = auditBroker ?? new NotConfiguredAuditBroker();
         this.verbosity = verbosity;
         this.logPath = logPath is null ? null : Path.GetFullPath(logPath);
-        this.principal = principal;
     }
 
     public async ValueTask LogInformationAsync(string message) =>
@@ -60,26 +53,21 @@ public sealed class LoggingBroker : ILoggingBroker
     public async ValueTask LogErrorAsync(Exception exception)
     {
         this.logger.LogError(exception, exception.Message);
-
-        await AuditAsync(AuditKind.Error, actor: "Agent", message: exception.Message);
         await EmitAsync($"  → ERROR: {exception.Message.ReplaceLineEndings(" ")}");
     }
 
     public async ValueTask LogCriticalAsync(Exception exception)
     {
         this.logger.LogCritical(exception, exception.Message);
-
-        await AuditAsync(AuditKind.Error, actor: "Agent", message: exception.Message);
         await EmitAsync($"  → CRITICAL: {exception.Message.ReplaceLineEndings(" ")}");
     }
 
-    // Starts a run. The human-readable trace is transient and is reset here; the decision
-    // log is durable and MUST NOT be — SPEC.md §4.7 is explicit that this reset does not
-    // propagate to it. Truncating the audit here is exactly the defect this release fixes.
+    // Starts a run. The human-readable trace is transient and is reset here; the decision log
+    // is durable and is not touched by this broker at all (SPEC.md §4.7).
     public async ValueTask LogResetAsync()
     {
         this.Run.ResetProcessIndex();
-        this.Run.StartedOn = this.timeBroker.GetCurrentDateTimeOffset();
+        this.Run.StartedOn = DateTimeOffset.UtcNow;
 
         if (this.logPath is not null)
         {
@@ -94,31 +82,20 @@ public sealed class LoggingBroker : ILoggingBroker
                 this.traceLock.Release();
             }
         }
-
-        await AuditAsync(AuditKind.Run, actor: "Agent", message: "run started");
     }
 
-    public async ValueTask LogTurnAsync(int turn)
-    {
-        await AuditAsync(AuditKind.Turn, actor: "Agent", message: $"turn {turn}");
-
+    public async ValueTask LogTurnAsync(int turn) =>
         await EmitAsync($"{Environment.NewLine}Turn {turn}");
-    }
 
     public async ValueTask LogOutcomeAsync(string message)
     {
-        TimeSpan elapsed = this.timeBroker.GetCurrentDateTimeOffset() - this.Run.StartedOn;
-
-        await AuditAsync(AuditKind.Outcome, actor: "Agent", message: message);
-
+        TimeSpan elapsed = DateTimeOffset.UtcNow - this.Run.StartedOn;
         await EmitAsync($"  → {message} ({elapsed.TotalMilliseconds:F0}ms)");
     }
 
     public async ValueTask LogStepAsync(AgentStep step)
     {
         this.Run.ResetProcessIndex();
-
-        await AuditAsync(AuditKind.Step, actor: step.ToString(), message: step.ToString());
 
         if (TraceVerbosity.Natures <= this.verbosity)
         {
@@ -128,20 +105,17 @@ public sealed class LoggingBroker : ILoggingBroker
 
     public async ValueTask LogProcessAsync(string actor, string message, bool detail = false)
     {
-        await AuditAsync(AuditKind.Process, actor, message, detail);
-
         TraceVerbosity level = detail ? TraceVerbosity.Full : TraceVerbosity.Natures;
 
         if (level <= this.verbosity)
         {
             string indented = message.ReplaceLineEndings($"{Environment.NewLine}      ");
-
             await EmitAsync($"    Process {this.Run.NextProcessIndex()}: {actor}: {indented}");
         }
     }
 
     // The trace is a shared file and one broker serves every concurrent run, so writes are
-    // serialized — without this, sixty-four prompts in flight collide on the handle and most
+    // serialized - without this, sixty-four prompts in flight collide on the handle and most
     // of them fail with an IOException rather than an answer.
     //
     // Concurrent runs interleave in the trace, and each run's reset truncates it. That is the
@@ -167,28 +141,5 @@ public sealed class LoggingBroker : ILoggingBroker
         {
             this.traceLock.Release();
         }
-    }
-
-    private async ValueTask AuditAsync(
-        AuditKind kind,
-        string actor,
-        string message,
-        bool detail = false)
-    {
-        AgentRun run = this.Run;
-
-        var record = new AuditRecord
-        {
-            RunId = run.Id,
-            Sequence = run.NextSequence(),
-            Timestamp = this.timeBroker.GetCurrentDateTimeOffset(),
-            Kind = kind,
-            Actor = actor,
-            Message = message,
-            Detail = detail,
-            Principal = this.principal?.Invoke()
-        };
-
-        await this.auditBroker.WriteAsync(record);
     }
 }

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -66,3 +66,18 @@ Standard.Agents.Brokers.Generators.AnthropicGeneratorBrokerV1.AnthropicGenerator
 Standard.Agents.Brokers.Generators.GeneratorBroker.GeneratorBroker(System.Net.Http.HttpMessageHandler! handler, string! apiUrl, string! apiKey, string! model, double temperature, int maxTokens, int timeoutSeconds) -> void
 Standard.Agents.Brokers.Generators.GeneratorBrokerV1.GeneratorBrokerV1(System.Net.Http.HttpMessageHandler! handler, string! apiUrl, string! apiKey, string! model, double temperature, int maxTokens, int timeoutSeconds) -> void
 Standard.Agents.Brokers.Mcps.McpBroker.McpBroker(System.Net.Http.HttpMessageHandler! handler, string! endpointUrl, string! relativeUrl, int timeoutSeconds, string? bearerToken, string? apiKey, string! apiKeyHeader, System.Func<System.Threading.Tasks.ValueTask<string!>>? bearerTokenProvider) -> void
+*REMOVED*Standard.Agents.Brokers.Loggings.LoggingBroker.LoggingBroker(Microsoft.Extensions.Logging.ILogger<Standard.Agents.Brokers.Loggings.LoggingBroker!>! logger, Standard.Agents.Brokers.Times.ITimeBroker! timeBroker, Standard.Agents.Models.Loggings.TraceVerbosity verbosity = Standard.Agents.Models.Loggings.TraceVerbosity.Full, string? logPath = null, Standard.Agents.Brokers.Audits.IAuditBroker? auditBroker = null, System.Func<string?>? principal = null) -> void
+Standard.Agents.Brokers.Loggings.LoggingBroker.LoggingBroker(Microsoft.Extensions.Logging.ILogger<Standard.Agents.Brokers.Loggings.LoggingBroker!>! logger, Standard.Agents.Models.Loggings.TraceVerbosity verbosity = Standard.Agents.Models.Loggings.TraceVerbosity.Full, string? logPath = null) -> void
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.AuditingLoggingBroker(Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker, Standard.Agents.Brokers.Audits.IAuditBroker! auditBroker, Standard.Agents.Brokers.Times.ITimeBroker! timeBroker, System.Func<string?>? principal = null) -> void
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogCriticalAsync(System.Exception! exception) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogDebugAsync(string! message) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogErrorAsync(System.Exception! exception) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogInformationAsync(string! message) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogOutcomeAsync(string! message) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogProcessAsync(string! actor, string! message, bool detail = false) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogResetAsync() -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogStepAsync(Standard.Agents.Models.Loggings.AgentStep step) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogTraceAsync(string! message) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogTurnAsync(int turn) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogWarningAsync(string! message) -> System.Threading.Tasks.ValueTask

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -1759,16 +1759,25 @@ public sealed partial class StandardAgent : IAgent
 
         IFileBroker file = new FileBroker();
 
-        ILoggingBroker logging =
+        // The log is one broker; the decision log is another, applied over it by decoration
+        // when an audit sink is configured - over the built-in trace or a host's own logging
+        // broker alike, so .UseLogging(...) and .Audit(...) compose rather than compete (F-16).
+        ILoggingBroker trace =
             this.loggingBroker ?? new LoggingBroker(
                 new NullLogger<LoggingBroker>(),
-                new TimeBroker(),
                 this.traceVerbosity,
-                string.IsNullOrEmpty(this.logPath) ? null : this.logPath,
-                this.auditBroker
-                    ?? (string.IsNullOrEmpty(this.auditPath)
-                        ? new NotConfiguredAuditBroker()
-                        : new FileAuditBroker(this.auditPath)),
+                string.IsNullOrEmpty(this.logPath) ? null : this.logPath);
+
+        IAuditBroker? audit =
+            this.auditBroker
+                ?? (string.IsNullOrEmpty(this.auditPath) ? null : new FileAuditBroker(this.auditPath));
+
+        ILoggingBroker logging = audit is null
+            ? trace
+            : new AuditingLoggingBroker(
+                trace,
+                audit,
+                new TimeBroker(),
                 () => this.identityResolver?.Invoke()?.Id);
 
         // With only a native brain configured there is no V0 generator to build, and none is

--- a/docs/architecture-alignment.md
+++ b/docs/architecture-alignment.md
@@ -225,7 +225,17 @@ call, both of which the old code got right and which moving it had to preserve. 
 test that covers it was sabotage-verified after the move, not before: refusal detection was
 disabled and `ShouldWithholdAnInjectedToolResultFromTheBrainAsync` was watched failing.
 
-**No deviations remain.** The diagram says so without an asterisk.
+**No deviations remain** — with one correction, dated. When this document first said so, violation
+**A** had not in fact been closed: `LoggingBroker` still held `ITimeBroker` and `IAuditBroker`,
+built every audit record itself, and the sentence above was wrong (principal review 2026-09-04,
+F-16). Closed 2026-09-05, by the shape the resilience ruling already established: the logging
+broker wraps one resource, the log, and the decision log is applied over it by **decoration** —
+`AuditingLoggingBroker` implements `ILoggingBroker`, takes one, and adds the audit record to each
+call it forwards. Composed at the facade only when an audit sink is configured, over the built-in
+trace or a host's own logging broker alike, so `.UseLogging(...)` and `.Audit(...)` compose rather
+than compete. And the rule is now a test rather than a sentence: `TierDisciplineTests` reads every
+broker's constructors and fails on one that takes another broker without implementing the
+interface it takes — the dependency **flow**, not the folder a type sits in.
 
 **No public API change.** `docs/support.md` already states that service classes and their
 constructors are not a public contract, and the builder surface is untouched. This is `1.2.0.0` —


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-16. `LoggingBroker` held `ITimeBroker` and `IAuditBroker`, built every audit record itself, and carried principal attribution and run sequencing for the audit; a broker orchestrated two other brokers. architecture-alignment.md named this violation A, said audit should be pulled out, and then concluded that no deviations remained.

## Change

- **`LoggingBroker` wraps one resource**: the log, as the host's `ILogger` and the trace file that is the same log on disk. Time, audit and principal are gone from it.
- **`AuditingLoggingBroker`** applies the decision log by decoration: it implements `ILoggingBroker`, takes one, and writes the stamped, sequenced, attributed audit record before forwarding each call. This is the shape the repository's own resilience ruling already established for brokers that add one concern to another broker's call and own no resource of their own.
- **Composed only when an audit sink is configured**, over whichever logging broker the deployment chose. A host that supplies `.UseLogging(...)` and also `.Audit(...)` now gets both; before, a custom logging broker silently lost the audit.
- **The rule is a test.** `TierDisciplineTests.ShouldHoldNoOtherBrokerUnlessDecoratingOne` reads every broker's constructors and fails on one that takes another broker without implementing the interface it takes: the dependency flow, not the folder a type sits in. It failed on exactly `LoggingBroker takes [ITimeBroker, IAuditBroker]` before the split and passes after.
- architecture-alignment.md now says, dated, that its "no deviations remain" sentence was wrong when written and how A was closed.

## Public API

The `LoggingBroker` constructor loses its time, audit and principal parameters (a `*REMOVED*` line and the new shape in PublicAPI.Unshipped.txt); `AuditingLoggingBroker` is new. docs/support.md names service constructors as not a public contract but says nothing about broker constructors, so this is recorded as a public API change; the builder surface is untouched. Versioning: a service and routine change, second segment.

## Verified

Unit 797 passed on net8.0 and net10.0 (the decision-log acceptance tests exercise the decorator end to end); conformance 77 passed; Critical certified; evals 6 passed.
