### PR TITLE
MAJOR FIX: A Turn Carries Its Work

### DIFF
--- a/Standard.Agents.Conformance/Models/RequestSpec.cs
+++ b/Standard.Agents.Conformance/Models/RequestSpec.cs
@@ -24,7 +24,24 @@ public sealed record RequestSpec(
     List<TurnSpec>? History = null);
 
 /// <summary>One prior exchange in the caller-owned transcript, oldest first.</summary>
-public sealed record TurnSpec(string Prompt, string Answer);
+/// <remarks>
+/// A turn carries what it DID as well as what it said. Without <see cref="Exchanges"/> a vector
+/// could only say that a prior turn's text reached the Brain, which is all vector 63 ever proved;
+/// a caller re-posting a conversation had nowhere to put a finished call but the request's own
+/// <c>toolExchanges</c>, this turn's in-flight work, where it certifies as evidence for the
+/// prompt being asked now (SPEC.md 4.11, SPEC.md 6).
+/// </remarks>
+public sealed record TurnSpec(
+    string Prompt,
+    string Answer,
+    List<ToolExchangeSpec>? Exchanges = null);
+
+/// <summary>One call a prior turn made, and what it returned.</summary>
+public sealed record ToolExchangeSpec(
+    string CallId,
+    string ToolName,
+    string ArgumentsJson,
+    string Result);
 
 /// <summary>
 /// A tool the CALLER will execute, declared so the model may name it. The agent never runs one

