### PR TITLE
MINOR BROKERS: The Decision Log Records Metadata By Default (Audit Data Policy)

### DIFF
--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -922,8 +922,16 @@ static bool AuditConformant(Vector vector, List<AuditRecord> records, out string
     {
         foreach (string prompt in prompts)
         {
+            // Evidence of a prompt is its record: the payload itself when the deployment opted
+            // into payload capture, otherwise the payload's hash - the decision log is
+            // metadata by default (F-14), and a hash is proof the prompt was received without
+            // the prompt travelling to the sink.
+            string promptHash = Sha256Hex(prompt);
+
             bool retained = records.Any(record =>
-                record.Message.Contains(prompt, StringComparison.Ordinal));
+                record.Message.Contains(prompt, StringComparison.Ordinal)
+                    || record.Payload?.Contains(prompt, StringComparison.Ordinal) is true
+                    || record.PayloadHash == promptHash);
 
             if (retained is false)
             {
@@ -1480,6 +1488,13 @@ static List<string> ProfileRequirements(
 
 static string Show(string value) =>
     value.Replace("\n", "\\n").Replace("\r", "\\r");
+
+// The same fingerprint the decision log writes for a payload: SHA-256 of the UTF-8 bytes,
+// lowercase hex, on both targets.
+static string Sha256Hex(string value) =>
+    Convert.ToHexString(
+        System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(value)))
+            .ToLowerInvariant();
 
 static string FindRepositoryRoot()
 {

--- a/Standard.Agents.Tests.Unit/Acceptance/AuditDataPolicyTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/AuditDataPolicyTests.cs
@@ -1,0 +1,129 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using Standard.Agents.Brokers.Knowledges;
+using Standard.Agents.Brokers.Memorys;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Brokers.Redactions;
+using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance;
+
+// Found in the 2026-09-04 principal review (F-14): Redact protected the model boundary, not the
+// logging boundary. The decision log kept the raw prompt, the system prompt, the Brain's reply
+// and every tool payload in clear text — and an audit sink usually has broader access and a
+// longer life than anything at runtime. The decision log now records METADATA by default: what
+// happened, who did it, when, and how large and which payload it was (length and hash), never
+// the payload itself. Payload capture is a separate, deliberate opt-in, and when it is on, the
+// configured redaction applies at the audit boundary as it does at the model boundary.
+public class AuditDataPolicyTests : IDisposable
+{
+    private const string CardNumber = "4111-1111-1111-1111";
+
+    private readonly string auditPath =
+        Path.Combine(Path.GetTempPath(), $"audit-policy-{Guid.NewGuid():n}.jsonl");
+
+    public void Dispose()
+    {
+        if (File.Exists(this.auditPath))
+        {
+            File.Delete(this.auditPath);
+        }
+    }
+
+    // A tool the Brain calls with the card number, so a tool payload and a tool result both
+    // carry it; a Brain that echoes it back, so the reply carries it; a prompt that starts it.
+    private sealed class EchoTool : ITool
+    {
+        public string Name => "echo";
+
+        public string Description => "Echoes its input.";
+
+        public async ValueTask<string> ExecuteAsync(string input) => $"echoed {input}";
+    }
+
+    private static StandardAgent BareShell()
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object);
+    }
+
+    private StandardAgent EchoingAgent()
+    {
+        int turn = 0;
+
+        return BareShell()
+            .Tool(new EchoTool())
+            .Audit(this.auditPath)
+            .OnBrain(async (systemPrompt, userPrompt) =>
+                ++turn is 1
+                    ? $"ACTION: echo: {CardNumber}"
+                    : $"FINAL: noted {CardNumber}");
+    }
+
+    [Fact]
+    public async Task ShouldWithholdPayloadsFromTheDecisionLogByDefaultAsync()
+    {
+        // given
+        StandardAgent agent = EchoingAgent();
+
+        // when
+        string answer = await agent.ProcessPromptAsync($"my card is {CardNumber}");
+        string decisionLog = await File.ReadAllTextAsync(this.auditPath);
+
+        // then — the run happened and the answer carried the number; the log did not
+        answer.Should().Contain(CardNumber);
+        decisionLog.Should().NotContain(CardNumber);
+
+        // and what happened is still on the record: the events, and the shape of the payloads
+        decisionLog.Should().Contain("Received prompt");
+        decisionLog.Should().Contain("Brain replied");
+        decisionLog.Should().Contain("Tool 'echo' input");
+        decisionLog.Should().Contain("Tool 'echo' output");
+        decisionLog.Should().Contain("\"payloadLength\":");
+        decisionLog.Should().Contain("\"payloadHash\":");
+    }
+
+    [Fact]
+    public async Task ShouldRedactPayloadsInTheDecisionLogWhenRedactionIsConfiguredAsync()
+    {
+        // given — payload capture on, and a redaction rule for card numbers
+        var cardRule = new RedactionRule
+        {
+            Label = "CARD",
+            Pattern = @"\d{4}-\d{4}-\d{4}-\d{4}"
+        };
+
+        StandardAgent agent = EchoingAgent()
+            .Redact(cardRule)
+            .AuditPayloads();
+
+        // when
+        await agent.ProcessPromptAsync($"my card is {CardNumber}");
+        string decisionLog = await File.ReadAllTextAsync(this.auditPath);
+
+        // then — the payloads are on the record, tokenized the way the Brain saw them
+        decisionLog.Should().NotContain(CardNumber);
+        decisionLog.Should().Contain("CARD");
+        decisionLog.Should().Contain("\"payload\":");
+    }
+}

--- a/Standard.Agents.Tests.Unit/Acceptance/AuditDataPolicyTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/AuditDataPolicyTests.cs
@@ -8,7 +8,7 @@ using Moq;
 using Standard.Agents.Brokers.Knowledges;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Skills;
-using Standard.Agents.Models.Brokers.Redactions;
+using Standard.Agents.Models.Foundations.Brains;
 using Standard.Agents.Models.Foundations.Skills;
 using Standard.Agents.Tools;
 using Xunit;
@@ -36,6 +36,11 @@ public class AuditDataPolicyTests : IDisposable
             File.Delete(this.auditPath);
         }
     }
