### PR TITLE
MINOR EVALS: Live Model And Skill Evals On PeerLLM

### DIFF
--- a/.github/workflows/live-evals.yml
+++ b/.github/workflows/live-evals.yml
@@ -1,0 +1,50 @@
+name: Standard.Agents Live Evals
+
+# The live evals: the same agent loop against LLooMA on PeerLLM and real skills from the PeerLLM
+# registry. Opt-in and outside the PR gate on purpose: a live model is not deterministic, a run
+# costs time on the network, and a flake in a required gate is a gate nobody trusts (principal
+# review 2026-09-04, F-19). Every prompt is sampled several times, a metric is a pass rate, and
+# the report records which model, which skillset version and which framework answered.
+#
+# Needs one repository secret: PEERLLM_API_KEY. Without it the run exits 3 and fails, so a
+# missing key never reads as a pass.
+on:
+  workflow_dispatch:
+    inputs:
+      samples:
+        description: "How many times each prompt is sampled"
+        required: false
+        default: "3"
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  live-evals:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Pulling Code
+      uses: actions/checkout@v7
+
+    - name: Installing .NET
+      uses: actions/setup-dotnet@v6
+      with:
+        global-json-file: global.json
+
+    - name: Building The Live Evals
+      run: dotnet build Standard.Agents.Evals.Live --configuration Release
+
+    - name: Evaluating LLooMA And The Registry Skills
+      env:
+        PEERLLM_API_KEY: ${{ secrets.PEERLLM_API_KEY }}
+      run: >
+        dotnet run --project Standard.Agents.Evals.Live --no-build --configuration Release
+        -- --samples ${{ github.event.inputs.samples || '3' }} --report artifacts/live-evals/report.json
+
+    - name: Publishing The Report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: live-evals-report
+        path: artifacts/live-evals/report.json
+        if-no-files-found: ignore

--- a/Standard.Agents.Evals.Live/Brokers/PeerLLMRegistrySkillBroker.cs
+++ b/Standard.Agents.Evals.Live/Brokers/PeerLLMRegistrySkillBroker.cs
@@ -1,0 +1,104 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Standard.Agents.Brokers.Skills;
+using Standard.Agents.Models.Foundations.Skills;
+
+namespace Standard.Agents.Evals.Live;
+
+// Skills from the PeerLLM registry (skills.peerllm.com), pinned to a skillset version, through
+// the same ISkillBroker seam the built-in file skills use. The live evals carry this thin
+// broker rather than the Standard.Agents.Data.Skills.PeerLLM package because that package pins
+// an older core; when it moves to 2.x, this file goes.
+public sealed class PeerLLMRegistrySkillBroker : ISkillBroker
+{
+    private const string BaseUrl = "https://skills.peerllm.com/api/v1/";
+
+    private readonly HttpClient httpClient;
+    private readonly string skillset;
+    private readonly IReadOnlyList<string> members;
+
+    public PeerLLMRegistrySkillBroker(
+        HttpClient httpClient,
+        string skillset,
+        IReadOnlyList<string> members)
+    {
+        this.httpClient = httpClient;
+        this.httpClient.BaseAddress ??= new Uri(BaseUrl);
+        this.skillset = skillset.Trim('/');
+        this.members = members;
+    }
+
+    public int ResolvedVersion { get; private set; }
+
+    public async ValueTask<IReadOnlyList<Skill>> SelectSkillsAsync()
+    {
+        SkillsetDto set =
+            await this.httpClient.GetFromJsonAsync<SkillsetDto>($"skillsets/{this.skillset}")
+                ?? new SkillsetDto();
+
+        this.ResolvedVersion = set.Version;
+        List<Skill> skills = [];
+
+        foreach (MemberDto member in set.Members)
+        {
+            if (this.members.Count > 0 && this.members.Contains(member.Name) is false)
+            {
+                continue;
+            }
+
+            SkillDto? skill = await this.httpClient.GetFromJsonAsync<SkillDto>(
+                $"skills/id/{member.SkillId}@{member.Version}");
+
+            if (skill is not null)
+            {
+                skills.Add(new Skill
+                {
+                    Name = skill.Name,
+                    Description = skill.Description,
+                    Content = StripFrontmatter(skill.SkillMd)
+                });
+            }
+        }
+
+        return skills;
+    }
+
+    // The registry serves SKILL.md whole; the YAML frontmatter is the registry's metadata, not
+    // instructions for the model.
+    private static string StripFrontmatter(string skillMd)
+    {
+        if (skillMd.StartsWith("---", StringComparison.Ordinal) is false)
+        {
+            return skillMd;
+        }
+
+        int end = skillMd.IndexOf("\n---", 3, StringComparison.Ordinal);
+
+        return end < 0 ? skillMd : skillMd[(end + 4)..].TrimStart('\r', '\n');
+    }
+
+    private sealed record SkillsetDto
+    {
+        [JsonPropertyName("version")] public int Version { get; init; }
+        [JsonPropertyName("members")] public MemberDto[] Members { get; init; } = [];
+    }
+
+    private sealed record MemberDto
+    {
+        [JsonPropertyName("skill_id")] public string SkillId { get; init; } = string.Empty;
+        [JsonPropertyName("name")] public string Name { get; init; } = string.Empty;
+        [JsonPropertyName("version")] public int Version { get; init; }
+    }
+
+    private sealed record SkillDto
+    {
+        [JsonPropertyName("name")] public string Name { get; init; } = string.Empty;
+        [JsonPropertyName("description")] public string Description { get; init; } = string.Empty;
+        [JsonPropertyName("skill_md")] public string SkillMd { get; init; } = string.Empty;
+    }
+}

