### PR TITLE
MINOR HOSTS: Identity Comes From The Authenticated User, Never From The Wire

### DIFF
--- a/Standard.Agents.Host/Program.cs
+++ b/Standard.Agents.Host/Program.cs
@@ -7,6 +7,7 @@
 // behind HTTP: composition here is configuration, never new concepts - the appliance
 // guarantee holds at the exposure layer too.
 
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -51,6 +52,33 @@ builder.Services.AddControllers();
 // put a proxy, a certificate, a resilience handler or an observer under all of it.
 builder.Services.AddHttpClient(AgentHttpClientName);
 
+// Who is acting comes from the request's authenticated user, translated per act into the
+// principal the policy decides on and the audit stamps (principal review 2026-09-04, F-10). The
+// wire has no field in which a caller can claim to be someone; the scheme establishes them.
+// Bearer tokens are the scheme in the box: name the issuer (Host:Authentication:Authority) and,
+// optionally, the audience, and every agent route wants a valid token. Name nothing and the
+// door is as open as before, with no principal handed to the agent.
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddSingleton<HttpPrincipalResolver>();
+
+string? authority = builder.Configuration["Host:Authentication:Authority"];
+bool authenticationConfigured = string.IsNullOrWhiteSpace(authority) is false;
+
+if (authenticationConfigured)
+{
+    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        .AddJwtBearer(options =>
+        {
+            options.Authority = authority;
+            options.Audience = builder.Configuration["Host:Authentication:Audience"];
+            options.MapInboundClaims = false;
+        });
+}
+else
+{
+    builder.Services.AddAuthentication();
+}
+
 // Exporting is opt-in by the standard OTel switch: set OTEL_EXPORTER_OTLP_ENDPOINT and the
 // agent's spans and metrics (plus the HTTP server's) leave for your collector; leave it unset
 // and nothing is wired, so the default host stays exactly what it was. The library side needs
@@ -80,6 +108,8 @@ builder.Services.AddSingleton<IAgent>(provider =>
 
     IHttpMessageHandlerFactory httpHandlers =
         provider.GetRequiredService<IHttpMessageHandlerFactory>();
+
+    HttpPrincipalResolver principals = provider.GetRequiredService<HttpPrincipalResolver>();
 
     // The agent as data: Agent:Config names a JSON document, or an agent.json beside the
     // executable is picked up on its own — a low-code platform writes a file and has an agent,
@@ -125,7 +155,9 @@ builder.Services.AddSingleton<IAgent>(provider =>
                     + "\"nativeBrainAnthropic\" to agent.json, then restart the host.");
         }
 
-        return configured.Http(() => httpHandlers.CreateHandler(AgentHttpClientName));
+        return configured
+            .Principal(principals.Resolve)
+            .Http(() => httpHandlers.CreateHandler(AgentHttpClientName));
     }
 
     string? url = configuration["Agent:Url"];
@@ -163,7 +195,9 @@ builder.Services.AddSingleton<IAgent>(provider =>
     // laptop and load-bearing behind a collector.
     agent.Telemetry(configuration["Agent:Name"] ?? "standard-agent");
 
-    return agent.Http(() => httpHandlers.CreateHandler(AgentHttpClientName));
+    return agent
+        .Principal(principals.Resolve)
+        .Http(() => httpHandlers.CreateHandler(AgentHttpClientName));
 });
 
 var app = builder.Build();
@@ -171,22 +205,39 @@ var app = builder.Build();
 // The front door, before the routes: no configured Host:ApiKey means open (a laptop), one
 // configuration line means every agent route wants X-Api-Key (a deployment). The heartbeat
 // stays open either way - a probe cannot present a key and learns nothing.