+
+    // The sink is JSON lines, and the serializer escapes an apostrophe as a ' sequence;
+    // read it the way a reader would, with the escape undone, so an assertion can name a tool.
+    private async Task<string> ReadDecisionLogAsync() =>
+        (await File.ReadAllTextAsync(this.auditPath)).Replace("\\u0027", "'");
 
     // A tool the Brain calls with the card number, so a tool payload and a tool result both
     // carry it; a Brain that echoes it back, so the reply carries it; a prompt that starts it.
@@ -88,7 +93,7 @@ public class AuditDataPolicyTests : IDisposable
 
         // when
         string answer = await agent.ProcessPromptAsync($"my card is {CardNumber}");
-        string decisionLog = await File.ReadAllTextAsync(this.auditPath);
+        string decisionLog = await ReadDecisionLogAsync();
 
         // then — the run happened and the answer carried the number; the log did not
         answer.Should().Contain(CardNumber);
@@ -119,7 +124,7 @@ public class AuditDataPolicyTests : IDisposable
 
         // when
         await agent.ProcessPromptAsync($"my card is {CardNumber}");
-        string decisionLog = await File.ReadAllTextAsync(this.auditPath);
+        string decisionLog = await ReadDecisionLogAsync();
 
         // then — the payloads are on the record, tokenized the way the Brain saw them
         decisionLog.Should().NotContain(CardNumber);

--- a/Standard.Agents.Tests.Unit/Acceptance/DecisionLogTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/DecisionLogTests.cs
@@ -64,14 +64,21 @@ public class DecisionLogTests : IDisposable
         await agent.ProcessPromptAsync(prompt: "the ALPHA question");
         await agent.ProcessPromptAsync(prompt: "the BRAVO question");
 
-        // then
+        // then — evidence of each prompt is its record's payload hash: the decision log is
+        // metadata by default (F-14), so the prompt itself never travels to the sink
         string[] actualLines = await File.ReadAllLinesAsync(this.auditPath);
 
-        actualLines.Should().Contain(line => line.Contains("ALPHA"));
-        actualLines.Should().Contain(line => line.Contains("BRAVO"));
+        actualLines.Should().Contain(line => line.Contains(Sha256Hex("the ALPHA question")));
+        actualLines.Should().Contain(line => line.Contains(Sha256Hex("the BRAVO question")));
+        actualLines.Should().NotContain(line => line.Contains("ALPHA"));
 
         actualLines.Select(RunIdOf).Distinct().Should().HaveCount(2);
     }
+
+    private static string Sha256Hex(string value) =>
+        Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(value)))
+                .ToLowerInvariant();
 
     [Fact]
     public async Task ShouldNumberEachRunFromZeroInTheDecisionLogOnProcessPromptAsync()

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DataNature/DataCoordinationServiceTests.Exceptions.Recall.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DataNature/DataCoordinationServiceTests.Exceptions.Recall.cs
@@ -91,8 +91,8 @@ Xeption foundationException)
         // The prompt is announced before anything is fetched, so a failure still says which
         // prompt Data was working on.
         this.loggingBrokerMock.Verify(broker =>
-            broker.LogProcessAsync(
-                "Data", $"Received prompt: \"{inputContext.Prompt}\"", false),
+            broker.LogPayloadAsync(
+                "Data", "Received prompt", inputContext.Prompt, false),
                     Times.Once);
 
         this.loggingBrokerMock.VerifyNoOtherCalls();
@@ -133,8 +133,8 @@ Xeption foundationException)
         // The prompt is announced before anything is fetched, so a failure still says which
         // prompt Data was working on.
         this.loggingBrokerMock.Verify(broker =>
-            broker.LogProcessAsync(
-                "Data", $"Received prompt: \"{inputContext.Prompt}\"", false),
+            broker.LogPayloadAsync(
+                "Data", "Received prompt", inputContext.Prompt, false),
                     Times.Once);
 
         this.loggingBrokerMock.VerifyNoOtherCalls();