--- a/Standard.Agents.Evals.Live/Models/LiveCase.cs
+++ b/Standard.Agents.Evals.Live/Models/LiveCase.cs
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Evals.Live;
+
+// One live case: a pinned skillset from the PeerLLM registry, the door the prompts enter by,
+// the tools on offer, the prompts with their golden data, how many times each is sampled, and
+// the pass rate each metric must reach. Pinned means pinned: a skillset without @version is
+// refused, because a score nobody can reproduce is a score nobody can investigate.
+[System.Text.Json.Serialization.JsonUnmappedMemberHandling(
+    System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow)]
+public sealed record LiveCase(
+    string Name,
+    string? Description,
+    string Skillset,
+    List<LivePrompt> Prompts,
+    Dictionary<string, double> Thresholds,
+
+    // Which members of the skillset to load; empty loads them all. A skillset can be far
+    // larger than a system prompt should be, and a case measures one skill at a time.
+    List<string>? Members = null,
+
+    // "text" rides the text protocol (Brain); "native" rides tool calling (NativeBrain).
+    string Protocol = "text",
+    Dictionary<string, string>? Tools = null,
+    int Samples = 3,
+    int MaxTurns = 4,
+
+    // The cost control: tokens a single run may spend before the budget stops it.
+    int MaxTokensPerRun = 12000);

--- a/Standard.Agents.Evals.Live/Models/LivePrompt.cs
+++ b/Standard.Agents.Evals.Live/Models/LivePrompt.cs
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+namespace Standard.Agents.Evals.Live;
+
+[System.Text.Json.Serialization.JsonUnmappedMemberHandling(
+    System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow)]
+public sealed record LivePrompt(
+    string Prompt,
+
+    // Task completion: every one of these is in the answer (case-insensitive, because a live
+    // model's casing is not the fact under test).
+    List<string>? AnswerMustContain = null,
+
+    // Task completion, the looser form: at least one of these is in the answer.
+    List<string>? AnswerMustContainAny = null,
+
+    // Groundedness: none of these is in the answer - the fabrication the author knows to watch for.
+    List<string>? AnswerMustNotContain = null,
+
+    // Tool selection: exactly these tools ran, no more and no fewer.
+    List<string>? ExpectedTools = null);

