### PR TITLE
MINOR EVALS: The Live Tool Case Accepts A Thousands Separator

### DIFF
--- a/evals/live/02-tool-selection-on-the-native-protocol.json
+++ b/evals/live/02-tool-selection-on-the-native-protocol.json
@@ -10,7 +10,7 @@
     {
       "prompt": "Use the calculator tool to compute 47 times 89, then tell me the result it returned.",
       "expectedTools": ["calculator"],
-      "answerMustContain": ["4183"]
+      "answerMustContainAny": ["4183", "4,183"]
     }
   ],
   "thresholds": { "toolSelection": 0.67, "taskCompletion": 0.67 }


### PR DESCRIPTION
## What the first scheduled-style run showed

Run 34023974517, the first with the PEERLLM_API_KEY secret, scored the tool-selection case at toolSelection 1.00 and taskCompletion 0.33. The calculator ran every time and the number was right every time; twice LLooMA wrote 4,183 with a thousands separator and the golden data accepted only 4183. The miss was the case's literalness, not the model's.

## Change

answerMustContainAny: ["4183", "4,183"].

## Verified

Re-run locally with the new key at five samples: both the versioning case and the tool case at 1.00 on every metric.