@@ -179,8 +179,8 @@ Xeption foundationException)
         // The prompt is announced before anything is fetched, so a failure still says which
         // prompt Data was working on.
         this.loggingBrokerMock.Verify(broker =>
-            broker.LogProcessAsync(
-                "Data", $"Received prompt: \"{inputContext.Prompt}\"", false),
+            broker.LogPayloadAsync(
+                "Data", "Received prompt", inputContext.Prompt, false),
                     Times.Once);
 
         this.loggingBrokerMock.VerifyNoOtherCalls();

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DataNature/DataCoordinationServiceTests.Trace.SystemPrompt.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DataNature/DataCoordinationServiceTests.Trace.SystemPrompt.cs
@@ -30,10 +30,10 @@ public partial class DataCoordinationServiceTests
 
         // then
         this.loggingBrokerMock.Verify(broker =>
-            broker.LogProcessAsync(
+            broker.LogPayloadAsync(
                 "Data",
-                It.Is<string>(message =>
-                    message.Contains("System prompt") && message.Contains("SKILL-MARKER-XYZ")),
+                It.Is<string>(summary => summary.Contains("System prompt")),
+                It.Is<string>(payload => payload.Contains("SKILL-MARKER-XYZ")),
                 It.IsAny<bool>()),
                     Times.Once);
     }

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.Trace.BrainReply.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.Trace.BrainReply.cs
@@ -35,10 +35,10 @@ public partial class DecisionCoordinationServiceTests
 
         // then
         this.loggingBrokerMock.Verify(broker =>
-            broker.LogProcessAsync(
+            broker.LogPayloadAsync(
                 "Decision",
-                It.Is<string>(message =>
-                    message.Contains("Brain") && message.Contains("my-secret-answer")),
+                It.Is<string>(summary => summary.Contains("Brain")),
+                It.Is<string>(payload => payload.Contains("my-secret-answer")),
                 It.IsAny<bool>()),
                     Times.Once);
     }

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.Trace.GateVerdict.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.Trace.GateVerdict.cs
@@ -38,10 +38,10 @@ public partial class DecisionCoordinationServiceTests
 
         // then
         this.loggingBrokerMock.Verify(broker =>
-            broker.LogProcessAsync(
+            broker.LogPayloadAsync(
                 "Decision",
-                It.Is<string>(message =>
-                    message.Contains("ACCEPT") && message.Contains("safe")),
+                It.Is<string>(summary => summary.Contains("ACCEPT")),
+                It.Is<string>(payload => payload.Contains("safe")),
                 It.IsAny<bool>()),
                     Times.Once);
     }

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.Trace.Refuse.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.Trace.Refuse.cs
@@ -32,11 +32,10 @@ public partial class DecisionCoordinationServiceTests
 
         // then
         this.loggingBrokerMock.Verify(broker =>
-            broker.LogProcessAsync(
+            broker.LogPayloadAsync(
                 "Decision",
-                It.Is<string>(message =>
-                    message.Contains("REFUSE")
-                        && message.Contains("personal information")),
+                It.Is<string>(summary => summary.Contains("REFUSE")),
+                It.Is<string>(payload => payload.Contains("personal information")),
                 It.IsAny<bool>()),
                     Times.Once);
     }

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.Trace.Route.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.Trace.Route.cs
@@ -41,10 +41,10 @@ public partial class DecisionCoordinationServiceTests
         decisionStream.Result.DirectionType.Should().Be("ReturnResponse");
 
         this.loggingBrokerMock.Verify(broker =>
-            broker.LogProcessAsync(
+            broker.LogPayloadAsync(
                 "Decision",
-                It.Is<string>(message =>
-                    message.Contains("ROUTE") && message.Contains("arithmetic")),
+                It.Is<string>(summary => summary.Contains("ROUTE")),
+                It.Is<string>(payload => payload.Contains("arithmetic")),
                 It.IsAny<bool>()),
                     Times.Once);
     }

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.Trace.ThinkStream.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DecisionNature/DecisionCoordinationServiceTests.Trace.ThinkStream.cs
@@ -35,9 +35,10 @@ public partial class DecisionCoordinationServiceTests
 
         // then
         this.loggingBrokerMock.Verify(broker =>
-            broker.LogProcessAsync(
+            broker.LogPayloadAsync(
                 "Decision",
-                It.Is<string>(message => message.Contains("Gate")),
+                It.Is<string>(summary => summary.Contains("Gate")),
+                It.IsAny<string>(),
                 It.IsAny<bool>()),
                     Times.Once);
 

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Trace.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Trace.Act.cs
@@ -35,9 +35,10 @@ public partial class DirectionCoordinationServiceTests
 
         // then
         this.loggingBrokerMock.Verify(broker =>
-            broker.LogProcessAsync(
+            broker.LogPayloadAsync(
                 "Direction",
-                It.Is<string>(message => message.Contains("Tool") && message.Contains("2")),
+                It.Is<string>(summary => summary.Contains("Tool")),
+                It.Is<string>(payload => payload.Contains("2")),
                 It.IsAny<bool>()),
                     Times.Once);
     }

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Trace.Return.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Trace.Return.cs
@@ -31,10 +31,10 @@ public partial class DirectionCoordinationServiceTests
 
         // then
         this.loggingBrokerMock.Verify(broker =>
-            broker.LogProcessAsync(
+            broker.LogPayloadAsync(
                 "Direction",
-                It.Is<string>(message =>
-                    message.Contains("returned") && message.Contains("RESULT-MARKER")),
+                It.Is<string>(summary => summary.Contains("returned")),
+                It.Is<string>(payload => payload.Contains("RESULT-MARKER")),
                 It.IsAny<bool>()),
                     Times.Once);
     }

--- a/Standard.Agents/Brokers/Audits/AuditingLoggingBroker.cs
+++ b/Standard.Agents/Brokers/Audits/AuditingLoggingBroker.cs
@@ -3,7 +3,10 @@
 // Licensed under the The Standard Software License (TSSL)
 // ---------------------------------------------------------------
 
+using System.Security.Cryptography;
+using System.Text;
 using Standard.Agents.Brokers.Loggings;
+using Standard.Agents.Brokers.Redactions;
 using Standard.Agents.Brokers.Times;
 using Standard.Agents.Models.Brokers.Audits;
 using Standard.Agents.Models.Loggings;
@@ -17,11 +20,18 @@ namespace Standard.Agents.Brokers.Audits;
 // own; that is the one shape in which a broker may hold another (principal review 2026-09-04,
 // F-16). Composed at the facade only when an audit sink is configured, over whichever logging
 // broker the deployment chose - the built-in one or a host's own.
+//
+// What the record carries is policy (F-14): metadata by default - a payload's length and hash,
+// never the payload - and the payload itself only when the deployment opted in, as the
+// configured redaction leaves it. Redact protects the model boundary; this is the same rule at
+// the audit boundary.
 public sealed class AuditingLoggingBroker : ILoggingBroker
 {
     private readonly ILoggingBroker loggingBroker;
     private readonly IAuditBroker auditBroker;
     private readonly ITimeBroker timeBroker;
+    private readonly IRedactionBroker redactionBroker;
+    private readonly AuditPolicy policy;
     private readonly Func<string?>? principal;
 
     // The run is read from the ambient AgentRun that Coordination begins (SPEC.md §4.4); the
@@ -34,11 +44,15 @@ public sealed class AuditingLoggingBroker : ILoggingBroker
         ILoggingBroker loggingBroker,
         IAuditBroker auditBroker,
         ITimeBroker timeBroker,
+        IRedactionBroker redactionBroker,
+        AuditPolicy policy,
         Func<string?>? principal = null)
     {
         this.loggingBroker = loggingBroker;
         this.auditBroker = auditBroker;
         this.timeBroker = timeBroker;
+        this.redactionBroker = redactionBroker;
+        this.policy = policy;
         this.principal = principal;
     }
 
@@ -98,11 +112,34 @@ public sealed class AuditingLoggingBroker : ILoggingBroker
         await this.loggingBroker.LogProcessAsync(actor, message, detail);
     }
 