+app.UseAuthentication();
+
 app.Use(async (context, next) =>
 {
-    bool allowed = ApiKeyGate.Allows(
+    bool keyAllowed = ApiKeyGate.Allows(
         configuredKey: app.Configuration["Host:ApiKey"],
         presentedKey: context.Request.Headers["X-Api-Key"],
         path: context.Request.Path);
 
-    if (allowed)
+    if (keyAllowed is false)
     {
-        await next();
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        await context.Response.WriteAsync("missing or invalid X-Api-Key");
 
         return;
     }
 
-    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-    await context.Response.WriteAsync("missing or invalid X-Api-Key");
+    // The second lock: with authentication configured, an agent route wants an authenticated
+    // user, established by the scheme above and handed to the agent as the principal.
+    bool identityAllowed = IdentityGate.Allows(
+        authenticationConfigured,
+        userIsAuthenticated: context.User.Identity?.IsAuthenticated is true,
+        path: context.Request.Path);
+
+    if (identityAllowed is false)
+    {
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        await context.Response.WriteAsync("an authenticated user is required");
+
+        return;
+    }
+
+    await next();
 });
 
 app.MapControllers();

--- a/Standard.Agents.Host/Properties/launchSettings.json
+++ b/Standard.Agents.Host/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Standard.Agents.Host": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:55838;http://localhost:55839"
+    }
+  }
+}

--- a/Standard.Agents.Host/Security/HttpPrincipalResolver.cs
+++ b/Standard.Agents.Host/Security/HttpPrincipalResolver.cs
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Security.Claims;
+using Standard.Agents.Models.Orchestrations.Effects;
+
+namespace Standard.Agents.Host.Security;
+
+/// <summary>
+/// Who is acting, read from the request's authenticated user and handed to the agent per act
+/// (SPEC.md §4.9). Whatever scheme the deployment configured established the user; this only
+/// translates the claims the token world uses into the principal the policy decides on and the
+/// audit stamps. An anonymous request, or no request at all, resolves to nobody: the framework
+/// consumes a principal and never mints one (principal review 2026-09-04, F-10).
+/// </summary>
+public sealed class HttpPrincipalResolver
+{
+    private readonly IHttpContextAccessor httpContextAccessor;
+
+    public HttpPrincipalResolver(IHttpContextAccessor httpContextAccessor) =>
+        this.httpContextAccessor = httpContextAccessor;
+
+    public AgentPrincipal? Resolve()
+    {
+        ClaimsPrincipal? user = this.httpContextAccessor.HttpContext?.User;
+
+        if (user?.Identity?.IsAuthenticated is not true)
+        {
+            return null;
+        }
+
+        // "sub" is the token's subject; NameIdentifier is the same thing in .NET's vocabulary
+        // after the default inbound mapping; the identity's name is the last resort.
+        string? id = user.FindFirst("sub")?.Value
+            ?? user.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? user.Identity.Name;
+
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return null;
+        }
+
+        return new AgentPrincipal
+        {
+            Id = id,
+            TenantId = user.FindFirst("tid")?.Value ?? user.FindFirst("tenant")?.Value,
+            Jurisdiction = user.FindFirst("jurisdiction")?.Value,
+            DelegatedBy = user.FindFirst("act")?.Value
+        };
+    }
+}

--- a/Standard.Agents.Host/Security/IdentityGate.cs
+++ b/Standard.Agents.Host/Security/IdentityGate.cs
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Host.Security;
+
+/// <summary>
+/// The second lock on the front door. When the deployment configured authentication, an agent
+/// route wants an authenticated user; the heartbeat stays open either way, and a deployment that
+/// configured nothing is as open as before (principal review 2026-09-04, F-10).
+/// </summary>
+public static class IdentityGate
+{
+    public static bool Allows(bool authenticationConfigured, bool userIsAuthenticated, string path) =>
+        authenticationConfigured is false
+            || string.Equals(path, "/api/home", StringComparison.OrdinalIgnoreCase)
+            || userIsAuthenticated;
+}

--- a/Standard.Agents.Host/Standard.Agents.Host.csproj
+++ b/Standard.Agents.Host/Standard.Agents.Host.csproj
@@ -20,6 +20,11 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <!-- Bearer-token authentication from configuration (Host:Authentication:Authority and
+         Audience): the one scheme most estates already run an issuer for. One line per target,
+         because the handler must match the ASP.NET Core runtime it runs on (F-10). -->
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.30" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
 </Project>