--- a/Standard.Agents.Evals.Live/Program.cs
+++ b/Standard.Agents.Evals.Live/Program.cs
@@ -1,0 +1,331 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+// The live evals: the same agent loop against a real model on PeerLLM and real skills from the
+// PeerLLM registry. Where the deterministic evals pin how the loop treats a scripted Brain,
+// these measure the Brain and the skills themselves: does LLooMA read a skill and answer from
+// it, does it pick the tool the task needs, does it stay off the fabrication the author named.
+// Opt-in and outside the PR gate, because a live model is not deterministic and a flake in a
+// required gate is a gate nobody trusts (principal review 2026-09-04, F-19). So every prompt is
+// sampled several times, a metric is a pass rate over the samples, a threshold is a pass rate
+// the case must reach, and every report records which model, which skillset version, which
+// framework and when - a score nobody can attribute is a score nobody can investigate.
+
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Standard.Agents;
+using Standard.Agents.Evals.Live;
+using Standard.Agents.Models.Clients.Agents;
+using Standard.Agents.Models.Orchestrations.Agents;
+
+const string SamplesFlag = "--samples";
+const string MaxCasesFlag = "--max-cases";
+const string ReportFlag = "--report";
+const string KeyFileFlag = "--key-file";
+
+string[] knownMetrics = ["taskCompletion", "groundedness", "toolSelection"];
+
+string apiUrl = Environment.GetEnvironmentVariable("PEERLLM_API_URL") ?? "https://api.peerllm.com/v1/";
+string model = Environment.GetEnvironmentVariable("PEERLLM_MODEL") ?? "LLooMA2.0";
+string? apiKey = Environment.GetEnvironmentVariable("PEERLLM_API_KEY");
+
+int? samplesOverride = null;
+int maxCases = int.MaxValue;
+string? reportPath = null;
+string? casesPath = null;
+
+for (int index = 0; index < args.Length; index++)
+{
+    switch (args[index])
+    {
+        case SamplesFlag:
+            samplesOverride = int.Parse(args[++index]);
+
+            break;
+
+        case MaxCasesFlag:
+            maxCases = int.Parse(args[++index]);
+
+            break;
+
+        case ReportFlag:
+            reportPath = args[++index];
+
+            break;
+
+        case KeyFileFlag:
+            apiKey = (await File.ReadAllTextAsync(args[++index])).Trim();
+
+            break;
+
+        default:
+            casesPath = args[index];
+
+            break;
+    }
+}
+
+casesPath ??= Path.Combine(FindRepositoryRoot(), "evals", "live");
+
+// No key, no run - and no green. A live eval that silently skipped is a live eval that never
+// measured anything.
+if (string.IsNullOrWhiteSpace(apiKey))
+{
+    Console.WriteLine(
+        $"No PeerLLM key. Set PEERLLM_API_KEY, or pass {KeyFileFlag} <path>. Exit 3.");
+
+    return 3;
+}
+
+JsonSerializerOptions jsonOptions = new() { PropertyNameCaseInsensitive = true };
+string frameworkVersion = typeof(StandardAgent).Assembly.GetName().Version?.ToString() ?? "unknown";
+string setHash = HashSet(casesPath);
+DateTimeOffset startedOn = DateTimeOffset.UtcNow;
+using HttpClient registry = new();
+
+Console.WriteLine($"Live set:   {casesPath}");
+Console.WriteLine($"Model:      {model} at {new Uri(apiUrl).Host}");
+Console.WriteLine($"Framework:  Standard.Agents {frameworkVersion}");
+Console.WriteLine($"Set hash:   {setHash}");
+Console.WriteLine();
+
+int passed = 0;
+int failed = 0;
+List<object> caseReports = [];
+
+foreach (string caseFile in Directory.EnumerateFiles(casesPath, "*.json")
+    .OrderBy(path => path, StringComparer.Ordinal)
+    .Take(maxCases))
+{
+    LiveCase liveCase =
+        JsonSerializer.Deserialize<LiveCase>(await File.ReadAllTextAsync(caseFile), jsonOptions)!;
+
+    if (liveCase.Skillset.Contains('@') is false)
+    {
+        failed++;
+        Console.WriteLine($"FAIL  {liveCase.Name}");
+        Console.WriteLine("        skillset is not pinned to a version (owner/name@N); an unpinned live score cannot be reproduced");
+
+        continue;
+    }
+
+    int samples = samplesOverride ?? liveCase.Samples;
+    Stopwatch caseClock = Stopwatch.StartNew();
+
+    (Dictionary<string, double> scores, int skillsetVersion, List<string> answers) =
+        await ScoreCaseAsync(liveCase, samples);
+
+    List<string> verdicts = [];
+    bool caseFailed = false;
+
+    foreach (KeyValuePair<string, double> threshold in liveCase.Thresholds)
+    {
+        if (knownMetrics.Contains(threshold.Key) is false)
+        {
+            caseFailed = true;
+            verdicts.Add($"unknown metric '{threshold.Key}' — knowable: {string.Join(", ", knownMetrics)}");
+
+            continue;
+        }
+
+        if (scores.TryGetValue(threshold.Key, out double score) is false)
+        {
+            caseFailed = true;
+            verdicts.Add($"{threshold.Key}: threshold {threshold.Value:0.00} binds nothing — no prompt carries its golden data");
+
+            continue;
+        }
+
+        bool met = score >= threshold.Value;
+        caseFailed |= met is false;
+        verdicts.Add($"{threshold.Key} = {score:0.00} over {samples} sample(s) (threshold {threshold.Value:0.00}){(met ? "" : "  ← UNMET")}");
+    }
+
+    foreach (KeyValuePair<string, double> score in scores
+        .Where(score => liveCase.Thresholds.ContainsKey(score.Key) is false))
+    {
+        verdicts.Add($"{score.Key} = {score.Value:0.00} (unthresholded)");
+    }
+
+    if (caseFailed)
+    {
+        failed++;
+        Console.WriteLine($"FAIL  {liveCase.Name}");
+    }
+    else
+    {
+        passed++;
+        Console.WriteLine($"PASS  {liveCase.Name}");
+    }
+
+    Console.WriteLine($"        skillset {liveCase.Skillset} (registry version {skillsetVersion}), {liveCase.Protocol} protocol, {caseClock.Elapsed.TotalSeconds:0}s");
+
+    foreach (string verdict in verdicts)
+    {
+        Console.WriteLine($"        {verdict}");
+    }
+
+    caseReports.Add(new
+    {
+        liveCase.Name,
+        liveCase.Skillset,
+        skillsetVersion,
+        liveCase.Protocol,
+        samples,
+        scores,
+        liveCase.Thresholds,
+        passed = caseFailed is false,
+        elapsedSeconds = caseClock.Elapsed.TotalSeconds,
+        answers
+    });
+}
+
+Console.WriteLine();
+Console.WriteLine($"{passed} passed, {failed} failed  [{model} at {new Uri(apiUrl).Host}, Standard.Agents {frameworkVersion}, set {setHash}]");
+
+if (reportPath is not null)
+{
+    var report = new
+    {
+        startedOn,
+        finishedOn = DateTimeOffset.UtcNow,
+        model,
+        apiHost = new Uri(apiUrl).Host,
+        frameworkVersion,
+        setHash,
+        passed,
+        failed,
+        cases = caseReports
+    };
+
+    Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(reportPath))!);
+
+    await File.WriteAllTextAsync(
+        reportPath,
+        JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
+
+    Console.WriteLine($"Report:     {Path.GetFullPath(reportPath)}");
+}
+
+if (passed + failed == 0)
+{
+    Console.WriteLine($"No cases discovered in {casesPath}. A run that certifies nothing is not a pass.");
+
+    return 2;
+}
+
+return failed == 0 ? 0 : 1;
+
+// Every prompt of the case, sampled the case's number of times through a fresh agent each time,
+// so no sample sees another's session or tool history. A metric is the pass rate over samples.
+async Task<(Dictionary<string, double> Scores, int SkillsetVersion, List<string> Answers)> ScoreCaseAsync(
+    LiveCase liveCase,
+    int samples)
+{
+    List<double> taskCompletion = [];
+    List<double> groundedness = [];
+    List<double> toolSelection = [];
+    List<string> answers = [];
+    int skillsetVersion = 0;
+
+    foreach (LivePrompt livePrompt in liveCase.Prompts)
+    {
+        for (int sample = 0; sample < samples; sample++)
+        {
+            Dictionary<string, RecordingTool> tools = (liveCase.Tools ?? []).ToDictionary(
+                pair => pair.Key,
+                pair => new RecordingTool(pair.Key, pair.Value, description: $"The {pair.Key} tool."));
+
+            var skills = new PeerLLMRegistrySkillBroker(registry, liveCase.Skillset, liveCase.Members ?? []);
+
+            StandardAgent agent = new StandardAgent()
+                .UseSkills(skills)
+                .WithoutMemory()
+                .Tools(tools.Values)
+                .MaxTurns(liveCase.MaxTurns)
+                .Budget(maxTokens: liveCase.MaxTokensPerRun);
+
+            agent = liveCase.Protocol.Equals("native", StringComparison.OrdinalIgnoreCase)
+                ? agent.NativeBrain(apiUrl, apiKey!, model, temperature: 0)
+                : agent.Brain(apiUrl, apiKey!, model, temperature: 0);
+
+            AgentOutcome outcome = await agent.RunAsync(livePrompt.Prompt);
+            skillsetVersion = skills.ResolvedVersion;
+            string answer = outcome.Status is AgentStatus.Responded ? outcome.Result : $"[{outcome.Status}] {outcome.Result}";
+            answers.Add(answer);
+
+            bool responded = outcome.Status is AgentStatus.Responded;
+
+            if (livePrompt.AnswerMustContain is { Count: > 0 } || livePrompt.AnswerMustContainAny is { Count: > 0 })
+            {
+                bool carriesAll = (livePrompt.AnswerMustContain ?? [])
+                    .All(fact => outcome.Result.Contains(fact, StringComparison.OrdinalIgnoreCase));
+
+                bool carriesAny = livePrompt.AnswerMustContainAny is not { Count: > 0 }
+                    || livePrompt.AnswerMustContainAny.Any(fact =>
+                        outcome.Result.Contains(fact, StringComparison.OrdinalIgnoreCase));
+
+                taskCompletion.Add(responded && carriesAll && carriesAny ? 1 : 0);
+            }
+
+            if (livePrompt.AnswerMustNotContain is { Count: > 0 })
+            {
+                bool fabricatesNothing = livePrompt.AnswerMustNotContain
+                    .All(claim => outcome.Result.Contains(claim, StringComparison.OrdinalIgnoreCase) is false);
+
+                groundedness.Add(fabricatesNothing ? 1 : 0);
+            }
+
+            if (livePrompt.ExpectedTools is not null)
+            {
+                HashSet<string> executed =
+                    [.. tools.Values.Where(tool => tool.ReceivedInputs.Count > 0).Select(tool => tool.Name)];
+
+                toolSelection.Add(executed.SetEquals(livePrompt.ExpectedTools) ? 1 : 0);
+            }
+        }
+    }
+
+    Dictionary<string, double> scores = [];
+    AddAverage(scores, "taskCompletion", taskCompletion);
+    AddAverage(scores, "groundedness", groundedness);
+    AddAverage(scores, "toolSelection", toolSelection);
+
+    return (scores, skillsetVersion, answers);
+}
+
+static void AddAverage(Dictionary<string, double> scores, string metric, List<double> samples)
+{
+    if (samples.Count > 0)
+    {
+        scores[metric] = samples.Average();
+    }
+}
+
+static string HashSet(string casesPath)
+{
+    using IncrementalHash hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+    foreach (string file in Directory.EnumerateFiles(casesPath, "*.json").OrderBy(path => path, StringComparer.Ordinal))
+    {
+        hash.AppendData(File.ReadAllBytes(file));
+    }
+
+    return Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant()[..12];
+}
+
+static string FindRepositoryRoot()
+{
+    DirectoryInfo? directory = new(AppContext.BaseDirectory);
+
+    while (directory is not null && Directory.Exists(Path.Combine(directory.FullName, "evals")) is false)
+    {
+        directory = directory.Parent;
+    }
+
+    return directory?.FullName ?? throw new DirectoryNotFoundException("No 'evals' folder above the runner.");
+}