+    // The summary is the record; the payload is its length and its hash, and the payload
+    // itself only under a policy that asked for it - redacted, because the sink outlives the run.
+    public async ValueTask LogPayloadAsync(string actor, string summary, string payload, bool detail)
+    {
+        string? recorded = this.policy.Payloads
+            ? this.redactionBroker.Redact(payload, new Dictionary<string, string>())
+            : null;
+
+        await AuditAsync(
+            AuditKind.Process,
+            actor,
+            summary,
+            detail,
+            recorded,
+            payload.Length,
+            Hash(payload));
+
+        await this.loggingBroker.LogPayloadAsync(actor, summary, payload, detail);
+    }
+
     private async ValueTask AuditAsync(
         AuditKind kind,
         string actor,
         string message,
-        bool detail = false)
+        bool detail = false,
+        string? payload = null,
+        int? payloadLength = null,
+        string? payloadHash = null)
     {
         AgentRun run = this.Run;
 
@@ -115,9 +152,23 @@ public sealed class AuditingLoggingBroker : ILoggingBroker
             Actor = actor,
             Message = message,
             Detail = detail,
-            Principal = this.principal?.Invoke()
+            Principal = this.principal?.Invoke(),
+            Payload = payload,
+            PayloadLength = payloadLength,
+            PayloadHash = payloadHash
         };
 
         await this.auditBroker.WriteAsync(record);
+    }
+
+    // The same fingerprint on both targets: lowercase hex either way, so a hash written on one
+    // matches the same payload's hash on the other.
+    private static string Hash(string payload)
+    {
+#if NET9_0_OR_GREATER
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
+#else
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
+#endif
     }
 }

--- a/Standard.Agents/Brokers/Loggings/ILoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/ILoggingBroker.cs
@@ -30,4 +30,13 @@ public interface ILoggingBroker
     ValueTask LogStepAsync(AgentStep step);
 
     ValueTask LogProcessAsync(string actor, string message, bool detail = false);
+
+    /// <summary>
+    /// A process event that carries a payload: the prompt, the system prompt, the Brain's reply,
+    /// a tool's input or output. The summary says what happened; the payload is the content, kept
+    /// apart so a sink can decide what it keeps (principal review 2026-09-04, F-14). A broker that
+    /// does not distinguish the two logs them as one message.
+    /// </summary>
+    ValueTask LogPayloadAsync(string actor, string summary, string payload, bool detail) =>
+        LogProcessAsync(actor, $"{summary} → {payload}", detail);
 }

--- a/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
+++ b/Standard.Agents/Brokers/Loggings/LoggingBroker.cs
@@ -114,6 +114,15 @@ public sealed class LoggingBroker : ILoggingBroker
         }
     }
 
+    // The trace is the human's reading aid, so the payload is written in full: on the same line
+    // when it fits, under the summary when it spans lines.
+    public ValueTask LogPayloadAsync(string actor, string summary, string payload, bool detail)
+    {
+        string separator = payload.Contains('\n') ? Environment.NewLine : " ";
+
+        return LogProcessAsync(actor, $"{summary} →{separator}{payload}", detail);
+    }
+
     // The trace is a shared file and one broker serves every concurrent run, so writes are
     // serialized - without this, sixty-four prompts in flight collide on the handle and most
     // of them fail with an IOException rather than an answer.

--- a/Standard.Agents/Models/Brokers/Audits/AuditPolicy.cs
+++ b/Standard.Agents/Models/Brokers/Audits/AuditPolicy.cs
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Models.Brokers.Audits;
+
+/// <summary>
+/// What the decision log may carry. <see cref="Payloads"/> false, the default, records metadata:
+/// the event, the actor, the time, the principal, and the length and hash of any payload, never
+/// the payload itself. True records the payloads too, as the configured redaction leaves them.
+/// A deliberate opt-in, because an audit sink usually has broader access and a longer life than
+/// anything at runtime (principal review 2026-09-04, F-14).
+/// </summary>
+public sealed record AuditPolicy(bool Payloads)
+{
+    public static AuditPolicy Metadata => new(Payloads: false);
+}

--- a/Standard.Agents/Models/Brokers/Audits/AuditRecord.cs
+++ b/Standard.Agents/Models/Brokers/Audits/AuditRecord.cs
@@ -17,5 +17,16 @@ public sealed record AuditRecord
     public bool Detail { get; init; }
 
     public string? Principal { get; init; }