--- a/Standard.Agents.Tests.Unit/Acceptance/Host/HostAcceptanceTests.Identity.cs
+++ b/Standard.Agents.Tests.Unit/Acceptance/Host/HostAcceptanceTests.Identity.cs
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Standard.Agents.Host.Models.V1;
+using Standard.Agents.Host.Security;
+using Standard.Agents.Tools;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Acceptance.Host;
+
+public partial class HostAcceptanceTests
+{
+    // A scheme that believes the Authorization header: "Test <subject>" authenticates as that
+    // subject with a tenant claim. It stands in for whatever the deployment configures - JWT
+    // bearer from the host's configuration, or a proxy's headers - which is exactly the point:
+    // the host hands the agent whoever the scheme established, and nothing else.
+    private sealed class TestAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public TestAuthenticationHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            string header = this.Request.Headers.Authorization.ToString();
+
+            if (header.StartsWith("Test ", StringComparison.Ordinal) is false)
+            {
+                return AuthenticateResult.NoResult();
+            }
+
+            var identity = new ClaimsIdentity(
+                [new Claim("sub", header["Test ".Length..]), new Claim("tid", "peerllm")],
+                authenticationType: "Test");
+
+            return AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(identity), "Test"));
+        }
+    }
+
+    private sealed class WireTool : ITool
+    {
+        public string Name => "wire";
+
+        public string Description => "Moves money.";
+
+        public async ValueTask<string> ExecuteAsync(string input) => "sent";
+    }
+
+    // The real agent behind the door this time, composed the way the host composes it: the
+    // principal comes from the host's resolver over the request's authenticated user, and an act
+    // that needs approval is held with that principal on the pending effect.
+    private WebApplicationFactory<Program> CreateAuthenticatedHost() =>
+        this.hostFactory.WithWebHostBuilder(builder => builder.ConfigureServices(services =>
+        {
+            services.AddAuthentication("Test")
+                .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>("Test", _ => { });
+
+            services.AddSingleton<IAgent>(provider =>
+                new StandardAgent()
+                    .WithoutMemory()
+                    .Tool(new WireTool())
+                    .RequireApproval("wire")
+                    .Principal(provider.GetRequiredService<HttpPrincipalResolver>().Resolve)
+                    .OnBrain(async (systemPrompt, userPrompt) => "ACTION: wire: 100"));
+        }));
+
+    [Fact]
+    public async Task ShouldHandTheAuthenticatedUserToTheAgentAsThePrincipalThroughHttpAsync()
+    {
+        // given
+        using WebApplicationFactory<Program> authenticatedHost = CreateAuthenticatedHost();
+        using HttpClient client = authenticatedHost.CreateClient();
+        client.DefaultRequestHeaders.Add("Authorization", "Test hassan");
+
+        // when
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            "api/V1/agents/runs",
+            new AgentRunRequestV1 { Prompt = "wire the money" },
+            wireOptions);
+
+        AgentRunResponseV1? actualResponse =
+            await response.Content.ReadFromJsonAsync<AgentRunResponseV1>(wireOptions);
+
+        // then — held for approval, and the act names who asked, as the scheme established it
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        actualResponse!.Status.Should().Be("AwaitingApproval");
+        actualResponse.PendingEffect.Should().NotBeNull();
+        actualResponse.PendingEffect!.Principal.Should().Be("hassan");
+    }
+
+    [Fact]
+    public async Task ShouldHandNoPrincipalToTheAgentForAnAnonymousRequestThroughHttpAsync()
+    {
+        // given — the same host, no credential presented, no authentication configured to require one
+        using WebApplicationFactory<Program> authenticatedHost = CreateAuthenticatedHost();
+        using HttpClient client = authenticatedHost.CreateClient();
+
+        // when
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            "api/V1/agents/runs",
+            new AgentRunRequestV1 { Prompt = "wire the money" },
+            wireOptions);
+
+        AgentRunResponseV1? actualResponse =
+            await response.Content.ReadFromJsonAsync<AgentRunResponseV1>(wireOptions);
+
+        // then — nobody was invented
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        actualResponse!.PendingEffect!.Principal.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ShouldRequireAnAuthenticatedUserOnAgentRoutesWhenAuthenticationIsConfiguredAsync()
+    {
+        // given — a deployment that configured bearer authentication against an issuer
+        using WebApplicationFactory<Program> lockedHost = this.hostFactory.WithWebHostBuilder(builder =>
+            builder.UseSetting("Host:Authentication:Authority", "https://issuer.test/"));
+
+        using HttpClient client = lockedHost.CreateClient();
+
+        // when — no token at all
+        using HttpResponseMessage runResponse = await client.PostAsJsonAsync(
+            "api/V1/agents/runs",
+            new AgentRunRequestV1 { Prompt = "what is owed" },
+            wireOptions);
+
+        using HttpResponseMessage heartbeat = await client.GetAsync("api/home");
+
+        // then — the agent route is 401 before any run starts; the heartbeat stays open
+        runResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        heartbeat.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/Standard.Agents.Tests.Unit/Controllers/HttpPrincipalResolverTests.cs
+++ b/Standard.Agents.Tests.Unit/Controllers/HttpPrincipalResolverTests.cs
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Standard.Agents.Host.Security;
+using Standard.Agents.Models.Orchestrations.Effects;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Controllers;
+
+// Found in the 2026-09-04 principal review (F-10): the host's API key proved possession of one
+// secret and established nobody. Identity now comes from the request's authenticated user, which
+// whatever scheme the deployment configured established, and is handed to the agent per act as
+// the principal the policy decides on and the audit stamps (SPEC.md §4.9). The wire still has
+// no field in which a caller can claim to be someone.
+public class HttpPrincipalResolverTests
+{
+    private static HttpPrincipalResolver ResolverFor(ClaimsPrincipal? user)
+    {
+        var accessor = new HttpContextAccessor();
+
+        if (user is not null)
+        {
+            accessor.HttpContext = new DefaultHttpContext { User = user };
+        }
+
+        return new HttpPrincipalResolver(accessor);
+    }
+
+    [Fact]
+    public void ShouldResolveTheAuthenticatedUserAsThePrincipal()
+    {
+        // given — the claims a bearer token carries, in the names the token world uses
+        var identity = new ClaimsIdentity(
+            [
+                new Claim("sub", "hassan"),
+                new Claim("tid", "peerllm"),
+                new Claim("jurisdiction", "US-WA"),
+                new Claim("act", "ops-bot")
+            ],
+            authenticationType: "Bearer");
+
+        HttpPrincipalResolver resolver = ResolverFor(new ClaimsPrincipal(identity));
+
+        var expectedPrincipal = new AgentPrincipal
+        {
+            Id = "hassan",
+            TenantId = "peerllm",
+            Jurisdiction = "US-WA",
+            DelegatedBy = "ops-bot"
+        };
+
+        // when
+        AgentPrincipal? actualPrincipal = resolver.Resolve();
+
+        // then
+        actualPrincipal.Should().BeEquivalentTo(expectedPrincipal);
+    }
+
+    [Fact]
+    public void ShouldResolveTheNameIdentifierWhenThereIsNoSubjectClaim()
+    {
+        // given — an identity in the .NET claim vocabulary rather than the token one
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.NameIdentifier, "hassan@peerllm.com")],
+            authenticationType: "Cookies");
+
+        HttpPrincipalResolver resolver = ResolverFor(new ClaimsPrincipal(identity));
+        var expectedPrincipal = new AgentPrincipal { Id = "hassan@peerllm.com" };
+
+        // when
+        AgentPrincipal? actualPrincipal = resolver.Resolve();
+
+        // then
+        actualPrincipal.Should().BeEquivalentTo(expectedPrincipal);
+    }
+
+    [Fact]
+    public void ShouldResolveNoPrincipalWhenTheUserIsNotAuthenticated()
+    {
+        // given — an anonymous request, which is what an open laptop host receives
+        HttpPrincipalResolver resolver =
+            ResolverFor(new ClaimsPrincipal(new ClaimsIdentity()));
+
+        // when
+        AgentPrincipal? actualPrincipal = resolver.Resolve();
+
+        // then — the framework consumes a principal and never mints one
+        actualPrincipal.Should().BeNull();
+    }
+
+    [Fact]
+    public void ShouldResolveNoPrincipalOutsideARequest()
+    {
+        // given — no HTTP context at all, as when the agent runs from a background job
+        HttpPrincipalResolver resolver = ResolverFor(user: null);
+
+        // when
+        AgentPrincipal? actualPrincipal = resolver.Resolve();
+
+        // then
+        actualPrincipal.Should().BeNull();
+    }
+}

