### PR TITLE
MINOR CLIENTS: The Document's Schema Is Emitted, Not Written

### DIFF
--- a/Standard.Agents.Host/Program.cs
+++ b/Standard.Agents.Host/Program.cs
@@ -18,6 +18,15 @@ using Standard.Agents.Models.Clients.Agents.Exceptions;
 
 const string AgentHttpClientName = "standard-agent";
 
+// `--schema` prints the JSON Schema of the agent document, emitted from the same table the
+// document is validated against, for editors and pipelines (F-24).
+if (args.Contains("--schema"))
+{
+    Console.WriteLine(StandardAgent.DocumentSchemaJson());
+
+    return 0;
+}
+
 // A validate-only run: `--validate [path]` composes the document and says whether it composes,
 // naming the entry when it does not, without standing the host up - the check a deployment
 // pipeline runs before a green heartbeat could mislead it (principal review 2026-09-04, F-24).

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.DocumentSchema.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.DocumentSchema.cs
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Standard.Agents.Models.Clients.Agents.Exceptions;
+using Xunit;
+
+namespace Standard.Agents.Tests.Unit.Clients;
+
+// Found in the 2026-09-04 principal review (F-24): the agent document had no schema an editor
+// could read. A hand-written one would drift from the switch that is the truth, so the schema is
+// EMITTED from the same table the document is validated against: every key it names composes,
+// every key it does not name is refused, and every nested property it lists is one the section
+// accepts, because there is only one list.
+public partial class StandardAgentFromJsonTests
+{
+    private static JsonObject Schema() =>
+        JsonNode.Parse(StandardAgent.DocumentSchemaJson())!.AsObject();
+
+    [Fact]
+    public void ShouldEmitAClosedSchemaForTheDocument()
+    {
+        // when
+        JsonObject schema = Schema();
+
+        // then — a document is an object with only the keys the builder knows
+        schema["$schema"]!.GetValue<string>().Should().Contain("json-schema.org");
+        schema["type"]!.GetValue<string>().Should().Be("object");
+        schema["additionalProperties"]!.GetValue<bool>().Should().BeFalse();
+        schema["properties"]!.AsObject().Count.Should().BeGreaterThan(30);
+    }
+
+    [Fact]
+    public void ShouldComposeEveryExampleTheSchemaCarries()
+    {
+        // given — each key's example, as the schema shows it to an editor
+        JsonObject properties = Schema()["properties"]!.AsObject();
+
+        foreach ((string key, JsonNode? description) in properties)
+        {
+            JsonNode example = description!["examples"]![0]!;
+            string document = new JsonObject { [key] = example.DeepClone() }.ToJsonString();
+
+            // when
+            Action composing = () => StandardAgent.FromJson(document);
+
+            // then — an example the builder refuses is a lie in the editor
+            composing.Should().NotThrow(because: $"the schema's example for '{key}' must compose");
+        }
+    }
+
+    [Fact]
+    public void ShouldRefuseAKeyTheSchemaDoesNotName()
+    {
+        // given
+        JsonObject properties = Schema()["properties"]!.AsObject();
+        properties.ContainsKey("buget").Should().BeFalse();
+
+        // when
+        Action composing = () => StandardAgent.FromJson("""{ "buget": { "maxTokens": 50000 } }""");
+
+        // then
+        composing.Should().Throw<InvalidAgentConfigurationException>().WithMessage("*buget*");
+    }
+
+    [Fact]
+    public void ShouldCloseEveryObjectSectionInTheSchema()
+    {
+        // given
+        JsonObject properties = Schema()["properties"]!.AsObject();
+
+        // when . then — every object shape names its properties and admits nothing else
+        foreach ((string key, JsonNode? description) in properties)
+        {
+            foreach (JsonNode? shape in description!["anyOf"]!.AsArray())
+            {
+                if (shape!["type"]?.GetValue<string>() == "object")
+                {
+                    shape["additionalProperties"]!.GetValue<bool>().Should().BeFalse(
+                        because: $"'{key}' is validated against a closed property list");
+                }
+            }
+        }
+    }
+}