+
+    /// <summary>
+    /// The payload behind a process record (the prompt, the system prompt, the reply, a tool's
+    /// input or output), present only when the deployment opted into payload capture and then
+    /// as the redaction left it. Withheld by default: the decision log records that a payload
+    /// existed, how large it was and which one it was (<see cref="PayloadLength"/>,
+    /// <see cref="PayloadHash"/>), never the payload itself (principal review 2026-09-04, F-14).
+    /// </summary>
+    public string? Payload { get; init; }
+    public int? PayloadLength { get; init; }
+    public string? PayloadHash { get; init; }
     public string? PreviousHash { get; init; }
 }

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -81,3 +81,28 @@ Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogStepAsync(Standard.Agent
 Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogTraceAsync(string! message) -> System.Threading.Tasks.ValueTask
 Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogTurnAsync(int turn) -> System.Threading.Tasks.ValueTask
 Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogWarningAsync(string! message) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Loggings.ILoggingBroker.LogPayloadAsync(string! actor, string! summary, string! payload, bool detail) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Loggings.LoggingBroker.LogPayloadAsync(string! actor, string! summary, string! payload, bool detail) -> System.Threading.Tasks.ValueTask
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.LogPayloadAsync(string! actor, string! summary, string! payload, bool detail) -> System.Threading.Tasks.ValueTask
+*REMOVED*Standard.Agents.Brokers.Audits.AuditingLoggingBroker.AuditingLoggingBroker(Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker, Standard.Agents.Brokers.Audits.IAuditBroker! auditBroker, Standard.Agents.Brokers.Times.ITimeBroker! timeBroker, System.Func<string?>? principal = null) -> void
+Standard.Agents.Brokers.Audits.AuditingLoggingBroker.AuditingLoggingBroker(Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker, Standard.Agents.Brokers.Audits.IAuditBroker! auditBroker, Standard.Agents.Brokers.Times.ITimeBroker! timeBroker, Standard.Agents.Brokers.Redactions.IRedactionBroker! redactionBroker, Standard.Agents.Models.Brokers.Audits.AuditPolicy! policy, System.Func<string?>? principal = null) -> void
+Standard.Agents.Models.Brokers.Audits.AuditPolicy
+Standard.Agents.Models.Brokers.Audits.AuditPolicy.AuditPolicy(bool Payloads) -> void
+Standard.Agents.Models.Brokers.Audits.AuditPolicy.Payloads.get -> bool
+Standard.Agents.Models.Brokers.Audits.AuditPolicy.Payloads.init -> void
+static Standard.Agents.Models.Brokers.Audits.AuditPolicy.Metadata.get -> Standard.Agents.Models.Brokers.Audits.AuditPolicy!
+Standard.Agents.Models.Brokers.Audits.AuditRecord.Payload.get -> string?
+Standard.Agents.Models.Brokers.Audits.AuditRecord.Payload.init -> void
+Standard.Agents.Models.Brokers.Audits.AuditRecord.PayloadHash.get -> string?
+Standard.Agents.Models.Brokers.Audits.AuditRecord.PayloadHash.init -> void
+Standard.Agents.Models.Brokers.Audits.AuditRecord.PayloadLength.get -> int?
+Standard.Agents.Models.Brokers.Audits.AuditRecord.PayloadLength.init -> void
+Standard.Agents.StandardAgent.AuditPayloads() -> Standard.Agents.StandardAgent!
+Standard.Agents.Models.Brokers.Audits.AuditPolicy.<Clone>$() -> Standard.Agents.Models.Brokers.Audits.AuditPolicy!
+Standard.Agents.Models.Brokers.Audits.AuditPolicy.Deconstruct(out bool Payloads) -> void
+Standard.Agents.Models.Brokers.Audits.AuditPolicy.Equals(Standard.Agents.Models.Brokers.Audits.AuditPolicy? other) -> bool
+override Standard.Agents.Models.Brokers.Audits.AuditPolicy.Equals(object? obj) -> bool
+override Standard.Agents.Models.Brokers.Audits.AuditPolicy.GetHashCode() -> int
+override Standard.Agents.Models.Brokers.Audits.AuditPolicy.ToString() -> string!
+static Standard.Agents.Models.Brokers.Audits.AuditPolicy.operator !=(Standard.Agents.Models.Brokers.Audits.AuditPolicy? left, Standard.Agents.Models.Brokers.Audits.AuditPolicy? right) -> bool
+static Standard.Agents.Models.Brokers.Audits.AuditPolicy.operator ==(Standard.Agents.Models.Brokers.Audits.AuditPolicy? left, Standard.Agents.Models.Brokers.Audits.AuditPolicy? right) -> bool

--- a/Standard.Agents/Services/Coordinations/Data/DataCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/Data/DataCoordinationService.cs
@@ -39,7 +39,8 @@ public partial class DataCoordinationService : IDataCoordinationService
         ValidateContext(context);
 
         // Announced before anything is fetched, so the trace reads in the order things happened.
-        await this.loggingBroker.LogProcessAsync("Data", $"Received prompt: \"{context.Prompt}\"");
+        await this.loggingBroker.LogPayloadAsync(
+            "Data", "Received prompt", context.Prompt, detail: false);
 
         string systemPrompt = await this.retrievalService.RetrieveInstructionsAsync(context.Route);
 
@@ -54,10 +55,8 @@ public partial class DataCoordinationService : IDataCoordinationService
         IReadOnlyList<string> knowledge =
             await this.retrievalService.RetrieveGroundingAsync(context.Prompt);
 
-        await this.loggingBroker.LogProcessAsync(
-            "Data",
-            $"System prompt sent to Decision →{Environment.NewLine}{systemPrompt}",
-            detail: true);
+        await this.loggingBroker.LogPayloadAsync(
+            "Data", "System prompt sent to Decision", systemPrompt, detail: true);
 
         return context with
         {

--- a/Standard.Agents/Services/Coordinations/Decision/DecisionCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/Decision/DecisionCoordinationService.cs
@@ -406,8 +406,8 @@ public partial class DecisionCoordinationService : IDecisionCoordinationService
             return null;
         }
 
-        await this.loggingBroker.LogProcessAsync(
-            "Decision", $"Gate → REFUSE: {verdict.ReplaceLineEndings(" ").Trim()}");
+        await this.loggingBroker.LogPayloadAsync(
+            "Decision", "Gate REFUSE", verdict.ReplaceLineEndings(" ").Trim(), detail: false);
 
         return context with
         {
@@ -432,11 +432,11 @@ public partial class DecisionCoordinationService : IDecisionCoordinationService
             await LogGuardianOverreachAsync();
         }
 
-        await this.loggingBroker.LogProcessAsync(
+        await this.loggingBroker.LogPayloadAsync(
             "Decision",
-            IsRoute(verdict)
-                ? $"Gate → ROUTE: {verdict.ReplaceLineEndings(" ").Trim()}"
-                : $"Gate → ACCEPT: {verdict.ReplaceLineEndings(" ").Trim()}");
+            IsRoute(verdict) ? "Gate ROUTE" : "Gate ACCEPT",
+            verdict.ReplaceLineEndings(" ").Trim(),
+            detail: false);
 
         return IsRoute(verdict)
             ? context with { Route = ExtractRouteLabel(verdict) }

--- a/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Perimeter.cs
+++ b/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.Perimeter.cs
@@ -156,11 +156,11 @@ public partial class DirectionCoordinationService
         AgentRun.Current?.RecordPerformed(
             new PerformedEffect(effect.ToolName, effect.Arguments, output));
 
-        await this.loggingBroker.LogProcessAsync(
-            "Direction", $"Tool '{effect.ToolName}' ← {context.Payload}", detail: true);
+        await this.loggingBroker.LogPayloadAsync(
+            "Direction", $"Tool '{effect.ToolName}' input", context.Payload, detail: true);
 
-        await this.loggingBroker.LogProcessAsync(
-            "Direction", $"Tool '{effect.ToolName}' → {output}");
+        await this.loggingBroker.LogPayloadAsync(
+            "Direction", $"Tool '{effect.ToolName}' output", output, detail: false);
 
         return Observed(context, output);
     }