--- a/Standard.Agents.Conformance/Program.cs
+++ b/Standard.Agents.Conformance/Program.cs
@@ -747,7 +747,16 @@ async Task<VectorRun> RunVectorAsync(Vector vector)
 
         History =
             [.. (spec.History ?? []).Select(turn =>
-                new AgentTurn(turn.Prompt, turn.Answer))],
+                new AgentTurn(turn.Prompt, turn.Answer)
+                {
+                    Exchanges =
+                        [.. (turn.Exchanges ?? []).Select(exchange =>
+                            new ToolExchange(
+                                exchange.CallId,
+                                exchange.ToolName,
+                                exchange.ArgumentsJson,
+                                exchange.Result))]
+                })],
 
         CallerTools =
             [.. (spec.CallerTools ?? []).Select(tool =>

--- a/Standard.Agents.Host/Controllers/V1/AgentsV1Controller.cs
+++ b/Standard.Agents.Host/Controllers/V1/AgentsV1Controller.cs
@@ -84,7 +84,15 @@ public class AgentsV1Controller : ControllerBase
             SessionId = request.SessionId,
 
             History = [.. request.History.Select(turn =>
-                new AgentTurn(turn.Prompt, turn.Answer))],
+                new AgentTurn(turn.Prompt, turn.Answer)
+                {
+                    Exchanges = [.. turn.Exchanges.Select(exchange =>
+                        new ToolExchange(
+                            exchange.CallId,
+                            exchange.ToolName,
+                            exchange.ArgumentsJson,
+                            exchange.Result))]
+                })],
 
             ToolExchanges = [.. request.ToolExchanges.Select(exchange =>
                 new ToolExchange(

--- a/Standard.Agents.Host/Models/V1/AgentTurnV1.cs
+++ b/Standard.Agents.Host/Models/V1/AgentTurnV1.cs
@@ -5,5 +5,17 @@
 
 namespace Standard.Agents.Host.Models.V1;
 
-/// <summary>One past exchange in the caller-owned transcript: what was asked, what was answered.</summary>
-public sealed record AgentTurnV1(string Prompt, string Answer);
+/// <summary>
+/// One past exchange in the caller-owned transcript: what was asked, what was answered, and the
+/// calls that turn made to be able to answer.
+/// </summary>
+/// <remarks>
+/// A caller whose protocol is stateless re-posts the whole conversation on every request. Without
+/// a per-turn home for the calls, a finished call has nowhere to go but
+/// <c>AgentRunRequestV1.ToolExchanges</c>, which is this turn's in-flight work; a call replayed
+/// there is read as evidence for the prompt being asked now.
+/// </remarks>
+public sealed record AgentTurnV1(string Prompt, string Answer)
+{
+    public IReadOnlyList<ToolExchangeV1> Exchanges { get; init; } = [];
+}

--- a/Standard.Agents.Tests.Unit/Acceptance/SessionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/SessionTests.cs
@@ -316,4 +316,50 @@ public class SessionTests : IDisposable
         answer!.ToolCallId.Should().Be("call_7");
         answer.Content.Should().Be("4183");
     }
+
+    // The other half of the same property. Once a turn carries its calls, those calls have to be
+    // as session-scoped as its words already are: one agent instance serving two conversations
+    // must never hand one conversation's call to the other. Keeping the exchanges anywhere but the
+    // session, on the instance or in a static, satisfies the carrying test above and leaks here,
+    // and nothing else in this suite would notice: every other session test runs with no tools.
+    [Fact]
+    public async Task ShouldNotCarryOneSessionsToolExchangeIntoAnotherAsync()
+    {
+        // given
+        IReadOnlyList<ConversationMessage> otherConversation = [];
+        int brainCalls = 0;
+
+        StandardAgent agent = NewNativeAgent(new CalculatorTool(), messages =>
+        {
+            int call = brainCalls++;
+
+            if (call == 0)
+            {
+                return new GenerationResult
+                {
+                    ToolCalls =
+                    [
+                        new ModelToolCall("call_7", "calculator", """{"expression":"47*89"}""")
+                    ]
+                };
+            }
+
+            if (call == 2)
+            {
+                otherConversation = messages;
+            }
+
+            return new GenerationResult { Content = "4183" };
+        });
+
+        // when: one instance, two conversations
+        await agent.ProcessPromptAsync("what is 47 times 89?", sessionId: "alice");
+        await agent.ProcessPromptAsync("what is the capital of France?", sessionId: "bob");
+
+        // then: bob is handed neither alice's call nor the answer that names it
+        otherConversation.Should().NotContain(message => message.Role == MessageRole.Tool);
+
+        otherConversation.Should().NotContain(message =>
+            message.Role == MessageRole.Assistant && message.ToolCalls.Count > 0);
+    }
 }

--- a/Standard.Agents.Tests.Unit/Acceptance/SessionTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/SessionTests.cs
@@ -9,9 +9,11 @@ using Standard.Agents.Brokers.Knowledges;
 using Standard.Agents.Brokers.Memorys;
 using Standard.Agents.Brokers.Sessions;
 using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Brokers.Generators.V1;
 using Standard.Agents.Models.Brokers.Sessions;
 using Standard.Agents.Models.Coordinations.Agents.Exceptions;
 using Standard.Agents.Models.Foundations.Skills;
+using Standard.Agents.Tools;
 using Xunit;
 
 namespace Standard.Agents.Tests.Unit.Acceptance;
@@ -222,5 +224,96 @@ public class SessionTests : IDisposable
 
         session.Should().NotBeNull();
         session!.History.Select(turn => turn.Prompt).Should().BeEquivalentTo(prompts);
+    }
+
+    private sealed class CalculatorTool : ITool
+    {
+        public string Name => "calculator";
+        public string Description => "Evaluates arithmetic.";
+
+        public string Parameters =>
+            """{"type":"object","properties":{"expression":{"type":"string"}}}""";
+
+        public async ValueTask<string> ExecuteAsync(string input) => "4183";
+    }
+
+    private StandardAgent NewNativeAgent(
+        ITool tool,
+        Func<IReadOnlyList<ConversationMessage>, GenerationResult> reply)
+    {
+        var skillBroker = new Mock<ISkillBroker>();
+        skillBroker.Setup(broker => broker.SelectSkillsAsync()).ReturnsAsync(new List<Skill>());
+
+        var memoryBroker = new Mock<IMemoryBroker>();
+        memoryBroker.Setup(broker => broker.SelectMemoriesAsync()).ReturnsAsync([]);
+
+        var knowledgeBroker = new Mock<IKnowledgeBroker>();
+
+        knowledgeBroker.Setup(broker => broker.SelectKnowledgeAsync(It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        return new StandardAgent()
+            .UseSkills(skillBroker.Object)
+            .UseMemory(memoryBroker.Object)
+            .UseKnowledge(knowledgeBroker.Object)
+            .Tool(tool)
+            .OnNativeBrain(async (messages, tools) => reply(messages))
+            .Sessions(this.sessionsPath);
+    }
+
+    // A session that forgets its tool work is wrong in the same way a session that forgets an
+    // answer would be. AgentTurn carries a prompt and an answer and nothing else, so the call the
+    // agent made on the first prompt and the result it acted on are dropped at the save and can
+    // never be recalled: the next prompt is told what the agent said, never what it did in order
+    // to be able to say it. The conversation the Brain sees on the follow-up must still carry the
+    // assistant's request and the tool's answer against the id that asked for it, which is the one
+    // thing narrated prose cannot express (SPEC.md 4.11, SPEC.md 6).
+    [Fact]
+    public async Task ShouldCarryAToolExchangeAcrossPromptsInOneSessionAsync()
+    {
+        // given
+        IReadOnlyList<ConversationMessage> followUpConversation = [];
+        int brainCalls = 0;
+
+        StandardAgent agent = NewNativeAgent(new CalculatorTool(), messages =>
+        {
+            int call = brainCalls++;
+
+            if (call == 0)
+            {
+                return new GenerationResult
+                {
+                    ToolCalls =
+                    [
+                        new ModelToolCall("call_7", "calculator", """{"expression":"47*89"}""")
+                    ]
+                };
+            }
+
+            if (call == 2)
+            {
+                followUpConversation = messages;
+            }
+
+            return new GenerationResult { Content = "4183" };
+        });
+
+        // when
+        await agent.ProcessPromptAsync("what is 47 times 89?", sessionId: "user-13");
+        await agent.ProcessPromptAsync("how did you get that?", sessionId: "user-13");
+
+        // then: the follow-up still carries the call and the answer that names it
+        ConversationMessage? request = followUpConversation.FirstOrDefault(message =>
+            message.Role is MessageRole.Assistant && message.ToolCalls.Count > 0);
+
+        ConversationMessage? answer = followUpConversation.FirstOrDefault(message =>
+            message.Role is MessageRole.Tool);
+
+        request.Should().NotBeNull();
+        request!.ToolCalls[0].Id.Should().Be("call_7");
+
+        answer.Should().NotBeNull();
+        answer!.ToolCallId.Should().Be("call_7");
+        answer.Content.Should().Be("4183");
     }
 }

--- a/Standard.Agents/Models/Brokers/Sessions/AgentSession.cs
+++ b/Standard.Agents/Models/Brokers/Sessions/AgentSession.cs
@@ -70,5 +70,17 @@ public sealed record AgentSession
     public long Version { get; init; }
 }
 