--- a/Standard.Agents.Evals.Live/Standard.Agents.Evals.Live.csproj
+++ b/Standard.Agents.Evals.Live/Standard.Agents.Evals.Live.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- The live evals: the same agent loop against a real model and real skills, opt-in and
+       outside the PR gate, because they cost time on someone's network and are not
+       deterministic. The deterministic orchestration evals stay in Standard.Agents.Evals. -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Standard.Agents\Standard.Agents.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Standard.Agents.Evals.Live/Tools/RecordingTool.cs
+++ b/Standard.Agents.Evals.Live/Tools/RecordingTool.cs
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the The Standard Software License (TSSL)
+// ---------------------------------------------------------------
+
+using Standard.Agents.Tools;
+
+namespace Standard.Agents.Evals.Live;
+
+// A tool that answers with a fixed output and remembers being called, so a case can say
+// which tools a correct run selects without depending on a real tool's behaviour.
+public sealed class RecordingTool : ITool
+{
+    private readonly string output;
+    private readonly List<string> receivedInputs = [];
+
+    public RecordingTool(string name, string output, string description)
+    {
+        this.Name = name;
+        this.output = output;
+        this.Description = description;
+    }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    public string Parameters => "{\"type\":\"object\",\"properties\":{\"input\":{\"type\":\"string\"}}}";
+
+    public IReadOnlyList<string> ReceivedInputs => this.receivedInputs;
+
+    public async ValueTask<string> ExecuteAsync(string input)
+    {
+        this.receivedInputs.Add(input);
+
+        return this.output;
+    }
+}

