### PR TITLE
MINOR CLIENTS: The Ledger's Lease Is The Deployment's To Set

### DIFF
--- a/Standard.Agents.Tests.Unit/Acceptance/EffectLedgerReconciliationTests.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/EffectLedgerReconciliationTests.cs
@@ -203,6 +203,56 @@ public class EffectLedgerReconciliationTests : IDisposable
         actualOutcome.Result.Should().Be("already paid");
     }
 
+    // The lease is how long an in-flight claim is presumed live; a deployment whose tools take
+    // longer than the default five minutes, or far less, says so once at composition.
+    [Fact]
+    public async Task ShouldClaimUnderTheConfiguredLeaseAsync()
+    {
+        // given
+        var ledger = new CapturingLedger();
+        var tool = new CountingTool();
+        TimeSpan configuredLease = TimeSpan.FromSeconds(30);
+
+        StandardAgent agent = NewProcess(ledger, tool, Proposal, "FINAL: paid")
+            .EffectLease(configuredLease);
+
+        // when
+        AgentOutcome actualOutcome =
+            await agent.RunAsync(Request("pay the invoice"), CancellationToken.None);
+
+        // then — the act's claim was written for exactly the configured window
+        actualOutcome.Status.Should().Be(AgentStatus.Responded);
+        tool.ExecutionCount.Should().Be(1);
+
+        EffectRecord actualClaim = ledger.Claims.Should().ContainSingle().Subject;
+        (actualClaim.LeaseUntil - actualClaim.ClaimedOn).Should().Be(configuredLease);
+        actualClaim.ToolName.Should().Be("wire_transfer");
+    }
+
+    // Keeps every claim the agent writes, so a test can read the lease it was written under.
+    private sealed class CapturingLedger : IEffectLedgerBroker
+    {
+        private readonly InMemoryEffectLedgerBroker store = new();
+
+        public List<EffectRecord> Claims { get; } = [];
+
+        public ValueTask<bool> InsertClaimAsync(EffectRecord claim)
+        {
+            this.Claims.Add(claim);
+
+            return this.store.InsertClaimAsync(claim);
+        }
+
+        public ValueTask<EffectRecord?> SelectRecordAsync(string idempotencyKey) =>
+            this.store.SelectRecordAsync(idempotencyKey);
+
+        public ValueTask UpdateRecordAsync(EffectRecord record) =>
+            this.store.UpdateRecordAsync(record);
+
+        public ValueTask DeleteRecordAsync(string idempotencyKey) =>
+            this.store.DeleteRecordAsync(idempotencyKey);
+    }
+
     [Fact]
     public async Task ShouldRecordAFailedAttemptAndHoldItsRepeatAsync()
     {

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.Semantics.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.FromJson.Semantics.cs
@@ -105,6 +105,7 @@ public partial class StandardAgentFromJsonTests
     [InlineData(
         """{ "mcp": { "endpointUrl": "http://mcp.test/", "timeoutSeconds": 0 } }""",
         "'mcp.timeoutSeconds' must be a positive number.")]
+    [InlineData("""{ "effectLeaseSeconds": 0 }""", "'effectLeaseSeconds' must be a positive number.")]
     public void ShouldThrowInvalidAgentConfigurationExceptionOnFromJsonIfALimitIsNotPositive(
         string json,
         string expectedMessage) =>

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Guardians.Act.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.Guardians.Act.cs
@@ -33,7 +33,10 @@ public partial class DirectionCoordinationServiceTests
                 new ApprovalService(
                     new NotConfiguredApprovalBroker(), this.loggingBrokerMock.Object),
                 new EffectLedgerService(
-                    new InMemoryEffectLedgerBroker(), new TimeBroker(), this.loggingBrokerMock.Object),
+                    new InMemoryEffectLedgerBroker(),
+                    new TimeBroker(),
+                    this.loggingBrokerMock.Object,
+                    TimeSpan.FromMinutes(5)),
                 new TimeBroker(),
                 this.loggingBrokerMock.Object),
             executionService: NewExecution(),
@@ -72,7 +75,10 @@ public partial class DirectionCoordinationServiceTests
                 new ApprovalService(
                     new NotConfiguredApprovalBroker(), this.loggingBrokerMock.Object),
                 new EffectLedgerService(
-                    new InMemoryEffectLedgerBroker(), new TimeBroker(), this.loggingBrokerMock.Object),
+                    new InMemoryEffectLedgerBroker(),
+                    new TimeBroker(),
+                    this.loggingBrokerMock.Object,
+                    TimeSpan.FromMinutes(5)),
                 new TimeBroker(),
                 this.loggingBrokerMock.Object),
             executionService: NewExecution(),