-/// <summary>One exchange: what was asked, and what came back.</summary>
-public sealed record AgentTurn(string Prompt, string Answer);
+/// <summary>One exchange: what was asked, what came back, and the work that produced it.</summary>
+public sealed record AgentTurn(string Prompt, string Answer)
+{
+    /// <summary>The native calls this turn made and what they returned, oldest first.</summary>
+    /// <remarks>
+    /// A turn is not only what was said. It is what the agent did in order to be able to say it,
+    /// and a history that keeps the answer while dropping the call that produced it tells the next
+    /// prompt that the agent answered but never how. A caller that holds the conversation itself
+    /// then has nowhere to put a finished call except the current turn's exchange list, where it
+    /// reads as this turn's evidence rather than as something already done (SPEC.md 4.11, SPEC.md 6).
+    /// Empty for a turn that called nothing, which is every turn the text protocol produces.
+    /// </remarks>
+    public IReadOnlyList<ToolExchange> Exchanges { get; init; } = [];
+}

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -218,3 +218,5 @@ static Standard.Agents.Models.Brokers.Effects.EffectRecord.operator !=(Standard.
 static Standard.Agents.Models.Brokers.Effects.EffectRecord.operator ==(Standard.Agents.Models.Brokers.Effects.EffectRecord? left, Standard.Agents.Models.Brokers.Effects.EffectRecord? right) -> bool
 static Standard.Agents.Models.Orchestrations.Effects.EffectClaim.operator !=(Standard.Agents.Models.Orchestrations.Effects.EffectClaim? left, Standard.Agents.Models.Orchestrations.Effects.EffectClaim? right) -> bool
 static Standard.Agents.Models.Orchestrations.Effects.EffectClaim.operator ==(Standard.Agents.Models.Orchestrations.Effects.EffectClaim? left, Standard.Agents.Models.Orchestrations.Effects.EffectClaim? right) -> bool
+Standard.Agents.Models.Brokers.Sessions.AgentTurn.Exchanges.get -> System.Collections.Generic.IReadOnlyList<Standard.Agents.Models.Orchestrations.Agents.ToolExchange!>!
+Standard.Agents.Models.Brokers.Sessions.AgentTurn.Exchanges.init -> void

--- a/Standard.Agents/Services/Foundations/Brains/BrainService.V1.cs
+++ b/Standard.Agents/Services/Foundations/Brains/BrainService.V1.cs
@@ -66,6 +66,15 @@ public partial class BrainService
                 Content = turn.Prompt
             };
 