--- a/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.DocumentSchema.cs
+++ b/Standard.Agents.Tests.Unit/Clients/StandardAgentTests.DocumentSchema.cs
@@ -72,17 +72,31 @@ public partial class StandardAgentFromJsonTests
         // given
         JsonObject properties = Schema()["properties"]!.AsObject();
 
-        // when . then — every object shape names its properties and admits nothing else
+        var openSections = new List<string>();
+
+        // when . then — every object shape with a property list admits nothing else; the one
+        // without a list is the contract, which is a JSON Schema of its own and stays open
         foreach ((string key, JsonNode? description) in properties)
         {
             foreach (JsonNode? shape in description!["anyOf"]!.AsArray())
             {
-                if (shape!["type"]?.GetValue<string>() == "object")
+                if (shape!["type"]?.GetValue<string>() != "object")
                 {
-                    shape["additionalProperties"]!.GetValue<bool>().Should().BeFalse(
-                        because: $"'{key}' is validated against a closed property list");
+                    continue;
                 }
+
+                if (shape["properties"] is null)
+                {
+                    openSections.Add(key);
+
+                    continue;
+                }
+
+                shape["additionalProperties"]!.GetValue<bool>().Should().BeFalse(
+                    because: $"'{key}' is validated against a closed property list");
             }
         }
+
+        openSections.Should().Equal("contract");
     }
 }

--- a/Standard.Agents/PublicAPI.Unshipped.txt
+++ b/Standard.Agents/PublicAPI.Unshipped.txt
@@ -2,3 +2,4 @@
 *REMOVED*Standard.Agents.Services.Foundations.EffectLedgers.EffectLedgerService.EffectLedgerService(Standard.Agents.Brokers.Effects.IEffectLedgerBroker! effectLedgerBroker, Standard.Agents.Brokers.Times.ITimeBroker! timeBroker, Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker) -> void
 Standard.Agents.Services.Foundations.EffectLedgers.EffectLedgerService.EffectLedgerService(Standard.Agents.Brokers.Effects.IEffectLedgerBroker! effectLedgerBroker, Standard.Agents.Brokers.Times.ITimeBroker! timeBroker, Standard.Agents.Brokers.Loggings.ILoggingBroker! loggingBroker, System.TimeSpan lease) -> void
 Standard.Agents.StandardAgent.EffectLease(System.TimeSpan lease) -> Standard.Agents.StandardAgent!
+static Standard.Agents.StandardAgent.DocumentSchemaJson() -> string!

--- a/Standard.Agents/StandardAgent.Configurations.cs
+++ b/Standard.Agents/StandardAgent.Configurations.cs
@@ -102,7 +102,7 @@ public partial class StandardAgent
                 break;
 
             case "brain":