--- a/Standard.Agents.slnx
+++ b/Standard.Agents.slnx
@@ -3,6 +3,7 @@
   <Project Path="Standard.Agents.Conformance/Standard.Agents.Conformance.csproj" />
   <Project Path="Standard.Agents.Demo/Standard.Agents.Demo.csproj" />
   <Project Path="Standard.Agents.Evals/Standard.Agents.Evals.csproj" />
+  <Project Path="Standard.Agents.Evals.Live/Standard.Agents.Evals.Live.csproj" />
   <Project Path="Standard.Agents.Host/Standard.Agents.Host.csproj" />
   <Project Path="Standard.Agents.Tests.Unit/Standard.Agents.Tests.Unit.csproj" />
 </Solution>

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -25,6 +25,37 @@ case misses a threshold, `2` when the run discovered no cases at all. A run that
 nothing is not a pass, so an empty or mistyped golden path fails loudly rather than printing
 `0 passed, 0 failed` in green; pass `--allow-empty` to accept an empty set on purpose.
 
+## Live evals: LLooMA and the registry skills
+
+`Standard.Agents.Evals.Live` runs the same loop against a real model on PeerLLM and real skills
+pulled from the PeerLLM registry, pinned to a skillset version. Where the deterministic evals
+pin how the loop treats a scripted Brain, these measure the Brain and the skills: does LLooMA
+read a skill and answer from it, does it pick the tool the task needs, does it stay off the
+fabrication the author named.
+
+```bash
+PEERLLM_API_KEY=psk_… dotnet run --project Standard.Agents.Evals.Live -- --report artifacts/live-evals/report.json
+dotnet run --project Standard.Agents.Evals.Live -- --key-file ~/peerllm-api-key.txt --samples 5 --max-cases 1
+```
+
+Opt-in and outside the PR gate on purpose: a live model is not deterministic and a flake in a
+required gate is a gate nobody trusts. So every prompt is sampled several times (`samples`, three
+by default), a metric is the pass rate over the samples, and a threshold is the pass rate the case
+must reach. The report records which model, which registry version of the skillset, which
+framework and when answered, and every answer, so a drop can be read rather than guessed at.
+Exit `0` when every threshold is met, `1` when one is not, `2` when no cases were found, `3` when
+there is no key, so a missing key never reads as a pass.
+
+The cases live in `evals/live`. Each names a pinned skillset (`owner/name@N`, an unpinned one
+is refused), optionally the members to load (a skillset can be far larger than a system prompt
+should be), the door the prompts enter by (`text` or `native`), the tools on offer, the prompts
+with their golden data, and cost controls: `maxTurns` and `maxTokensPerRun`, which the budget
+enforces. The metrics are `taskCompletion` (`answerMustContain`, `answerMustContainAny`),
+`groundedness` (`answerMustNotContain`) and `toolSelection` (`expectedTools`).
+
+The workflow `live-evals.yml` runs them weekly and on demand with the repository secret
+`PEERLLM_API_KEY`, and publishes the report as a build artifact.
+
 ## The metrics
 
 | Metric | Question it answers | Golden data on the prompt |