--- a/Standard.Agents.Tests.Unit/Controllers/IdentityGateTests.cs
+++ b/Standard.Agents.Tests.Unit/Controllers/IdentityGateTests.cs
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Standard.Agents.Host.Security;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Controllers;
+
+// When a deployment configures authentication, an agent route wants an authenticated user and
+// the heartbeat stays open; when it configures none, the door is as open as before.
+public class IdentityGateTests
+{
+    [Theory]
+    [InlineData(false, false, "/api/agents/runs", true)]
+    [InlineData(false, false, "/api/V1/agents/runs", true)]
+    [InlineData(true, true, "/api/V1/agents/runs", true)]
+    [InlineData(true, false, "/api/V1/agents/runs", false)]
+    [InlineData(true, false, "/api/agents/streams", false)]
+    [InlineData(true, false, "/api/home", true)]
+    [InlineData(true, false, "/API/HOME", true)]
+    public void ShouldAllowOnlyAuthenticatedUsersOnAgentRoutesWhenAuthenticationIsConfigured(
+        bool authenticationConfigured,
+        bool userIsAuthenticated,
+        string path,
+        bool expectedAllowed)
+    {
+        // when
+        bool actualAllowed = IdentityGate.Allows(authenticationConfigured, userIsAuthenticated, path);
+
+        // then
+        actualAllowed.Should().Be(expectedAllowed);
+    }
+}

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -98,12 +98,22 @@ ended `AwaitingInput` with the call as the pending effect, the caller ran it, an
 comes back in `toolExchanges` naming the `callId` the model minted. There is no separate resume
 route, because resuming is not a different operation; the session already holds everything.
 