--- a/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Coordinations/DirectionNature/DirectionCoordinationServiceTests.cs
@@ -54,7 +54,10 @@ public partial class DirectionCoordinationServiceTests
             new PolicyService(new NotConfiguredPolicyBroker(), this.loggingBrokerMock.Object),
             new ApprovalService(new NotConfiguredApprovalBroker(), this.loggingBrokerMock.Object),
             new EffectLedgerService(
-                new InMemoryEffectLedgerBroker(), new TimeBroker(), this.loggingBrokerMock.Object),
+                new InMemoryEffectLedgerBroker(),
+                new TimeBroker(),
+                this.loggingBrokerMock.Object,
+                TimeSpan.FromMinutes(5)),
             new TimeBroker(),
             this.loggingBrokerMock.Object);
 

--- a/Standard.Agents.Tests.Unit/Services/Foundations/Perimeter/PerimeterFoundationTests.cs
+++ b/Standard.Agents.Tests.Unit/Services/Foundations/Perimeter/PerimeterFoundationTests.cs
@@ -53,7 +53,8 @@ public partial class PerimeterFoundationTests
         this.effectLedgerService = new EffectLedgerService(
             effectLedgerBroker: this.effectLedgerBrokerMock.Object,
             timeBroker: this.timeBrokerMock.Object,
-            loggingBroker: this.loggingBrokerMock.Object);
+            loggingBroker: this.loggingBrokerMock.Object,
+            lease: lease);
     }
 
     private static string CreateRandomString() =>

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+*REMOVED*Standard.Agents.Services.Foundations.EffectLedgers.EffectLedgerService.EffectLedgerService(Standard.Agents.Brokers.Effects.IEffectLedgerBroker! effectLedgerBroker, Standard.Agents.Brokers.Times.ITimeBroker! timeBroker, Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker) -> void
+Standard.Agents.Services.Foundations.EffectLedgers.EffectLedgerService.EffectLedgerService(Standard.Agents.Brokers.Effects.IEffectLedgerBroker! effectLedgerBroker, Standard.Agents.Brokers.Times.ITimeBroker! timeBroker, Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker, System.TimeSpan lease) -> void
+Standard.Agents.StandardAgent.EffectLease(System.TimeSpan lease) -> Standard.Agents.StandardAgent!

--- a/Standard.Agents/Services/Foundations/EffectLedgers/EffectLedgerService.cs
+++ b/Standard.Agents/Services/Foundations/EffectLedgers/EffectLedgerService.cs
@@ -13,23 +13,26 @@ namespace Standard.Agents.Services.Foundations.EffectLedgers;
 
 public partial class EffectLedgerService : IEffectLedgerService
 {
-    // How long an in-flight claim is presumed live. Past it, a claim with no outcome is an
-    // earlier attempt whose fate is unknown, and a repeat is held for reconciliation rather than
-    // presumed either way (principal review 2026-09-04, F-08).
-    private static readonly TimeSpan Lease = TimeSpan.FromMinutes(5);
-
     private readonly IEffectLedgerBroker effectLedgerBroker;
     private readonly ITimeBroker timeBroker;
     private readonly ILoggingBroker loggingBroker;
 
+    // How long an in-flight claim is presumed live. Past it, a claim with no outcome is an
+    // earlier attempt whose fate is unknown, and a repeat is held for reconciliation rather than
+    // presumed either way (principal review 2026-09-04, F-08). The deployment sets it, because
+    // only the deployment knows how long its tools take.
+    private readonly TimeSpan lease;
+
     public EffectLedgerService(
         IEffectLedgerBroker effectLedgerBroker,
         ITimeBroker timeBroker,
-        ILoggingBroker loggingBroker)
+        ILoggingBroker loggingBroker,
+        TimeSpan lease)
     {
         this.effectLedgerBroker = effectLedgerBroker;
         this.timeBroker = timeBroker;
         this.loggingBroker = loggingBroker;
+        this.lease = lease;
     }
 
     public ValueTask<EffectRecord?> ClaimEffectAsync(AgentEffect effect) =>
@@ -45,7 +48,7 @@ public partial class EffectLedgerService : IEffectLedgerService
             State = EffectState.InFlight,
             Owner = effect.RunId,
             ClaimedOn = now,
-            LeaseUntil = now + Lease
+            LeaseUntil = now + this.lease
         };
 
         bool claimed = await this.effectLedgerBroker.InsertClaimAsync(claim);