--- a/evals/live/01-versioning-skill-is-followed.json
+++ b/evals/live/01-versioning-skill-is-followed.json
@@ -1,0 +1,26 @@
+{
+  "name": "versioning-skill-is-followed",
+  "description": "The Standard's versioning skill, pulled from the PeerLLM registry, states rules a model must apply rather than recite: a model change advances the first segment and resets the rest; a routine change advances the second; a fix advances the third. LLooMA is asked each case and must answer from the skill, not from semver habit.",
+  "skillset": "hassanhabib/the-standard-skills@15",
+  "members": ["the-standard-versioning"],
+  "protocol": "text",
+  "samples": 3,
+  "prompts": [
+    {
+      "prompt": "Our current release is v1.2.3.4. This release changes a model. Under the versioning rules you were given, what is the next release version? Reply with the version only.",
+      "answerMustContainAny": ["v2.0.0.0", "2.0.0.0"],
+      "answerMustNotContain": ["1.3.0.0", "1.2.4.0", "1.2.3.5"]
+    },
+    {
+      "prompt": "Our current release is v1.2.3.4. This release changes a service routine and nothing else. Under the versioning rules you were given, what is the next release version? Reply with the version only.",
+      "answerMustContainAny": ["v1.3.0.0", "1.3.0.0"],
+      "answerMustNotContain": ["2.0.0.0", "1.2.4.0"]
+    },
+    {
+      "prompt": "Our current release is v1.2.3.4. This release is a bug fix and nothing else. Under the versioning rules you were given, what is the next release version? Reply with the version only.",
+      "answerMustContainAny": ["v1.2.4.0", "1.2.4.0"],
+      "answerMustNotContain": ["2.0.0.0", "1.3.0.0"]
+    }
+  ],
+  "thresholds": { "taskCompletion": 0.67, "groundedness": 0.67 }
+}