-**Identity is not established by this door.** The `X-Api-Key` gate below authenticates
-possession of one shared secret and nothing more: it does not name a principal or a tenant, and
-the wire carries none. A deployment that needs identity in policy, sessions and audit puts an
-authenticating proxy or an ASP.NET authentication scheme in front of the host and resolves the
-principal where the agent is composed (`.Principal(...)`, [how-to.md §12](how-to.md)); the wire
-is deliberately not a place a caller can claim to be someone.
+**Identity comes from the authenticated user, never from the wire.** The wire carries no field
+in which a caller can claim to be someone. Who is acting is whoever the request's authentication
+scheme established, translated per act into the principal the policy decides on and the audit
+stamps (`sub` or the name identifier becomes the id, `tid` or `tenant` the tenant, `jurisdiction`
+and `act` the rest). Bearer tokens are the scheme in the box:
+
+```json
+{ "Host": { "Authentication": { "Authority": "https://login.example.com/", "Audience": "standard-agent" } } }
+```
+
+Name the issuer and every agent route wants a valid token: `401` without one, the heartbeat
+open as always, and a held act's `pendingEffect.principal` names the token's subject. Name no
+issuer and the door is as open as before, with no principal handed to the agent. Another scheme,
+a cookie or a proxy's headers, is one `AddAuthentication` registration in front of the same
+resolver; the agent never learns which. The `X-Api-Key` gate below is a separate, cruder lock
+and still proves possession of one shared secret and nothing more.
 
 ## Configuration
 


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-10 remainder. The API-key gate proved possession of one shared secret and established nobody; no identity reached policy, sessions or audit through the host.

## Change

- HttpPrincipalResolver translates the request's authenticated user into the AgentPrincipal the agent hands to policy per act and stamps on every record: sub (or the name identifier, or the identity name) is the id; tid or tenant the tenant; jurisdiction and act the rest. An anonymous request, or no request, resolves to nobody. Both composition paths in the host call .Principal(resolver.Resolve).
- Bearer tokens are the scheme in the box: Host:Authentication:Authority (and optional Audience) registers JWT bearer from configuration; with it configured, IdentityGate answers 401 on agent routes without an authenticated user and leaves the heartbeat open. With nothing configured the door is as open as before.
- Any other scheme is one AddAuthentication registration in front of the same resolver; the agent never learns which.
- hosting.md documents it. The wire still has no field in which a caller can claim to be someone.

## Tests

- HttpPrincipalResolverTests: the token claims, the .NET claim vocabulary, an anonymous user, and no request.
- IdentityGateTests: configured or not, authenticated or not, heartbeat.
- Host acceptance through real HTTP with a test scheme and the real StandardAgent behind the door: a held act names the authenticated subject on pendingEffect.principal; an anonymous request hands the agent no principal; with an issuer configured, agent routes are 401 without a token and the heartbeat stays 200.
- Unit 824 passed on net8.0 and net10.0.

The JwtBearer package is a host dependency only; the library graph and its budget are unchanged.