+            // A past turn's calls belong inside that turn, between the prompt that asked for
+            // them and the answer they produced. Held back and flushed after the CURRENT
+            // prompt they read as this turn's evidence, which is how a finished edit becomes a
+            // claim that the file was just edited (SPEC.md 4.11).
+            foreach (ConversationMessage replayed in Replayed(turn.Exchanges))
+            {
+                yield return replayed;
+            }
+
             yield return new ConversationMessage
             {
                 Role = MessageRole.Assistant,
@@ -79,29 +88,9 @@ public partial class BrainService
             Content = context.Prompt
         };
 
-        // Native calls go back as what they were: the assistant's request, then the tool's answer
-        // naming the call it answers (SPEC.md §6). This is the shape hosted models are trained on,
-        // and it is the reason the id exists — narrating "calculator: 4183" would leave the model
-        // matching answers to questions by reading.
-        foreach (ToolExchange exchange in context.ToolExchanges)
+        foreach (ConversationMessage replayed in Replayed(context.ToolExchanges))
         {
-            yield return new ConversationMessage
-            {
-                Role = MessageRole.Assistant,
-
-                ToolCalls =
-                [
-                    new ModelToolCall(
-                        exchange.CallId, exchange.ToolName, exchange.ArgumentsJson)
-                ]
-            };
-
-            yield return new ConversationMessage
-            {
-                Role = MessageRole.Tool,
-                ToolCallId = exchange.CallId,
-                Content = exchange.Result
-            };
+            yield return replayed;
         }
 
         // What is left is everything the exchanges do not already carry — a denial, a screening
@@ -122,6 +111,35 @@ public partial class BrainService
                 Role = MessageRole.Assistant,
                 Content = "Observations so far:\n"
                     + string.Join('\n', narrated.Select(o => $"- {o}"))
+            };
+        }
+    }
+
+    // Native calls go back as what they were: the assistant's request, then the tool's answer
+    // naming the call it answers (SPEC.md 6). This is the shape hosted models are trained on, and
+    // it is the reason the id exists. Narrating "calculator: 4183" would leave the model matching
+    // answers to questions by reading.
+    private static IEnumerable<ConversationMessage> Replayed(
+        IReadOnlyList<ToolExchange> exchanges)
+    {
+        foreach (ToolExchange exchange in exchanges)
+        {
+            yield return new ConversationMessage
+            {
+                Role = MessageRole.Assistant,
+
+                ToolCalls =
+                [
+                    new ModelToolCall(
+                        exchange.CallId, exchange.ToolName, exchange.ArgumentsJson)
+                ]
+            };
+
+            yield return new ConversationMessage
+            {
+                Role = MessageRole.Tool,
+                ToolCallId = exchange.CallId,
+                Content = exchange.Result
             };
         }
     }