--- a/evals/live/02-tool-selection-on-the-native-protocol.json
+++ b/evals/live/02-tool-selection-on-the-native-protocol.json
@@ -1,0 +1,17 @@
+{
+  "name": "tool-selection-on-the-native-protocol",
+  "description": "LLooMA 2.0 speaks OpenAI-style tool calling. Offered one tool the task needs, it must call exactly that tool and carry the tool's result into its answer rather than compute or guess around it.",
+  "skillset": "hassanhabib/the-standard-agentic-skills@1",
+  "protocol": "native",
+  "samples": 3,
+  "maxTurns": 4,
+  "tools": { "calculator": "4183" },
+  "prompts": [
+    {
+      "prompt": "Use the calculator tool to compute 47 times 89, then tell me the result it returned.",
+      "expectedTools": ["calculator"],
+      "answerMustContain": ["4183"]
+    }
+  ],
+  "thresholds": { "toolSelection": 0.67, "taskCompletion": 0.67 }
+}

--- a/evals/live/03-agentic-skill-drives-the-first-move.json
+++ b/evals/live/03-agentic-skill-drives-the-first-move.json
@@ -1,0 +1,14 @@
+{
+  "name": "agentic-skill-drives-the-first-move",
+  "description": "The extract-expert-skills skill from the PeerLLM registry tells the agent how to begin capturing expertise: establish consent, the domain and the scope, then interview. Asked to begin, LLooMA must open the way the skill says rather than lecture about month-end close.",
+  "skillset": "hassanhabib/the-standard-agentic-skills@1",
+  "protocol": "text",
+  "samples": 3,
+  "prompts": [
+    {
+      "prompt": "I want to capture how our senior accountant closes the books each month, so we can turn it into a reusable skill. Please begin.",
+      "answerMustContainAny": ["consent", "scope", "domain", "interview"]
+    }
+  ],
+  "thresholds": { "taskCompletion": 0.67 }
+}