@@ -224,10 +224,11 @@ public partial class DirectionCoordinationService
         {
             CompensationOutcome outcome = await CompensateEffectAsync(effect);
 
-            await this.loggingBroker.LogProcessAsync(
+            await this.loggingBroker.LogPayloadAsync(
                 "Direction",
-                $"Compensate '{effect.ToolName}' → "
-                    + $"{(outcome.Undone ? "UNDONE" : "STANDS")}: {outcome.Detail}");
+                $"Compensate '{effect.ToolName}' {(outcome.Undone ? "UNDONE" : "STANDS")}",
+                outcome.Detail,
+                detail: false);
 
             outcomes.Add(outcome);
         }

--- a/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.cs
+++ b/Standard.Agents/Services/Coordinations/Direction/DirectionCoordinationService.cs
@@ -84,8 +84,8 @@ public partial class DirectionCoordinationService : IDirectionCoordinationServic
         {
             string result = await this.executionService.ReturnAsync(context.Payload);
 
-            await this.loggingBroker.LogProcessAsync(
-                "Direction", $"{context.DirectionType} → returned: {result}");
+            await this.loggingBroker.LogPayloadAsync(
+                "Direction", $"{context.DirectionType} returned", result, detail: false);
 
             return context with
             {

--- a/Standard.Agents/Services/Managements/RunManagementService.Narration.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.Narration.cs
@@ -37,8 +37,8 @@ public partial class RunManagementService
                     .Replace("{tool}", context.DirectionType, StringComparison.Ordinal)
                     .Replace("{payload}", context.Payload, StringComparison.Ordinal);
 
-                await this.loggingBroker.LogProcessAsync(
-                    "Direction", $"Narration → {prose}", detail: true);
+                await this.loggingBroker.LogPayloadAsync(
+                    "Direction", "Narration", prose, detail: true);
 
                 await events.WriteAsync(
                     new AgentStreamEvent(AgentStreamEventType.Narration, prose), abandoned);
@@ -61,8 +61,8 @@ public partial class RunManagementService
             return;
         }
 
-        await this.loggingBroker.LogProcessAsync(
-            "Direction", $"Narration → {context.Narration}", detail: true);
+        await this.loggingBroker.LogPayloadAsync(
+            "Direction", "Narration", context.Narration, detail: true);
 
         await events.WriteAsync(
             new AgentStreamEvent(AgentStreamEventType.Narration, context.Narration),

--- a/Standard.Agents/Services/Managements/RunManagementService.Screening.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.Screening.cs
@@ -42,10 +42,11 @@ public partial class RunManagementService
         string refusal =
             $"the result of '{acted.DirectionType}' was refused by screening and withheld";
 
-        await this.loggingBroker.LogProcessAsync(
+        await this.loggingBroker.LogPayloadAsync(
             "Direction",
-            $"Screening → REFUSED the result of '{acted.DirectionType}': "
-                + verdict.ReplaceLineEndings(" ").Trim());
+            $"Screening REFUSED the result of '{acted.DirectionType}'",
+            verdict.ReplaceLineEndings(" ").Trim(),
+            detail: false);
 
         return acted with
         {

--- a/Standard.Agents/Services/Orchestrations/Decision/Inferences/InferenceOrchestrationService.cs
+++ b/Standard.Agents/Services/Orchestrations/Decision/Inferences/InferenceOrchestrationService.cs
@@ -113,10 +113,7 @@ public partial class InferenceOrchestrationService : IInferenceOrchestrationServ
     // check could hold the doors to each other.
     private async ValueTask NarrateDecidedAsync(AgentContext decided, string reply)
     {
-        await this.loggingBroker.LogProcessAsync(
-            "Decision",
-            $"Brain replied →{Environment.NewLine}{reply}",
-            detail: true);
+        await this.loggingBroker.LogPayloadAsync("Decision", "Brain replied", reply, detail: true);
 
         await this.loggingBroker.LogProcessAsync(
             "Decision",

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -329,6 +329,14 @@ public partial class StandardAgent
 
                 break;
 
+            case "auditPayloads" when Truth(value, key):
+                agent.AuditPayloads();
+
+                break;
+
+            case "auditPayloads":
+                break;
+
             case "telemetry" when value?.GetValueKind() is JsonValueKind.String:
                 agent.Telemetry(Text(value, key));
 

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -119,6 +119,7 @@ public sealed partial class StandardAgent : IAgent
     private Func<string, string, ValueTask<string>>? localJudgeEvaluate;
     private ILoggingBroker? loggingBroker;
     private IAuditBroker? auditBroker;
+    private bool auditPayloads;
     private ITelemetryBroker? telemetryBroker;
     private IPolicyBroker? policyBroker;
     private IApprovalBroker? approvalBroker;
@@ -578,6 +579,18 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent Audit(string path) =>
         Set(() => this.auditPath = path);
+
+    /// <summary>
+    /// Records payloads in the decision log — the prompt, the system prompt, the Brain's reply,
+    /// every tool's input and output — as the configured redaction leaves them. Off by default:
+    /// the log records that a payload existed, how large it was and which one it was (its hash),
+    /// never the payload, because an audit sink usually has broader access and a longer life
+    /// than anything at runtime (principal review 2026-09-04, F-14). Turn this on knowing that
+    /// whoever reads the sink reads the conversation.
+    /// </summary>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent AuditPayloads() =>
+        Set(() => this.auditPayloads = true);
 
     /// <summary>
     /// Sends the decision log to a provider — the <b>External</b> mode (SPEC.md §4.8). Install a
@@ -1772,12 +1785,22 @@ public sealed partial class StandardAgent : IAgent
             this.auditBroker
                 ?? (string.IsNullOrEmpty(this.auditPath) ? null : new FileAuditBroker(this.auditPath));
 
+        // Composed here, above the log, because the same redaction that guards the model
+        // boundary guards the audit boundary (F-14); the generators and guardians below take it
+        // by decoration as before.
+        IRedactionBroker redaction = this.redactionBroker
+            ?? (this.redactionRules is null
+                ? new NotConfiguredRedactionBroker()
+                : new RuleRedactionBroker(this.redactionRules));
+
         ILoggingBroker logging = audit is null
             ? trace
             : new AuditingLoggingBroker(
                 trace,
                 audit,
                 new TimeBroker(),
+                redaction,
+                new AuditPolicy(Payloads: this.auditPayloads),
                 () => this.identityResolver?.Invoke()?.Id);
 
         // With only a native brain configured there is no V0 generator to build, and none is
@@ -1931,11 +1954,6 @@ public sealed partial class StandardAgent : IAgent
         // service. That is what makes "every model call" structural: a foundation holds one
         // broker, knows nothing of redaction, and a fourth model call added tomorrow cannot
         // forget (docs/architecture-alignment.md).
-        IRedactionBroker redaction = this.redactionBroker
-            ?? (this.redactionRules is null
-                ? new NotConfiguredRedactionBroker()
-                : new RuleRedactionBroker(this.redactionRules));
-
         IResilienceBroker resilience =
             this.resilienceBroker ?? new NotConfiguredResilienceBroker();
 

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -160,7 +160,7 @@ the deterministic core of the Standard.
 | `gate-refusal-short-circuits` | A Gate refusal ends the run without reaching the Brain |
 | `constitution-binds-guardians` | A constitution reaches *both* guardian rubrics |
 | `consumption-replaces-policy` | A consumption skill replaces the policy in both, contract intact |
-| `audit-retains-every-run` | Beginning a run never discards a prior run's records (§4.7) |
+| `audit-retains-every-run` | Beginning a run never discards a prior run's records (§4.7); evidence of a prompt is its record's payload hash, or the payload itself when the deployment opted into payload capture |
 | `concurrent-runs-are-isolated` | Eight prompts at once on one instance; no record corrupts another |
 | `judge-receives-the-task` | The Judge scores against the task, not the candidate alone (§4.2) |
 | `redaction-covers-every-model-call` | Brain, Gate and Judge all see the token, never the value (§4.6) |

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -632,14 +632,30 @@ var agent = new StandardAgent(url, key, "LLooMA2.0")
 - `TraceVerbosity.Full`: every Process (`Process 0: Data: Received prompt`, and so on). This is the default.
 
 **Machine-readable audit, with `.Audit(path)`.** Writes one JSON object per trace event (turn,
-step, process, outcome, error) as JSON lines, always at full detail, for ingestion into a SIEM or
-telemetry pipeline. It runs alongside `.LogTo(...)`, not instead of it.
+step, process, outcome, error) as JSON lines, for ingestion into a SIEM or telemetry pipeline.
+It runs alongside `.LogTo(...)`, not instead of it.
 
 ```csharp
 var agent = new StandardAgent(url, key, "LLooMA2.0")
     .LogTo("log.txt")        // human-readable transcript
     .Audit("audit.jsonl");   // {"kind":"turn",...} {"kind":"process",...} {"kind":"outcome",...}
 ```
+
+**The decision log records metadata, not content, unless you say otherwise.** A process record
+that carries a payload (the prompt, the system prompt, the Brain's reply, a tool's input or
+output, the agent's narration) records *that* it happened, who did it, when, and the payload's
+length and SHA-256, never the payload:
+
+```json
+{"kind":"process","actor":"Data","message":"Received prompt","payloadLength":31,"payloadHash":"9f2c…"}
+```
+
+An audit sink usually has broader access and a longer life than anything at runtime, so the
+conversation does not travel there by default. `.AuditPayloads()` (or `"auditPayloads": true`
+in the document) turns payload capture on, knowing that whoever reads the sink reads the
+conversation, and when it is on the configured `.Redact(...)` rules apply at the audit boundary
+exactly as at the model boundary, so a card number the Brain never saw is a card number the
+sink never sees either. The trace file (`.LogTo`) is a development aid and keeps the full text.
 
 **Spans and metrics, with `.Telemetry()`.** The third observability voice, beside the trace's
 prose and the audit's records: OpenTelemetry-compatible telemetry through the BCL's
@@ -665,15 +681,16 @@ the `Standard.Agents` source and meter and the spans flow to your collector —
 pipeline or a metrics API no ActivityListener reaches.
 
 **What the trace carries — and where it may go.** Know this before pointing any of these at a
-central sink: the trace and the audit carry message **content** — the received prompt, the
-returned answer, tool lines. For a SIEM inside a bank that is the point. For a deployment whose
-promise to its users is that no central party reads their messages, it is a broken promise in
-one config line — the reference deployment wired its audit stream to a cloud log store and
-un-wired it the same day, on exactly this ground. Until a content-free audit mode ships
-(structure only: kind, actor, outcome, timings — never message text), a privacy-first
-deployment should keep content-bearing sinks local and user-owned (`LogTo`/`Audit` to the
-user's own disk), or not wire them at all. Telemetry is the exception: its events carry counts
-and outcomes, never text.
+central sink: the trace carries message **content** — the received prompt, the returned
+answer, tool lines — and the audit carries it only when `.AuditPayloads()` says so. For a SIEM
+inside a bank, payload capture is the point. For a deployment whose promise to its users is
+that no central party reads their messages, it would be a broken promise in one config line —
+the reference deployment wired its audit stream to a cloud log store and un-wired it the same
+day, on exactly this ground, which is why the decision log is content-free by default
+(structure only: kind, actor, outcome, timings, payload length and hash — never message text).
+A privacy-first deployment keeps the trace local and user-owned (`LogTo` to the user's own
+disk), or does not wire it at all, and leaves payload capture off. Telemetry carries counts and
+outcomes, never text.
 
 ---
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -137,6 +137,12 @@ the file can recompute it. Treat the file as local, append-only, hash-linked evi
 deployment gets immutability from the store, not the file: append-only or WORM storage, a signed
 or keyed record, and the terminal hash anchored somewhere the writer cannot reach.
 
+What the records carry is policy, and the default is metadata: a process record whose event has a
+payload (the prompt, the system prompt, the Brain's reply, a tool's input or output) records the
+payload's length and SHA-256, never the payload. `.AuditPayloads()` opts into recording payloads,
+as the configured redaction leaves them, so a sink never holds what the Brain was not shown.
+The trace file (`.LogTo`) is a development aid and is not governed by this policy.
+
 ## Supply chain
 
 Every change on `main` and every pull request runs:


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-14. Redact protected the model boundary, not the logging boundary: the decision log kept the raw prompt, the system prompt, the Brain's reply and every tool payload in clear text, and an audit sink usually has broader access and a longer life than anything at runtime. how-to §7 itself said a content-free audit mode was owed.

## Change

- **Structured process events.** `ILoggingBroker.LogPayloadAsync(actor, summary, payload, detail)` carries the summary and the content apart, so a sink can decide what it keeps. The eleven payload-bearing sites (received prompt, system prompt, Brain reply, tool input and output, returned result, gate verdicts, screening verdict, compensation detail, narration) use it; the trace still prints the full text.
- **Metadata by default.** `AuditingLoggingBroker` records the event, the actor, the time, the principal, and the payload's length and SHA-256, never the payload. `AuditRecord` gains `Payload`, `PayloadLength` and `PayloadHash`; `AuditPolicy` names the choice.
- **Payload capture is a deliberate opt-in**: `.AuditPayloads()` or `"auditPayloads": true`, and when it is on the configured `.Redact(...)` rules apply at the audit boundary exactly as at the model boundary. The redaction broker is composed once, above the log, and the generators and guardians take it by decoration as before.
- **Conformance.** Two vectors prove a run's prompt is retained in the decision log; evidence is now the record's payload hash (or the payload when captured). The runner and CONFORMANCE.md say so.
- Docs: how-to §7 (the owed content-free mode is the default; the privacy paragraph rewritten to match), support.md (the audit sink's data policy).

## Tests

- `AuditDataPolicyTests`: a prompt, a tool call, a tool result and a reply all carrying a card number leave no trace of it in the sink by default, while the events, lengths and hashes are on the record; with capture on and a card rule configured, the sink holds the token and not the number.
- `DecisionLogTests` asserts retention by hash and that the prompt text is absent; nine service-tier trace tests verify the structured member.
- Unit 799 passed on net8.0 and net10.0; conformance 77 passed; Core, Reliable, Enterprise and Critical certified; evals 6 passed.

## Versioning

New interface member with a default, a new record field set, a new verb: a routine change, second segment.