--- a/Standard.Agents/Services/Managements/RunManagementService.Sessions.cs
+++ b/Standard.Agents/Services/Managements/RunManagementService.Sessions.cs
@@ -165,7 +165,17 @@ public partial class RunManagementService
             new AgentSession
             {
                 Id = context.SessionId,
-                History = [.. existing?.History ?? [], new AgentTurn(context.Prompt, context.Result)],
+                // What the turn DID travels with what it said. Recording the answer alone was
+                // lossy in a way nothing errored on: the history reloaded, the run completed, and
+                // the calls that produced the answer were simply gone (SPEC.md 4.11, SPEC.md 6).
+                History =
+                [
+                    .. existing?.History ?? [],
+                    new AgentTurn(context.Prompt, context.Result)
+                    {
+                        Exchanges = context.ToolExchanges
+                    }
+                ],
                 Status = context.Status,
                 RunId = AgentRun.Current?.Id ?? string.Empty,
 

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -512,8 +512,10 @@
          turn, between the prompt that asked for them and the answer they produced;
          SaveSessionAsync persists them; AgentTurnV1 carries them on the wire so a stateless
          caller can say which turn a call belongs to. Additive: the shipped constructor,
-         Deconstruct, Prompt and Answer are untouched, so no consumer must react. The model shape
-         changed: segment 1 advances, 2/3/4 reset. -->
+         Deconstruct, Prompt and Answer are untouched, so no consumer must react. Certified by
+         vectors 78 and 79, which fail against a build with the fix suppressed while all 77
+         pre-existing vectors pass against that same build. Spec-first: tracks SPEC.md v1.13
+         (SS3.2, SS4.11, SS6.2). The model shape changed: segment 1 advances, 2/3/4 reset. -->
     <Version>2.0.0.0</Version>
 
     <Authors>Hassan Habib</Authors>

--- a/Standard.Agents/Standard.Agents.csproj
+++ b/Standard.Agents/Standard.Agents.csproj
@@ -498,7 +498,23 @@
          (EnforceSelection, AdvertisedTools - derived from the same 6.1 rendering the catalogs
          use). Spec-first: tracks SPEC.md v1.12 (SS4.15). New routines and models: segment 2
          advances, 3/4 reset. -->
-    <Version>1.16.0.0</Version>
+    <!-- 2.0.0.0 "A Turn Carries Its Work": a turn was a prompt and an answer, so the calls an
+         agent made in order to answer were dropped at the save and could never be recalled.
+         Sessions and native tool calling each worked; the seam between them lost the tool work,
+         and no vector covered the pair - every multi-turn vector runs with no tools, and vector
+         63 proves only that a prior turn's TEXT reaches the Brain. Two symptoms, one missing
+         field: a session forgot what it had already done, and a caller holding a stateless
+         conversation had nowhere to put a finished call except the CURRENT turn's exchange list,
+         where a call already made reads as evidence for the prompt being asked now (the
+         motivating production finding: an editor plugin's agent kept reporting a file edited on
+         every follow-up, because the edit from turn one was replayed under turn two's prompt).
+         AgentTurn.Exchanges carries a turn's own calls; BuildConversation emits them inside that
+         turn, between the prompt that asked for them and the answer they produced;
+         SaveSessionAsync persists them; AgentTurnV1 carries them on the wire so a stateless
+         caller can say which turn a call belongs to. Additive: the shipped constructor,
+         Deconstruct, Prompt and Answer are untouched, so no consumer must react. The model shape
+         changed: segment 1 advances, 2/3/4 reset. -->
+    <Version>2.0.0.0</Version>
 
     <Authors>Hassan Habib</Authors>
     <Company>Hassan Habib</Company>

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -193,6 +193,7 @@ the deterministic core of the Standard.
 | `open-circuit-falls-back-to-secondary` | An unhealthy provider degrades rather than fails (§4.10) |
 | `open-circuit-falls-back-on-the-native-protocol` | The same degradation on the native seam; the text alternative becomes a final answer, never a cast (§4.10, §6) |
 | `conversation-carries-history` | A follow-up resolves against what came before (§4.11) |
+| `a-session-carries-a-turns-tool-call` | A turn's calls survive the save with its words; the next prompt is told what the agent did, not only what it said (§4.11, §6) |
 | `failed-run-unwinds-in-reverse` | Compensation undoes what was performed, newest first (§4.9) |
 | `effect-outcome-survives-a-crash` | A new instance resumes and does not repeat the act (§4.9, §4.11) |
 | `awaiting-approval-resumes-in-a-new-process` | A held act runs once the authority says yes, elsewhere |
@@ -214,6 +215,7 @@ the deterministic core of the Standard.
 | `caller-tool-name-collision-drops-caller-tool` | A caller cannot shadow the deployment's own tool; configured wins |
 | `pending-call-rides-the-outcome-without-a-session` | A stateless exposer reads the caller's call off the outcome itself |
 | `the-callers-transcript-reaches-the-brain` | A prior turn re-posted by the caller reaches the Brain; the run never starts from nothing |
+| `the-callers-transcript-carries-a-turns-tool-call` | A prior turn's CALLS travel on the request as its words do, so a finished call is never handed over as this turn's evidence (§4.11, §6) |
 | `a-model-narrates-before-acting` | A leading SAY: line is narration — peeled, screened, voiced; never the act, never the answer (§6.0) |
 | `a-refused-narration-is-withheld` | A refused narration reaches no channel at all, and the run is unharmed (Invariant 5, §4.9) |
 | `a-tool-narrates-and-the-model-says-nothing` | A tool's declared templates are the floor: the run never goes silent because the model was terse (§6.0) |

--- a/conformance/vectors/78-a-session-carries-a-turns-tool-call.json
+++ b/conformance/vectors/78-a-session-carries-a-turns-tool-call.json
@@ -1,0 +1,27 @@
+{
+  "name": "a-session-carries-a-turns-tool-call",
+  "description": "SPEC.md 4.11 and SPEC.md 6 together, which is where they were never certified as a pair. A turn is not only what was said; it is what the agent did in order to be able to say it. A session that records the answer and drops the call that produced it tells the next prompt that the agent answered and never how, so the agent forgets what it already did. Every other multi-turn vector runs with no tools and vector 29 runs a single prompt, so the seam between sessions and native tool calling was covered by nothing. Two prompts share a session; the first calls the tool, and the second must still be handed that call and the answer naming it.",
+  "generatorReplies": [],
+  "nativeReplies": [
+    {
+      "toolCalls": [
+        {
+          "id": "call_7",
+          "name": "calculator",
+          "argumentsJson": "{\"expression\":\"47*89\"}"
+        }
+      ]
+    },
+    { "content": "4183" },
+    { "content": "I multiplied 47 by 89." }
+  ],
+  "tools": { "calculator": "4183" },
+  "prompt": "what is 47 times 89?",
+  "prompts": ["what is 47 times 89?", "how did you get that?"],
+  "sessionId": "conformance-session-tools",
+  "expect": {
+    "result": "I multiplied 47 by 89.",
+    "toolRunCount": { "calculator": 1 },
+    "toolResultAnswersCall": "call_7"
+  }
+}

--- a/conformance/vectors/79-the-callers-transcript-carries-a-turns-tool-call.json
+++ b/conformance/vectors/79-the-callers-transcript-carries-a-turns-tool-call.json
@@ -1,0 +1,28 @@
+{
+  "name": "the-callers-transcript-carries-a-turns-tool-call",
+  "description": "The sibling vector 63 never had. The exposed protocols are stateless and the client re-posts the conversation, so a prior turn's CALLS have to travel on the request exactly as its words do. Without a per-turn home for them a caller has nowhere to put a finished call but the request's own toolExchanges, which is this turn's in-flight work: a call replayed there is handed to the model as evidence for the prompt being asked now, and a finished edit reads as an edit just made. A prior turn's call carried on the request must reach the Brain as that turn's call.",
+  "generatorReplies": [],
+  "nativeReplies": [{ "content": "ok" }],
+  "tools": {},
+  "prompt": "and then?",
+  "request": {
+    "history": [
+      {
+        "prompt": "what is 47 times 89?",
+        "answer": "4183",
+        "exchanges": [
+          {
+            "callId": "call_7",
+            "toolName": "calculator",
+            "argumentsJson": "{\"expression\":\"47*89\"}",
+            "result": "4183"
+          }
+        ]
+      }
+    ]
+  },
+  "expect": {
+    "result": "ok",
+    "toolResultAnswersCall": "call_7"
+  }
+}

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -925,6 +925,12 @@ await agent.ProcessPromptAsync("and how many people live there?", sessionId: "tr
 // the second prompt knows "there" means Paris
 ```
 
+**A turn carries what it did, not only what it said.** When the agent calls a tool to answer, that
+call and its result are recorded on the turn beside the answer, and replayed inside that turn on the
+next prompt. Without it the follow-up is told the agent answered and never how, so the agent forgets
+what it already looked up and what it already performed — and a conversation that cannot remember
+its own acts is a poor place to reason about whether to repeat one.
+
 History is bounded — `.Sessions(path, maxHistoryTurns: 20)` — because an unbounded conversation
 makes every prompt cost more than the last, without limit. A cancelled or budget-stopped run is
 never written back as an answer: the next prompt would otherwise be told the agent said something
@@ -1489,12 +1495,15 @@ Two more fields deserve a word:
   `CallId` so the caller's result can answer it. A caller tool sharing a configured tool's name
   is dropped at the boundary: a caller cannot shadow the deployment's own tool.
 
-- **`History` and `ToolExchanges`** — the caller-owned transcript. The exposed protocols are
-  stateless: the client re-posts the conversation, prior tool results included, and the run
-  receives it here — prior turns render into the conversation on both protocols, and a
-  replayed exchange returns as a tool message still naming the call the model minted. When a
-  session exists it wins: the deployment's record of the conversation beats the caller's
-  retelling of it.
+- **`History` and `ToolExchanges`** — the caller-owned transcript, and this turn's in-flight
+  work. They are not interchangeable. The exposed protocols are stateless: the client re-posts
+  the conversation and the run receives it in `History`, where each `AgentTurn` carries its own
+  `Exchanges` — the calls that turn made and what they returned — so a past call is replayed
+  inside the turn it belongs to, still naming the call the model minted. `ToolExchanges` is
+  narrower: it is the work of the turn being asked *now*, a caller answering a call this run is
+  still waiting on. A finished call put there is handed to the model as evidence for the current
+  prompt, which is how an edit made three turns ago reads as an edit just made. When a session
+  exists it wins: the deployment's record of the conversation beats the caller's retelling of it.
 
 - **Parallel tool calls** — one pending call per run, today. A decider that can emit several
   (set `parallel_tool_calls: false` where the provider supports it) hands them back one turn at


### PR DESCRIPTION
Tracks SPEC v1.13 (hassanhabib/The-Standard-Agent-Specs#33), sections 3.2, 4.11 and 6.2.

## The defect

`AgentTurn` was `(Prompt, Answer)`. It had nowhere to keep the calls a turn made, so `SaveSessionAsync` recorded the answer and dropped the tool work, and `BuildConversation` had only one place to put calls at all: after the current prompt.

Sessions worked. Native tool calling worked. The seam between them lost the work, and it produced two different symptoms depending on who holds the conversation:

- **The framework holds it.** A session forgets what it already did. The agent cannot see the search it ran or the effect it performed, which is a poor position from which to decide whether to repeat one.
- **A caller holds it.** Any stateless client re-posts the whole conversation and has nowhere to put a finished call but the request's own `ToolExchanges`, which is this turn's in-flight work. Replayed there, the model is handed a completed call as evidence for the prompt being asked now. The reference deployment watched an editor client report a file edited on every follow-up. The model was not hallucinating; it was reporting the evidence it was given.

## The fix

- `AgentTurn` gains `Exchanges`, additive and init-only. The shipped constructor, `Deconstruct`, `Prompt` and `Answer` are untouched, so no consumer must react. The PublicAPI analyzer flagged exactly two new members and nothing else.
- `BuildConversation` emits a past turn's calls inside that turn, between the prompt that asked for them and the answer they produced, through a `Replayed` helper it now shares with the current turn.
- `SaveSessionAsync` persists them; `AgentTurnV1` and the controller mapping carry them on the wire.

## Why the suite missed it

The vector schema could not express the case. `TurnSpec` was `Prompt` and `Answer`, mirroring the model it described, so the pair was unwritable: every multi-turn vector ran with no tools, vector 29 ran a single prompt, and vector 63 proved only that a prior turn's *text* reaches the Brain.

`TurnSpec` now carries `Exchanges`, and two vectors follow: **78** for the session case, **79** for the stateless caller.

## Verification

- `ShouldCarryAToolExchangeAcrossPromptsInOneSessionAsync` was committed red first and verified failing on net8.0 and net10.0.
- `ShouldNotCarryOneSessionsToolExchangeIntoAnotherAsync` is a guard, not a driver: against a deliberately wrong fix that keeps exchanges off the session it is the only one of the nine session tests that fails, while the carrying test stays green.
- Vectors 78 and 79 both fail against a build with the fix suppressed, while **all 77 pre-existing vectors pass against that same build**. That is the measure of how long this could have gone unnoticed.
- Full release gate locally: 808 unit tests, 79 vectors, Enterprise CERTIFIED, Critical CERTIFIED, 6 evals.
- Consumer validated before release: the PeerLLM orchestrator builds and its 624 tests pass against a locally packed 2.0.0.

Version 1.16.0.0 to 2.0.0.0: the model shape changed, so segment 1 advances and the rest reset.