--- a/Standard.Agents/StandardAgent.Composition.cs
+++ b/Standard.Agents/StandardAgent.Composition.cs
@@ -447,7 +447,8 @@ public sealed partial class StandardAgent
                 new EffectLedgerService(
                     this.effectLedgerBroker ?? new InMemoryEffectLedgerBroker(),
                     new TimeBroker(),
-                    logging),
+                    logging,
+                    this.effectLease),
                 new TimeBroker(),
                 logging),
             new ExecutionOrchestrationService(

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -369,6 +369,12 @@ public partial class StandardAgent
 
                 break;
 
+            case "effectLeaseSeconds":
+                agent.EffectLease(
+                    TimeSpan.FromSeconds(PositiveNumber(Number(value, key), key)));
+
+                break;
+
             case "screenToolOutput" when Truth(value, key):
                 agent.ScreenToolOutput();
 
@@ -679,6 +685,12 @@ public partial class StandardAgent
 
     private static double Number(JsonNode? node, string key, string property, double fallback) =>
         NumberNode(node, key, property)?.GetValue<double>() ?? fallback;
+
+    private static double Number(JsonNode? node, string key) =>
+        node?.GetValueKind() is JsonValueKind.Number
+            ? node.GetValue<double>()
+            : throw new InvalidAgentConfigurationException(
+                $"'{key}' must be a number.");
 
     private static int Whole(JsonNode? node, string key) =>
         node?.GetValueKind() is JsonValueKind.Number

--- a/Standard.Agents/StandardAgent.cs
+++ b/Standard.Agents/StandardAgent.cs
@@ -125,6 +125,7 @@ public sealed partial class StandardAgent : IAgent
     private IPolicyBroker? policyBroker;
     private IApprovalBroker? approvalBroker;
     private IEffectLedgerBroker? effectLedgerBroker;
+    private TimeSpan effectLease = TimeSpan.FromMinutes(5);
     private IEnumerable<string>? approvalRequiredTools;
     private bool screenToolOutput;
     private bool compensateOnFailure;
@@ -802,6 +803,17 @@ public sealed partial class StandardAgent : IAgent
     /// <returns>The same agent, so calls can be chained.</returns>
     public StandardAgent EffectLedger(string path) =>
         Set(() => this.effectLedgerBroker = new FileEffectLedgerBroker(path));
+
+    /// <summary>
+    /// How long the ledger presumes an in-flight claim to be live. Past the lease, a claim with
+    /// no recorded outcome is an earlier attempt whose fate is unknown, and a repeat of the act
+    /// is held for reconciliation rather than performed or presumed done (SPEC.md §4.9). Five
+    /// minutes by default; set it to how long your slowest tool can take.
+    /// </summary>
+    /// <param name="lease">How long a claim stays live without an outcome.</param>
+    /// <returns>The same agent, so calls can be chained.</returns>
+    public StandardAgent EffectLease(TimeSpan lease) =>
+        Set(() => this.effectLease = lease);
 
     /// <summary>
     /// Keeps the effect ledger wherever you say, in your own code — usually the store your

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1050,6 +1050,10 @@ claimed 2026-09-05 16:55:41Z); reconcile the ledger against the world - record t
 outcome, or release the claim - before this act can run again.
 ```
 
+The lease is five minutes by default; a deployment whose slowest tool takes longer, or far
+less, says so once: `.EffectLease(TimeSpan.FromMinutes(20))`, or `"effectLeaseSeconds": 1200`
+in the document.
+
 Reconciling is a person's act against the store you chose: read the record by the pending
 effect's `IdempotencyKey`, check the world, and either update it to `Completed` with the real
 outcome (the next run replays it) or delete the in-flight claim (the next run performs it). The


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-08 follow-up. The effect ledger presumed an in-flight claim live for five minutes, as a constant in the foundation. Only a deployment knows how long its slowest tool takes.

## Change

- StandardAgent.EffectLease(TimeSpan) and the document key effectLeaseSeconds (refused unless positive) set the lease; five minutes stays the default.
- EffectLedgerService takes the lease in its constructor instead of a constant (REMOVED and new lines in PublicAPI.Unshipped.txt).
- how-to section 12 documents it.

## Tests

- ShouldClaimUnderTheConfiguredLeaseAsync: a claim written by a real run carries exactly the configured window.
- The non-positive document case joins the semantic validation theory.
- Unit 810 passed on net8.0 and net10.0; conformance 79 passed; Critical certified; evals 6 passed.

Versioning: a routine change, second segment.