-                Shaped(value, key, "apiUrl", "apiKey", "model", "temperature", "maxTokens", "timeoutSeconds");
+                Shaped(value, key);
 
                 agent.Brain(
                     Text(value, key, "apiUrl"),
@@ -115,7 +115,7 @@ public partial class StandardAgent
                 break;
 
             case "nativeBrain":
-                Shaped(value, key, "apiUrl", "apiKey", "model", "temperature", "maxTokens");
+                Shaped(value, key);
 
                 agent.NativeBrain(
                     Text(value, key, "apiUrl"),
@@ -127,7 +127,7 @@ public partial class StandardAgent
                 break;
 
             case "nativeBrainAnthropic":
-                Shaped(value, key, "apiKey", "model", "temperature", "maxTokens");
+                Shaped(value, key);
 
                 agent.NativeBrainAnthropic(
                     Text(value, key, "apiKey"),
@@ -151,7 +151,7 @@ public partial class StandardAgent
                 break;
 
             case "knowledge" when value is JsonObject:
-                Shaped(value, key, "path", "pattern", "maxResults", "minScore");
+                Shaped(value, key);
 
                 agent.Knowledge(
                     Text(value, key, "path"),
@@ -209,7 +209,7 @@ public partial class StandardAgent
                 break;
 
             case "gate":
-                Shaped(value, key, "apiUrl", "apiKey", "model", "temperature", "maxTokens", "timeoutSeconds");
+                Shaped(value, key);
 
                 agent.Gate(
                     Text(value, key, "apiUrl"),
@@ -227,7 +227,7 @@ public partial class StandardAgent
                 break;
 
             case "judge":
-                Shaped(value, key, "apiUrl", "apiKey", "model", "temperature", "maxTokens", "timeoutSeconds");
+                Shaped(value, key);
 
                 agent.Judge(
                     Text(value, key, "apiUrl"),
@@ -262,12 +262,12 @@ public partial class StandardAgent
                 break;
 
             case "redact" when value is JsonObject rules:
-                Shaped(rules, key, "rules");
+                Shaped(rules, key);
 
                 agent.Redact([.. Listed(rules["rules"], "redact.rules").Select(rule =>
                     new RedactionRule
                     {
-                        Label = Text(Shaped(rule, "redact.rules", "label", "pattern"), "redact.rules", "label"),
+                        Label = Text(Shaped(rule, "redact.rules"), "redact.rules", "label"),
                         Pattern = Text(rule, "redact.rules", "pattern")
                     })]);
 
@@ -310,7 +310,7 @@ public partial class StandardAgent
                 break;
 
             case "logTo" when value is JsonObject:
-                Shaped(value, key, "path", "verbosity");
+                Shaped(value, key);
 
                 agent.LogTo(
                     Text(value, key, "path"),
@@ -351,7 +351,7 @@ public partial class StandardAgent
                 break;
 
             case "sessions" when value is JsonObject:
-                Shaped(value, key, "path", "maxHistoryTurns");
+                Shaped(value, key);
 
                 agent.Sessions(
                     Text(value, key, "path"),
@@ -389,7 +389,7 @@ public partial class StandardAgent
                 break;
 
             case "usage":
-                Shaped(value, key, "charactersPerToken");
+                Shaped(value, key);
 
                 agent.Usage(
                     PositiveNumber(
@@ -399,7 +399,7 @@ public partial class StandardAgent
                 break;
 
             case "resilience" when value is JsonObject:
-                Shaped(value, key, "retries");
+                Shaped(value, key);
 
                 agent.Resilience(
                     NonNegative(Whole(value, key, "retries", fallback: 3), $"{key}.retries"));
@@ -435,7 +435,7 @@ public partial class StandardAgent
     {
         const string key = "budget";
 
-        Shaped(budgetNode, key, "maxTokens", "maxCostUsd", "maxWallClockSeconds", "costPerThousandTokens");
+        Shaped(budgetNode, key);
 
         try
         {
@@ -496,15 +496,7 @@ public partial class StandardAgent
     {
         if (server is JsonObject)
         {
-            Shaped(
-                server,
-                key,
-                "endpointUrl",
-                "relativeUrl",
-                "timeoutSeconds",
-                "bearerToken",
-                "apiKey",
-                "apiKeyHeader");
+            Shaped(server, key);
 
             agent.Mcp(
                 Text(server, key, "endpointUrl"),
@@ -573,6 +565,11 @@ public partial class StandardAgent
     // F-24): it must be an object, and every key in it must be one the section accepts. A
     // nested typo used to be ignored, which is a control the author believes is on and is not,
     // the same failure the top-level unknown-key refusal exists to prevent.
+    // The section's accepted properties come from the one table the schema is emitted from
+    // (StandardAgent.Schema.cs), so an editor's completion list and this refusal cannot disagree.
+    private static JsonObject Shaped(JsonNode? node, string key) =>
+        Shaped(node, key, DocumentPropertyNames(key));
+
     private static JsonObject Shaped(JsonNode? node, string key, params string[] properties)
     {
         JsonObject section = node as JsonObject

--- a/Standard.Agents/StandardAgent.Schema.cs
+++ b/Standard.Agents/StandardAgent.Schema.cs
@@ -1,0 +1,334 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Standard.Agents;
+
+// The agent document, described once. This table is what FromJson validates a section's shape
+// against (Configurations.cs reads it for every object section) and what the JSON Schema is
+// emitted from, so an editor's completion list and the builder's refusals cannot disagree:
+// there is one list (principal review 2026-09-04, F-24).
+public sealed partial class StandardAgent
+{
+    private const string StringKind = "string";
+    private const string NumberKind = "number";
+    private const string IntegerKind = "integer";
+    private const string BooleanKind = "boolean";
+    private const string ObjectKind = "object";
+    private const string ArrayKind = "array";
+
+    // One property of an object section: its JSON kind, whether the section needs it, and
+    // whether it must be positive - the same rules the switch enforces.
+    private sealed record DocumentProperty(
+        string Name,
+        string Kind,
+        bool Required = false,
+        bool Positive = false,
+        string[]? Names = null);
+
+    // One top-level key: the shapes it accepts, the properties of its object shape, the kind of
+    // its array items, the names of its enum shape, and an example that composes.
+    private sealed record DocumentSection(
+        string Key,
+        string Description,
+        string[] Shapes,
+        string Example,
+        DocumentProperty[]? Properties = null,
+        string? ItemsKind = null,
+        string? ItemsSection = null,
+        string[]? Names = null,
+        bool BooleanMustBeFalse = false);
+
+    private static readonly DocumentProperty[] endpointProperties =
+    [
+        new("apiUrl", StringKind, Required: true),
+        new("apiKey", StringKind),
+        new("model", StringKind, Required: true),
+        new("temperature", NumberKind),
+        new("maxTokens", IntegerKind, Positive: true),
+        new("timeoutSeconds", IntegerKind, Positive: true)
+    ];
+
+    private static readonly DocumentSection[] documentSections =
+    [
+        new("name", "The agent's name; a handoff calls agents by it.", [StringKind], "\"refund-desk\""),
+        new("description", "What the agent is for, as a registry advertises it.", [StringKind], "\"Handles refunds and invoices.\""),
+        new("brain", "The text-protocol brain on an OpenAI-compatible endpoint.", [ObjectKind],
+            "{ \"apiUrl\": \"http://localhost:11434/v1/\", \"model\": \"LLooMA2.0\" }",
+            Properties: endpointProperties),
+        new("nativeBrain", "A native tool-calling brain on an OpenAI-compatible endpoint.", [ObjectKind],
+            "{ \"apiUrl\": \"http://localhost:11434/v1/\", \"model\": \"LLooMA2.0\" }",
+            Properties: [.. endpointProperties.Where(property => property.Name != "timeoutSeconds")]),
+        new("nativeBrainAnthropic", "A native tool-calling brain on the Anthropic Messages API.", [ObjectKind],
+            "{ \"apiKey\": \"k\", \"model\": \"claude-sonnet-5\" }",
+            Properties:
+            [
+                new("apiKey", StringKind, Required: true),
+                new("model", StringKind, Required: true),
+                new("temperature", NumberKind),
+                new("maxTokens", IntegerKind, Positive: true)
+            ]),
+        new("skills", "A skills folder, or several.", [StringKind, ArrayKind], "\"Skills\"", ItemsKind: StringKind),
+        new("knowledge", "A knowledge folder, or the folder with its pattern and ranking.", [StringKind, ObjectKind],
+            "\"Knowledge\"",
+            Properties:
+            [
+                new("path", StringKind, Required: true),
+                new("pattern", StringKind),
+                new("maxResults", IntegerKind, Positive: true),
+                new("minScore", NumberKind)
+            ]),
+        new("memory", "A memory file, or false to run without one.", [StringKind, BooleanKind], "\"memory.txt\"",
+            BooleanMustBeFalse: true),
+        new("mcp", "An MCP server by URL, or with its auth, or several.", [StringKind, ObjectKind, ArrayKind],
+            "\"http://localhost:8080/mcp/\"",
+            Properties:
+            [
+                new("endpointUrl", StringKind, Required: true),
+                new("relativeUrl", StringKind),
+                new("timeoutSeconds", IntegerKind, Positive: true),
+                new("bearerToken", StringKind),
+                new("apiKey", StringKind),
+                new("apiKeyHeader", StringKind)
+            ],
+            ItemsSection: "mcp"),
+        new("agents", "A folder of agent documents, or inline members, for handoffs.", [StringKind, ArrayKind],
+            "\"Agents\"",
+            ItemsSection: "agents"),
+        new("gate", "The guardian that screens the request, on an endpoint.", [ObjectKind],
+            "{ \"apiUrl\": \"http://localhost:11434/v1/\", \"model\": \"LLooMA2.0\" }",
+            Properties: endpointProperties),
+        new("ruleGate", "Patterns the gate refuses without a model.", [ArrayKind], "[\"password\"]", ItemsKind: StringKind),
+        new("judge", "The guardian that reviews the answer, on an endpoint.", [ObjectKind],
+            "{ \"apiUrl\": \"http://localhost:11434/v1/\", \"model\": \"LLooMA2.0\" }",
+            Properties: endpointProperties),
+        new("ruleJudge", "Patterns the judge rejects without a model.", [ArrayKind], "[\"as an AI\"]", ItemsKind: StringKind),
+        new("contract", "The JSON Schema the answer must satisfy, embedded.", [ObjectKind], "{ \"type\": \"object\" }"),
+        new("constitution", "The law above both guardians, a Markdown file.", [StringKind], "\"Constitution/ethics.md\""),
+        new("consumption", "The consumption prompt, a Markdown file.", [StringKind], "\"Consumption/rules.md\""),
+        new("redact", "PII redaction at the brain boundary: true for the default rules, or your own.",
+            [BooleanKind, ObjectKind], "true",
+            Properties: [new("rules", ArrayKind, Required: true)]),
+        new("maxTurns", "How many turns a run may take.", [IntegerKind], "7"),
+        new("allowTools", "The only tools the agent may call; empty closes the perimeter.", [ArrayKind],
+            "[\"calculator\"]", ItemsKind: StringKind),
+        new("permissions", "The disposition toward acts nothing names.", [StringKind], "\"Ask\"",
+            Names: ["Open", "Ask", "Deny"]),
+        new("risk", "Which tools carry which risk level.", [ObjectKind], "{ \"Irreversible\": [\"wire_transfer\"] }",
+            Properties:
+            [
+                new("Safe", ArrayKind),
+                new("Sensitive", ArrayKind),
+                new("Irreversible", ArrayKind)
+            ]),
+        new("requireApproval", "Tools a person must approve before they run.", [ArrayKind], "[\"wire_transfer\"]",
+            ItemsKind: StringKind),
+        new("logTo", "The human-readable trace, a file, or the file with its verbosity.", [StringKind, ObjectKind],
+            "\"log.txt\"",
+            Properties:
+            [
+                new("path", StringKind, Required: true),
+                new("verbosity", StringKind, Names: ["Summary", "Natures", "Full"])
+            ]),
+        new("audit", "The decision log, JSON lines.", [StringKind], "\"audit.jsonl\""),
+        new("auditPayloads", "Record payloads in the decision log, as redaction leaves them.", [BooleanKind], "true"),
+        new("telemetry", "OpenTelemetry spans and metrics, under this service name, or true.", [StringKind, BooleanKind],
+            "\"teller-agent\""),
+        new("sessions", "Conversations kept in a folder, or the folder with its history bound.", [StringKind, ObjectKind],
+            "\"Sessions\"",
+            Properties:
+            [
+                new("path", StringKind, Required: true),
+                new("maxHistoryTurns", IntegerKind, Positive: true)
+            ]),
+        new("effectLedger", "The run-once ledger folder.", [StringKind], "\"ledger\""),
+        new("effectLeaseSeconds", "How long an in-flight claim is presumed live.", [NumberKind], "300"),
+        new("screenToolOutput", "Screen tool results with the gate before the brain sees them.", [BooleanKind], "true"),
+        new("budget", "Bounds on tokens, cost and wall clock.", [ObjectKind], "{ \"maxTokens\": 50000 }",
+            Properties:
+            [
+                new("maxTokens", IntegerKind, Positive: true),
+                new("maxCostUsd", NumberKind, Positive: true),
+                new("maxWallClockSeconds", NumberKind, Positive: true),
+                new("costPerThousandTokens", NumberKind)
+            ]),
+        new("usage", "How tokens are counted when the provider does not say.", [ObjectKind],
+            "{ \"charactersPerToken\": 4 }",
+            Properties: [new("charactersPerToken", NumberKind, Positive: true)]),
+        new("resilience", "Retries on the brain, as a count or an object.", [IntegerKind, ObjectKind], "3",
+            Properties: [new("retries", IntegerKind)]),
+        new("compensateOnFailure", "Unwind performed effects when the run fails.", [BooleanKind], "true")
+    ];
+
+    // Nested object sections, validated by the same table under a dotted key.
+    private static readonly DocumentSection[] nestedSections =
+    [
+        new("redact.rules", "One redaction rule: a label and a pattern.", [ObjectKind],
+            "{ \"label\": \"CARD\", \"pattern\": \"\\\\d{4}-\\\\d{4}-\\\\d{4}-\\\\d{4}\" }",
+            Properties:
+            [
+                new("label", StringKind, Required: true),
+                new("pattern", StringKind, Required: true)
+            ])
+    ];
+
+    private static string[] DocumentPropertyNames(string key) =>
+        [.. documentSections.Concat(nestedSections)
+            .Single(section => section.Key == key)
+            .Properties!.Select(property => property.Name)];
+
+    /// <summary>
+    /// The JSON Schema of the agent document <see cref="FromJson"/> composes, for editors and
+    /// pipelines. Emitted from the same table the document is validated against, so what an
+    /// editor offers and what the builder refuses cannot disagree.
+    /// </summary>
+    /// <returns>A JSON Schema (draft 2020-12) as text.</returns>
+    public static string DocumentSchemaJson()
+    {
+        var properties = new JsonObject();
+
+        foreach (DocumentSection section in documentSections)
+        {
+            properties[section.Key] = DescribeSection(section);
+        }
+
+        var schema = new JsonObject
+        {
+            ["$schema"] = "https://json-schema.org/draft/2020-12/schema",
+            ["title"] = "Standard.Agents agent document",
+            ["description"] = "The whole configurable surface of a StandardAgent as data: one key per builder verb.",
+            ["type"] = ObjectKind,
+            ["additionalProperties"] = false,
+            ["properties"] = properties
+        };
+
+        return schema.ToJsonString(schemaOptions);
+    }
+
+    // Indented for a person, and with plain quotes: an editor reads this file, not a browser,
+    // so nothing here needs HTML-safe escaping. Derived from the defaults so net8.0's serializer
+    // has its type resolver.
+    private static readonly JsonSerializerOptions schemaOptions =
+        new(JsonSerializerOptions.Default)
+        {
+            WriteIndented = true,
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
+
+    private static JsonObject DescribeSection(DocumentSection section)
+    {
+        var shapes = new JsonArray();
+
+        foreach (string shape in section.Shapes)
+        {
+            shapes.Add(DescribeShape(section, shape));
+        }
+
+        return new JsonObject
+        {
+            ["description"] = section.Description,
+            ["anyOf"] = shapes,
+            ["examples"] = new JsonArray(JsonNode.Parse(section.Example))
+        };
+    }
+
+    private static JsonObject DescribeShape(DocumentSection section, string shape) =>
+        shape switch
+        {
+            ObjectKind => DescribeObject(section),
+            ArrayKind => DescribeArray(section),
+            StringKind when section.Names is not null =>
+                new JsonObject { ["type"] = StringKind, ["enum"] = new JsonArray([.. section.Names.Select(name => (JsonNode)name)]) },
+            BooleanKind when section.BooleanMustBeFalse =>
+                new JsonObject { ["type"] = BooleanKind, ["const"] = false },
+            _ => new JsonObject { ["type"] = shape }
+        };
+
+    // A section with no property list (the contract, which is a JSON Schema itself) stays open;
+    // every other object is closed, exactly as Shaped closes it.
+    private static JsonObject DescribeObject(DocumentSection section)
+    {
+        if (section.Properties is null)
+        {
+            return new JsonObject { ["type"] = ObjectKind };
+        }
+
+        var properties = new JsonObject();
+        var required = new JsonArray();
+
+        foreach (DocumentProperty property in section.Properties)
+        {
+            properties[property.Name] = DescribeProperty(property);
+
+            if (property.Required)
+            {
+                required.Add(property.Name);
+            }
+        }
+
+        var described = new JsonObject
+        {
+            ["type"] = ObjectKind,
+            ["additionalProperties"] = false,
+            ["properties"] = properties
+        };
+
+        if (required.Count > 0)
+        {
+            described["required"] = required;
+        }
+
+        return described;
+    }
+
+    private static JsonObject DescribeProperty(DocumentProperty property)
+    {
+        var described = new JsonObject { ["type"] = property.Kind };
+
+        if (property.Positive)
+        {
+            described["exclusiveMinimum"] = 0;
+        }
+
+        if (property.Names is not null)
+        {
+            described["enum"] = new JsonArray([.. property.Names.Select(name => (JsonNode)name)]);
+        }
+
+        if (property.Kind == ArrayKind)
+        {
+            described["items"] = property.Name == "rules"
+                ? DescribeObject(nestedSections.Single(nested => nested.Key == "redact.rules"))
+                : new JsonObject { ["type"] = StringKind };
+        }
+
+        return described;
+    }
+
+    // An array's items are strings, or the section's own object shape beside a string (an MCP
+    // server by URL or by object; a fleet member by path or as an inline document).
+    private static JsonObject DescribeArray(DocumentSection section)
+    {
+        JsonObject items = section.ItemsSection is null
+            ? new JsonObject { ["type"] = section.ItemsKind ?? StringKind }
+            : new JsonObject
+            {
+                ["anyOf"] = new JsonArray(
+                    new JsonObject { ["type"] = StringKind },
+                    section.Properties is null
+                        ? new JsonObject { ["type"] = ObjectKind }
+                        : DescribeObject(section))
+            };
+
+        return new JsonObject
+        {
+            ["type"] = ArrayKind,
+            ["minItems"] = 1,
+            ["items"] = items
+        };
+    }
+}

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -142,6 +142,9 @@ So a pipeline asks before it deploys:
 dotnet run --project Standard.Agents.Host -- --validate path/to/agent.json
 ```
 
+And `dotnet run --project Standard.Agents.Host -- --schema` prints the document's JSON Schema
+for an editor, emitted from the same table the validation reads.
+
 Exit `0` and "composes", or exit `1` and the entry that does not: an unknown key at any depth,
 a value of the wrong type, a limit that is not positive, a section of the wrong shape, or a
 control that lists nothing. Every rule the document refuses is the same rule the builder verb

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1323,6 +1323,10 @@ The rules, and each is deliberate:
   (`"ruleGate": []`) is refused, because a control that lists nothing is not a control. The
   supplied host checks all of this without starting: `--validate path/to/agent.json`
   ([hosting.md](hosting.md)).
+- **The schema is emitted, not written.** `StandardAgent.DocumentSchemaJson()` (or the host's
+  `--schema`) returns a JSON Schema of the document for your editor, built from the same table
+  every section's shape is validated against, so what the editor offers and what the builder
+  refuses cannot drift apart; every example in it is one that composes, and a test says so.
 - **Tools stay code, because they are code** — except `mcp`, where a tool is a URL, which is
   data. Delegates (`On*`) and broker instances (`Use*`) stay code for the same reason.
 - **Data and code compose.** `FromJson` returns the same `StandardAgent`, so keep chaining:


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-24 remainder: a JSON Schema for editors. A hand-written schema would drift from the switch that is the truth.

## Change

- One table (StandardAgent.Schema.cs) describes every top-level key: the shapes it accepts, the properties of its object shape with their kinds, required and positive rules, its enum names, and an example. Configurations.cs now reads every section's accepted properties from that table, so the validation and the schema have one source.
- StandardAgent.DocumentSchemaJson() emits a JSON Schema (draft 2020-12) from it: a closed top-level object, closed object sections (the contract stays open because it is a JSON Schema of its own), enums, exclusive minimums, minItems on control lists, and an example per key.
- The host prints it with --schema.

## Tests

- The schema is closed at the top and in every object section but the contract; every example it carries composes through FromJson; a key it does not name is refused.
- Unit 828 passed on net8.0 and net10.0; conformance 79 passed; Critical certified; evals 6 passed. The net8.0 serializer needed the default type resolver, which the first cut missed and the suite caught.