### PR DESCRIPTION
## Finding

Principal review 2026-09-04, F-19 remainder: opt-in live model and skill-quality evals with pinned datasets, repeated samples, statistical thresholds, cost controls and recorded model metadata. Hassan asked for PeerLLM and PeerLLM skills.

## Change

- Standard.Agents.Evals.Live: the same agent loop against LLooMA 2.0 on api.peerllm.com and skills pulled from the PeerLLM registry, pinned to a skillset version (an unpinned case is refused). Each prompt is sampled several times through a fresh agent; a metric is the pass rate over samples; a threshold is the pass rate the case must reach. Cost controls per case: maxTurns and maxTokensPerRun through the budget; --samples and --max-cases on the command line. The report records model, API host, registry version of the skillset, framework version, timestamps, every score and every answer. Exit 3 with no key, so a missing key never reads as a pass.
- Three cases in evals/live: the versioning skill from hassanhabib/the-standard-skills@15 applied rather than recited (model change to v2.0.0.0, routine change to v1.3.0.0, fix to v1.2.4.0, with the wrong answers named as fabrications); tool selection on the native protocol with the agentic skillset; the extract-expert-skills skill driving the first move of an interview.
- A thin registry broker inside the project, because Standard.Agents.Data.Skills.PeerLLM 0.1.0 pins Standard.Agents 0.17; when that package moves to 2.x the broker goes.
- live-evals.yml runs weekly and on demand with the PEERLLM_API_KEY repository secret and publishes the report as an artifact. It is not part of the PR gate.
- evals.md documents the live half.

## Verified

Run locally against PeerLLM with the real key: 3 passed, 0 failed; every metric 1.00 over 3 samples; about two minutes end to end. The recorded answers were read: v2.0.0.0, v1.3.0.0, v1.2.4.0 three times each; the calculator called and 4183 carried; the interview opened with consent, domain and scope.

## Needs one thing from you

Add the repository secret PEERLLM_API_KEY. I do not enter credentials into any system on your behalf.